### PR TITLE
Add coverage data, fix docker multistage

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,6 +1,9 @@
 name: Build and test
 on:
   push:
+    branches:
+      - main
+      - branch-*
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
@@ -41,7 +44,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B verify
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
       - name: verify contents of workspace
         run: |
           ls -l  ${{ github.workspace }}

--- a/Dockerfile-build-runner
+++ b/Dockerfile-build-runner
@@ -1,7 +1,7 @@
 # --- step 1: build the code on GraalVM
 FROM ghcr.io/graalvm/graalvm-ce:21.2.0 AS builder
 MAINTAINER Axual <maintainer@axual.io>
-RUN curl -O https://dlcdn.apache.org/maven/maven-3/3.8.4/binaries/apache-maven-3.8.4-bin.tar.gz \
+RUN curl -O https://downloads.apache.org/maven/maven-3/3.8.4/binaries/apache-maven-3.8.4-bin.tar.gz \
   && tar xvf apache-maven-3.8.4-bin.tar.gz \
   && gu install python
 ADD . /project_dir

--- a/ksml-query/pom.xml
+++ b/ksml-query/pom.xml
@@ -115,6 +115,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/ksml-runner-axual/pom.xml
+++ b/ksml-runner-axual/pom.xml
@@ -84,6 +84,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/ksml-runner/pom.xml
+++ b/ksml-runner/pom.xml
@@ -85,6 +85,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/ksml/pom.xml
+++ b/ksml/pom.xml
@@ -119,6 +119,10 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <license.licensename>apache_v2</license.licensename>
 
         <!-- sonarcloud properties -->
-        <sonar.organization>tonvanbart</sonar.organization>
+        <sonar.organization>axual</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <!-- Sonar for JACOCO-->
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>

--- a/pom.xml
+++ b/pom.xml
@@ -91,8 +91,12 @@
         <license.licensename>apache_v2</license.licensename>
 
         <!-- sonarcloud properties -->
-        <sonar.organization>axual</sonar.organization>
+        <sonar.organization>tonvanbart</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <!-- Sonar for JACOCO-->
+        <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
+        <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
+        <sonar.jacoco.xmlReportPaths>ksml/target/site/jacoco/jacoco.xml</sonar.jacoco.xmlReportPaths>
     </properties>
 
     <dependencyManagement>
@@ -391,6 +395,28 @@
                         </execution>
                     </executions>
                 </plugin>
+
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.7</version>
+                    <executions>
+                        <execution>
+                            <id>prepare-agent</id>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>report</id>
+                            <phase>test</phase>
+                            <goals>
+                                <goal>report</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
             </plugins>
         </pluginManagement>
 


### PR DESCRIPTION
- added jacoco plugin to Maven build
- run workflow on branches recognized as long lived by Sonarcloud (`branch-*`)
- need to add a workflow secret for SONAR_TOKEN

Verified on my fork that coverage is now shown in Sonarcloud.