### PR TITLE
Support Liberica NIK

### DIFF
--- a/ksml/src/test/java/io/axual/ksml/KSMLTopologyGeneratorBasicTest.java
+++ b/ksml/src/test/java/io/axual/ksml/KSMLTopologyGeneratorBasicTest.java
@@ -23,6 +23,7 @@ package io.axual.ksml;
 
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.TopologyDescription;
+import org.graalvm.home.Version;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -52,9 +53,8 @@ public class KSMLTopologyGeneratorBasicTest {
 
     @BeforeAll
     public static void checkGraalVM() {
-        final var vendor = System.getProperty("java.vendor.url");
-        if (!vendor.contains("graalvm")) {
-            fail("This test needs GraalVM to work, found java.vendor.url=" + vendor);
+        if (!Version.getCurrent().isRelease()) {
+            fail("This test needs GraalVM to work.");
         }
     }
 


### PR DESCRIPTION
Currently, it's not possible to use Liberica NIK to compile and test because the `checkGraalVM()` method fails : 

```
org.opentest4j.AssertionFailedError: This test needs GraalVM to work, found java.vendor.url=https://bell-sw.com/
	at io.axual.ksml.KSMLTopologyGeneratorBasicTest.checkGraalVM(KSMLTopologyGeneratorBasicTest.java:57)
```

As mentioned by Oleg Šelajev in this [StackOverflow thread](https://stackoverflow.com/questions/64902270/how-can-i-tell-in-a-standard-java-program-if-im-running-in-graalvm-or-not), a cleaner (and generic) way to check if we use GraalVM is to use the [`Version.isRelease()`](https://www.graalvm.org/sdk/javadoc/org/graalvm/home/Version.html) method from the `graal-sdk`.