### PR TITLE
resolve #36 by having workdirectory inside container

### DIFF
--- a/examples/ksml-runner.yml
+++ b/examples/ksml-runner.yml
@@ -1,8 +1,8 @@
 ksml:
-  workingDirectory: /ksml
+  workingDirectory: /tmp
   configDirectory: /ksml
   definitions:
-  - 1-demo-inspect.yaml
+  - 01-demo-inspect.yaml
 
 backend:
   type: kafka

--- a/ksml-runner-axual/src/main/java/io/axual/ksml/runner/backend/axual/AxualBackend.java
+++ b/ksml-runner-axual/src/main/java/io/axual/ksml/runner/backend/axual/AxualBackend.java
@@ -156,6 +156,7 @@ public class AxualBackend implements Backend {
         Map<String, Object> ksmlConfigs = new HashMap<>();
         ksmlConfigs.put(io.axual.ksml.KSMLConfig.KSML_SOURCE_TYPE, "file");
         ksmlConfigs.put(io.axual.ksml.KSMLConfig.KSML_WORKING_DIRECTORY, ksmlConfig.getWorkingDirectory());
+        ksmlConfigs.put(io.axual.ksml.KSMLConfig.KSML_CONFIG_DIRECTORY, ksmlConfig.getConfigurationDirectory());
         ksmlConfigs.put(io.axual.ksml.KSMLConfig.KSML_SOURCE, ksmlConfig.getDefinitions());
         ksmlConfigs.put(io.axual.ksml.KSMLConfig.NOTATION_LIBRARY, new AxualNotationLibrary(configs));
         var topologyFactory = new KSMLTopologyGenerator();

--- a/ksml-runner/pom.xml
+++ b/ksml-runner/pom.xml
@@ -50,6 +50,42 @@
             <groupId>io.axual.ksml</groupId>
             <artifactId>ksml-query</artifactId>
         </dependency>
+
+        <!-- TEST dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+        </dependency>
+        <!-- JUnit 4 (vintage) compatibility -->
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-runner</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+        </dependency>
     </dependencies>
 
     

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/KSMLRunner.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/KSMLRunner.java
@@ -53,12 +53,12 @@ public class KSMLRunner {
             final var mapper = new ObjectMapper(new YAMLFactory());
             final KSMLRunnerConfig config = mapper.readValue(configPath, KSMLRunnerConfig.class);
             config.validate();
-            log.info("Using backed of type {}", config.getBackend().getType());
+            log.info("Using backed of type {}", config.getBackendConfig().getType());
             Backend backend = config.getConfiguredBackend();
 
-            if (Boolean.TRUE.equals(config.getKsml().getApplicationServerEnabled())) {
+            if (Boolean.TRUE.equals(config.getKsmlConfig().getApplicationServerEnabled())) {
                 // Run with the REST server
-                HostInfo hostInfo = new HostInfo(config.getKsml().getApplicationServerHost(), config.getKsml().getApplicationServerPort());
+                HostInfo hostInfo = new HostInfo(config.getKsmlConfig().getApplicationServerHost(), config.getKsmlConfig().getApplicationServerPort());
 
                 try (RestServer restServer = new RestServer(hostInfo)) {
                     restServer.start(backend.getQuerier());

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/backend/kafka/KafkaBackend.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/backend/kafka/KafkaBackend.java
@@ -73,6 +73,7 @@ public class KafkaBackend implements Backend {
         Map<String, Object> ksmlConfigs = new HashMap<>();
         ksmlConfigs.put(io.axual.ksml.KSMLConfig.KSML_SOURCE_TYPE, "file");
         ksmlConfigs.put(io.axual.ksml.KSMLConfig.KSML_WORKING_DIRECTORY, ksmlConfig.getWorkingDirectory());
+        ksmlConfigs.put(io.axual.ksml.KSMLConfig.KSML_CONFIG_DIRECTORY, ksmlConfig.getConfigurationDirectory());
         ksmlConfigs.put(io.axual.ksml.KSMLConfig.KSML_SOURCE, ksmlConfig.getDefinitions());
         ksmlConfigs.put(io.axual.ksml.KSMLConfig.NOTATION_LIBRARY, new NotationLibrary(streamsProperties));
         var topologyFactory = new KSMLTopologyGenerator();

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/config/KSMLConfig.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/config/KSMLConfig.java
@@ -101,8 +101,10 @@ public class KSMLConfig {
             throw new KSMLRunnerConfigurationException("definitionFile", definitions, "At least one KSML definition file must be specified");
         }
 
+        log.info("Using configuration directory: {}", getConfigurationDirectory());
+
         for (String definitionFile : definitions) {
-            final var definitionFilePath = Paths.get(workingDirectory, definitionFile);
+            final var definitionFilePath = Paths.get(getConfigurationDirectory(), definitionFile);
             if (Files.notExists(definitionFilePath) || !Files.isRegularFile(definitionFilePath)) {
                 throw new KSMLRunnerConfigurationException("definitionFile", definitionFilePath, "The provided KSML definition file does not exists or is not a regular file");
             }

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/config/KSMLConfig.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/config/KSMLConfig.java
@@ -21,6 +21,9 @@ package io.axual.ksml.runner.config;
  */
 
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
@@ -39,6 +42,10 @@ public class KSMLConfig {
     private String applicationServerHost;
     private String applicationServerPort;
     private String workingDirectory;
+
+    @JsonProperty("configDirectory")
+    private String configurationDirectory;
+
     private List<String> definitions;
 
     public String getApplicationServer() {
@@ -66,13 +73,28 @@ public class KSMLConfig {
         return 0;
     }
 
+    public String getConfigurationDirectory() {
+        if (configurationDirectory == null) {
+            return workingDirectory;
+        }
+        return configurationDirectory;
+    }
+
     public void validate() throws KSMLRunnerConfigurationException {
         if (workingDirectory == null) {
             throw new KSMLRunnerConfigurationException("workingDirectory", workingDirectory);
         }
+
         final var workingDirectoryPath = Paths.get(workingDirectory);
         if (Files.notExists(workingDirectoryPath) || !Files.isDirectory(workingDirectoryPath)) {
             throw new KSMLRunnerConfigurationException("workingDirectory", workingDirectory, "The provided path does not exists or is not a directory");
+        }
+
+        if (configurationDirectory != null) {
+            final var configPath = Paths.get(configurationDirectory);
+            if (Files.notExists(configPath) || !Files.isDirectory(configPath)) {
+                throw new KSMLRunnerConfigurationException("configurationDirectory", configurationDirectory, "The provided path does not exists or is not a directory");
+            }
         }
 
         if (definitions == null || definitions.isEmpty()) {
@@ -82,7 +104,7 @@ public class KSMLConfig {
         for (String definitionFile : definitions) {
             final var definitionFilePath = Paths.get(workingDirectory, definitionFile);
             if (Files.notExists(definitionFilePath) || !Files.isRegularFile(definitionFilePath)) {
-                throw new KSMLRunnerConfigurationException("definitionFile", definitionFile, "The provided KSML definition file does not exists or is not a regular file");
+                throw new KSMLRunnerConfigurationException("definitionFile", definitionFilePath, "The provided KSML definition file does not exists or is not a regular file");
             }
         }
     }

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/config/KSMLRunnerConfig.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/config/KSMLRunnerConfig.java
@@ -22,6 +22,7 @@ package io.axual.ksml.runner.config;
 
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -40,21 +41,25 @@ import lombok.extern.slf4j.Slf4j;
 @Data
 public class KSMLRunnerConfig {
     private static final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-    private KSMLConfig ksml;
-    private KSMLRunnerBackendConfig backend;
+
+    @JsonProperty("ksml")
+    private KSMLConfig ksmlConfig;
+
+    @JsonProperty("backend")
+    private KSMLRunnerBackendConfig backendConfig;
 
     public void validate() throws KSMLRunnerConfigurationException {
-        if (ksml == null) {
-            throw new KSMLRunnerConfigurationException("ksml", ksml);
+        if (ksmlConfig == null) {
+            throw new KSMLRunnerConfigurationException("ksml", ksmlConfig);
         }
 
-        ksml.validate();
+        ksmlConfig.validate();
 
-        if (backend == null) {
-            throw new KSMLRunnerConfigurationException("backend", backend);
+        if (backendConfig == null) {
+            throw new KSMLRunnerConfigurationException("backend", backendConfig);
         }
 
-        backend.validate();
+        backendConfig.validate();
     }
 
     public Backend getConfiguredBackend() throws JsonProcessingException {
@@ -65,8 +70,8 @@ public class KSMLRunnerConfig {
             loader.forEach(pr -> log.info("Found provider {} for type {}", pr.getClass().getName(), pr.getType()));
         }
 
-        final String type = backend.getType();
-        final JsonNode config = backend.getConfig();
+        final String type = backendConfig.getType();
+        final JsonNode config = backendConfig.getConfig();
 
         BackendProvider<?> provider = loader.stream()
                 .map(ServiceLoader.Provider::get)
@@ -77,6 +82,6 @@ public class KSMLRunnerConfig {
         final BackendConfig backendConfig = mapper.readValue(mapper.writeValueAsString(config), provider.getConfigClass());
         backendConfig.validate();
 
-        return provider.create(ksml, backendConfig);
+        return provider.create(ksmlConfig, backendConfig);
     }
 }

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/config/KSMLConfigTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/config/KSMLConfigTest.java
@@ -1,0 +1,52 @@
+package io.axual.ksml.runner.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.axual.ksml.runner.exception.KSMLRunnerConfigurationException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class KSMLConfigTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setup() {
+        objectMapper = new ObjectMapper(new YAMLFactory());
+    }
+
+    @Test
+    @DisplayName("validate of complete config should not throw exceptions")
+    void shouldValidateConfig() throws Exception {
+        final var yaml = getClass().getClassLoader().getResourceAsStream("ksml-config.yml");
+        final var ksmlConfig = objectMapper.readValue(yaml, KSMLConfig.class);
+
+        ksmlConfig.validate();
+    }
+
+    @Test
+    @DisplayName("validate of incorrect config directory should throw exception")
+    void shouldThrowOnWrongConfigdir() throws Exception {
+        final var yaml = getClass().getClassLoader().getResourceAsStream("ksml-config-wrong-configdir.yml");
+        final var ksmlConfig = objectMapper.readValue(yaml, KSMLConfig.class);
+
+        assertThrows(KSMLRunnerConfigurationException.class, ksmlConfig::validate, "should throw exception for wrong configdir");
+    }
+
+    @Test
+    @DisplayName("if configdir is missing it should default to workdir")
+    void shouldDefaultConfigToWorkdir() throws Exception {
+        final var yaml = getClass().getClassLoader().getResourceAsStream("ksml-config-no-configdir.yml");
+        final var ksmlConfig = objectMapper.readValue(yaml, KSMLConfig.class);
+
+        ksmlConfig.validate();
+
+        assertEquals(".", ksmlConfig.getConfigurationDirectory(), "config dir should default to working dir");
+    }
+}

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/config/KsmlRunnerConfigTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/config/KsmlRunnerConfigTest.java
@@ -1,0 +1,36 @@
+package io.axual.ksml.runner.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class KsmlRunnerConfigTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setup() {
+        objectMapper = new ObjectMapper(new YAMLFactory());
+    }
+
+    @Test
+    @DisplayName("complete config should load without exceptions")
+    void shouldLoadWithoutExceptions() throws IOException {
+        final var yaml = getClass().getClassLoader().getResourceAsStream("ksml-runner-config.yml");
+        final var ksmlRunnerConfig = objectMapper.readValue(yaml, KSMLRunnerConfig.class);
+
+        ksmlRunnerConfig.validate();
+
+        assertNotNull(ksmlRunnerConfig.getKsmlConfig());
+        assertNotNull(ksmlRunnerConfig.getBackendConfig());
+        assertEquals("kafka", ksmlRunnerConfig.getBackendConfig().getType());
+    }
+}

--- a/ksml-runner/src/test/resources/example-definition.yaml
+++ b/ksml-runner/src/test/resources/example-definition.yaml
@@ -1,0 +1,1 @@
+# empty file, referenced by ksml-config.yml

--- a/ksml-runner/src/test/resources/ksml-config-no-configdir.yml
+++ b/ksml-runner/src/test/resources/ksml-config-no-configdir.yml
@@ -1,0 +1,4 @@
+workingDirectory: .
+definitions:
+- src/test/resources/example-definition.yaml
+

--- a/ksml-runner/src/test/resources/ksml-config-wrong-configdir.yml
+++ b/ksml-runner/src/test/resources/ksml-config-wrong-configdir.yml
@@ -1,0 +1,5 @@
+workingDirectory: .
+configDirectory: foo/bar/wrong
+definitions:
+- src/test/resources/example-definition.yaml
+

--- a/ksml-runner/src/test/resources/ksml-config.yml
+++ b/ksml-runner/src/test/resources/ksml-config.yml
@@ -1,0 +1,4 @@
+workingDirectory: .
+configDirectory: .
+definitions:
+  - src/test/resources/example-definition.yaml

--- a/ksml-runner/src/test/resources/ksml-runner-config.yml
+++ b/ksml-runner/src/test/resources/ksml-runner-config.yml
@@ -1,8 +1,8 @@
 ksml:
-  workingDirectory: /ksml
-  configDirectory: /ksml
+  workingDirectory: .
+  configDirectory: .
   definitions:
-  - 1-demo-inspect.yaml
+    - src/test/resources/example-definition.yaml
 
 backend:
   type: kafka

--- a/ksml/src/main/java/io/axual/ksml/KSMLConfig.java
+++ b/ksml/src/main/java/io/axual/ksml/KSMLConfig.java
@@ -34,11 +34,13 @@ import io.axual.ksml.notation.NotationLibrary;
 public class KSMLConfig {
     public static final String KSML_SOURCE_TYPE = "ksml.source.type";
     public static final String KSML_SOURCE = "ksml.source";
-    public static final String KSML_WORKING_DIRECTORY = "ksml.dir";
+    public static final String KSML_WORKING_DIRECTORY = "ksml.working.dir";
+    public static final String KSML_CONFIG_DIRECTORY = "ksml.config.dir";
     public static final String NOTATION_LIBRARY = "notation.library";
 
     public final String sourceType;
     public final String workingDirectory;
+    public final String configDirectory;
     public final Object source;
     public final NotationLibrary notationLibrary;
 
@@ -46,6 +48,7 @@ public class KSMLConfig {
         sourceType = configs.containsKey(KSML_SOURCE_TYPE) ? (String) configs.get(KSML_SOURCE_TYPE) : "file";
         source = configs.get(KSMLConfig.KSML_SOURCE);
         workingDirectory = (String) configs.get(KSML_WORKING_DIRECTORY);
+        configDirectory = (String) configs.get(KSML_CONFIG_DIRECTORY);
         notationLibrary = configs.containsKey(NOTATION_LIBRARY)
                 ? (NotationLibrary) configs.get(NOTATION_LIBRARY)
                 : new NotationLibrary(configs);

--- a/ksml/src/main/java/io/axual/ksml/KSMLTopologyGenerator.java
+++ b/ksml/src/main/java/io/axual/ksml/KSMLTopologyGenerator.java
@@ -48,7 +48,8 @@ public class KSMLTopologyGenerator implements Configurable, TopologyGenerator {
 
     @Override
     public Topology create(StreamsBuilder streamsBuilder) {
-        var avroSchemaLoader = new AvroSchemaLoader(config.workingDirectory);
+//        var avroSchemaLoader = new AvroSchemaLoader(config.workingDirectory);
+        var avroSchemaLoader = new AvroSchemaLoader(config.configDirectory);
         SchemaLibrary.registerLoader(avroSchemaLoader);
         var generator = new TopologyGeneratorImpl(config);
         return generator.create(streamsBuilder);

--- a/ksml/src/main/java/io/axual/ksml/generator/TopologyGeneratorImpl.java
+++ b/ksml/src/main/java/io/axual/ksml/generator/TopologyGeneratorImpl.java
@@ -109,7 +109,7 @@ public class TopologyGeneratorImpl {
                 case "file":
                     // Parse source from file
                     LOG.info("Reading KSML from source file(s): {}", config.source);
-                    return readYAMLsFromFile(mapper, config.workingDirectory, config.source);
+                    return readYAMLsFromFile(mapper, config.configDirectory, config.source);
                 case "content":
                     // Parse YAML content directly from string
                     LOG.info("Reading KSML from content string: {}", config.source);


### PR DESCRIPTION
This PR resolves #36 by making it possible to have separate work and config directories, and adjusting `example/ksml-runner.yml` so that the working directory is inside the container. Tested on Ubuntu 20.04 and verified that the issue does not occur anymore when following the README.