### PR TITLE
Build snapshot Docker image on pull request merged

### DIFF
--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -1,10 +1,12 @@
 name: build and push Docker images
 on:
-  push
-# TO DO: only on PR merge!
+  pull_request:
+    types:
+      - closed
 
 jobs:
   build-push-docker:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: set up Docker buildx

--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -1,0 +1,38 @@
+name: build and push Docker images
+on:
+  push
+# TO DO: only on PR merge!
+
+jobs:
+  build-push-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: set up Docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: build and push plain Kafka runner
+        uses: docker/build-push-action@v3
+        with:
+          file: Dockerfile-build-runner
+          push: true
+          tags: axual/ksml-kafka:snapshot
+          build-args: "runner=ksml-runner"
+
+      - name: build and push Axual runner
+        uses: docker/build-push-action@v3
+        with:
+          file: Dockerfile-build-runner
+          push: true
+          tags: axual/ksml-axual:snapshot
+          build-args: "runner=ksml-runner-axual"
+
+
+
+

--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -27,18 +27,16 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           file: Dockerfile-build-runner
-          context: .
           build-args: "runner=ksml-runner"
           push: true
           tags: |
-            axual/ksml-kafka:snapshot
-            ghcr.io/axual/ksml-kafka:snapshot
+            axual/ksml:snapshot
+            ghcr.io/axual/ksml:snapshot
 
       - name: build and push Axual runner
         uses: docker/build-push-action@v3
         with:
           file: Dockerfile-build-runner
-          context: .
           build-args: "runner=ksml-runner-axual"
           push: true
           tags: |

--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -27,21 +27,23 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           file: Dockerfile-build-runner
+          context: .
+          build-args: "runner=ksml-runner"
           push: true
           tags: |
             axual/ksml-kafka:snapshot
             ghcr.io/axual/ksml-kafka:snapshot
-          build-args: "runner=ksml-runner"
 
       - name: build and push Axual runner
         uses: docker/build-push-action@v3
         with:
           file: Dockerfile-build-runner
+          context: .
+          build-args: "runner=ksml-runner-axual"
           push: true
           tags: |
             axual/ksml-axual:snapshot
             ghcr.io/axual/ksml-axual:snapshot
-          build-args: "runner=ksml-runner-axual"
 
 
 

--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           file: Dockerfile-build-runner
           push: true
-          tags: axual/ksml-kafka:snapshot
+          tags: ghcr.io/axual/ksml-kafka:snapshot
           build-args: "runner=ksml-runner"
 
       - name: build and push Axual runner
@@ -30,7 +30,7 @@ jobs:
         with:
           file: Dockerfile-build-runner
           push: true
-          tags: axual/ksml-axual:snapshot
+          tags: ghcr.io/axual/ksml-axual:snapshot
           build-args: "runner=ksml-runner-axual"
 
 

--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -1,6 +1,8 @@
 name: build and push Docker images
 on:
   pull_request:
+    branches:
+      - master
     types:
       - closed
 

--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -17,12 +17,20 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: login to Docker hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: build and push plain Kafka runner
         uses: docker/build-push-action@v3
         with:
           file: Dockerfile-build-runner
           push: true
-          tags: ghcr.io/axual/ksml-kafka:snapshot
+          tags: |
+            axual/ksml-kafka:snapshot
+            ghcr.io/axual/ksml-kafka:snapshot
           build-args: "runner=ksml-runner"
 
       - name: build and push Axual runner
@@ -30,7 +38,9 @@ jobs:
         with:
           file: Dockerfile-build-runner
           push: true
-          tags: ghcr.io/axual/ksml-axual:snapshot
+          tags: |
+            axual/ksml-axual:snapshot
+            ghcr.io/axual/ksml-axual:snapshot
           build-args: "runner=ksml-runner-axual"
 
 

--- a/examples/ksml-runner.yml
+++ b/examples/ksml-runner.yml
@@ -2,7 +2,16 @@ ksml:
   workingDirectory: /tmp
   configDirectory: /ksml
   definitions:
-  - 01-demo-inspect.yaml
+#  - 01-demo-inspect.yaml
+#  - 02-demo-copy.yaml
+#  - 03-demo-filter.yaml
+#  - 04-demo-branch.yaml
+#  - 05-demo-dynamicrouting.yaml
+#  - 06-demo-double.yaml
+#  - 07-demo-convert.yaml
+#  - 08-demo-count.yaml
+#  - 09-demo-aggregate.yaml
+  - 10-demo-queryabletable.yaml
 
 backend:
   type: kafka


### PR DESCRIPTION
This PR fixes #17 by building and pushing `:snapshot` versions of the runner image when a pull request merges.