### PR TITLE
resolve #37 and #35 by upgrading dependencies

### DIFF
--- a/examples/ksml-runner.yml
+++ b/examples/ksml-runner.yml
@@ -1,7 +1,16 @@
 ksml:
   workingDirectory: /ksml
   definitions:
-  - 1-demo-inspect.yaml
+    - 01-demo-inspect.yaml
+#    - 02-demo-copy.yaml
+#    - 03-demo-filter.yaml
+#    - 04-demo-branch.yaml
+#    - 05-demo-dynamicrouting.yaml
+#    - 06-demo-double.yaml
+#    - 07-demo-convert.yaml
+#    - 08-demo-count.yaml
+#    - 09-demo-aggregate.yaml
+#    - 10-demo-queryabletable.yaml
 
 backend:
   type: kafka

--- a/ksml-axual/pom.xml
+++ b/ksml-axual/pom.xml
@@ -23,6 +23,12 @@
         <dependency>
             <groupId>io.axual.streams</groupId>
             <artifactId>axual-streams</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.kafka</groupId>
+                    <artifactId>connect-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.axual.ksml</groupId>

--- a/ksml-query/pom.xml
+++ b/ksml-query/pom.xml
@@ -75,12 +75,6 @@
             <artifactId>jakarta.xml.bind-api</artifactId>
             <version>3.0.1</version>
         </dependency>
-        <dependency>
-            <groupId>io.axual.streams</groupId>
-            <artifactId>axual-streams-proxy</artifactId>
-            <version>5.8.0-RC1</version>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/ksml/pom.xml
+++ b/ksml/pom.xml
@@ -15,7 +15,7 @@
     <description>The core components for parsing and executing a KSML definition to a Kafka Streams topology</description>
 
     <properties>
-        <confluent.version>6.0.0</confluent.version>
+        <confluent.version>7.1.1</confluent.version>
         <sonar.coverage.jacoco.xmlReportPaths>../ksml-reporting/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 

--- a/ksml/pom.xml
+++ b/ksml/pom.xml
@@ -15,7 +15,6 @@
     <description>The core components for parsing and executing a KSML definition to a Kafka Streams topology</description>
 
     <properties>
-        <confluent.version>7.1.1</confluent.version>
         <sonar.coverage.jacoco.xmlReportPaths>../ksml-reporting/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
@@ -52,7 +51,6 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
-            <version>${confluent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/ksml/src/test/java/io/axual/ksml/KSMLTopologyGeneratorBasicTest.java
+++ b/ksml/src/test/java/io/axual/ksml/KSMLTopologyGeneratorBasicTest.java
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Basic "golden master" test for topology generation.
- * Generate a topolgy and compare with stored string representation. Reference output is in src/test/resources/reference.
+ * Generate a topology and compare with stored string representation. Reference output is in src/test/resources/reference.
  */
 public class KSMLTopologyGeneratorBasicTest {
 
@@ -52,7 +52,7 @@ public class KSMLTopologyGeneratorBasicTest {
     public static void checkGraalVM() {
         final var vendor = System.getProperty("java.vendor.url");
         if (!vendor.contains("graalvm")) {
-            fail("This test needs GraalVM to work");
+            fail("This test needs GraalVM to work, found java.vendor.url=" + vendor);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,10 +59,11 @@
     </modules>
 
     <properties>
-        <apache.avro.version>1.9.2</apache.avro.version>
+        <apache.avro.version>1.11.0</apache.avro.version>
         <apache.kafka.version>2.8.1</apache.kafka.version>
         <axual.version>5.8.1</axual.version>
         <commons.logging.version>1.1</commons.logging.version>
+        <confluent.version>7.1.1</confluent.version>
         <graalvm.version>21.1.0</graalvm.version>
         <hamcrest.version>2.1</hamcrest.version>
         <jackson.version>2.11.1</jackson.version>
@@ -148,6 +149,12 @@
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-streams</artifactId>
                 <version>${apache.kafka.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.confluent</groupId>
+                <artifactId>kafka-avro-serializer</artifactId>
+                <version>${confluent.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This PR fixes issues #37 (and duplicate #35) by upgrading the confluent.version to 7.1.1 which removes the transitive dependency. As a result apache.avro.version needed to be upgraded to 1.11.0 as well.
Rebuilt axual/ksml and verified that examples work (with the exception of `10-demo-queryabletable.yaml`??) 