### PR TITLE
Use GraalVM in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,17 @@
-FROM adoptopenjdk/openjdk11:jre-11.0.11_9-ubi-minimal
-
+FROM redhat/ubi8:8.4-206.1626828523
 MAINTAINER Axual <maintainer@axual.io>
-USER root
-ADD target/libs/ /opt/ksml/libs/
-ADD target/ksml-runner*.jar /opt/ksml/ksml.jar
-RUN chown -R 1024:users /opt
+ENV JAVA_HOME=/opt/graalvm
+ENV PATH=/opt/graalvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN mkdir -p "/opt/ksml/libs"  \
+&& curl -k -L -o "/tmp/graalvm.tgz" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.2.0/graalvm-ce-java11-linux-amd64-21.2.0.tar.gz" \
+&& tar -xzf /tmp/graalvm.tgz -C "/opt" \
+&& mv /opt/graalvm* /opt/graalvm \
+&& chown -R 1024:users /opt
+
+ADD --chown=1024:users target/libs/ /opt/ksml/libs/
+ADD --chown=1024:users target/ksml-runner*.jar /opt/ksml/ksml.jar
+
 WORKDIR /opt/ksml
 USER 1024
 ENTRYPOINT ["java", "-jar", "/opt/ksml/ksml.jar"]


### PR DESCRIPTION
The new Dockerfile will use the Red Hat UBI image and download GraalVM 21.