### PR TITLE
Update to Java 17

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,14 +16,14 @@ jobs:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: download GraalVM
         run: |
-          download_url="https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.3.0/graalvm-ce-java11-linux-amd64-21.3.0.tar.gz"
+          download_url="https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.1.0/graalvm-ce-java17-linux-amd64-22.1.0.tar.gz"
           wget -O $RUNNER_TEMP/graal_package.tar.gz $download_url
       - name: Set up GraalVM
         uses: actions/setup-java@v2
         with:
           distribution: 'jdkfile'
           jdkFile: ${{ runner.temp }}/graal_package.tar.gz
-          java-version: '11'
+          java-version: '17'
           architecture: x64
       - name: install GraalVM Python runtime
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV JAVA_HOME=/opt/graalvm
 ENV PATH=/opt/graalvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 RUN mkdir -p "/opt/ksml/libs"  \
-&& curl -k -L -o "/tmp/graalvm.tgz" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.2.0/graalvm-ce-java11-linux-amd64-21.2.0.tar.gz" \
+&& curl -k -L -o "/tmp/graalvm.tgz" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.1.0/graalvm-ce-java17-linux-amd64-22.1.0.tar.gz" \
 && tar -xzf /tmp/graalvm.tgz -C "/opt" \
 && mv /opt/graalvm* /opt/graalvm \
 && chown -R 1024:users /opt \

--- a/Dockerfile-build-runner
+++ b/Dockerfile-build-runner
@@ -1,5 +1,5 @@
 # --- step 1: build the code on GraalVM
-FROM ghcr.io/graalvm/graalvm-ce:21.2.0 AS builder
+FROM ghcr.io/graalvm/graalvm-ce:22.1.0 AS builder
 MAINTAINER Axual <maintainer@axual.io>
 RUN curl -O https://archive.apache.org/dist/maven/maven-3/3.8.5/binaries/apache-maven-3.8.5-bin.tar.gz \
   && tar xvf apache-maven-3.8.5-bin.tar.gz \
@@ -17,7 +17,7 @@ ARG runner=ksml-runner
 RUN echo Building runner: $runner
 
 RUN mkdir -p "/opt/ksml/libs"  \
-  && curl -k -L -o "/tmp/graalvm.tgz" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.2.0/graalvm-ce-java11-linux-amd64-21.2.0.tar.gz" \
+  && curl -k -L -o "/tmp/graalvm.tgz" "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.1.0/graalvm-ce-java17-linux-amd64-22.1.0.tar.gz" \
   && tar -xzf /tmp/graalvm.tgz -C "/opt" \
   && mv /opt/graalvm* /opt/graalvm \
   && chown -R 1024:users /opt \

--- a/Dockerfile-build-runner
+++ b/Dockerfile-build-runner
@@ -1,11 +1,12 @@
 # --- step 1: build the code on GraalVM
 FROM ghcr.io/graalvm/graalvm-ce:22.1.0 AS builder
 MAINTAINER Axual <maintainer@axual.io>
+WORKDIR /
 RUN curl -O https://archive.apache.org/dist/maven/maven-3/3.8.5/binaries/apache-maven-3.8.5-bin.tar.gz \
   && tar xvf apache-maven-3.8.5-bin.tar.gz \
   && gu install python
 ADD . /project_dir
-RUN cd project_dir && /apache-maven-3.8.5/bin/mvn clean package
+RUN cd /project_dir && /apache-maven-3.8.5/bin/mvn clean package
 
 # --- step 2: build GraalVM image with compiled code
 FROM redhat/ubi8:8.4-206.1626828523

--- a/pom.xml
+++ b/pom.xml
@@ -67,10 +67,10 @@
         <graalvm.version>21.1.0</graalvm.version>
         <hamcrest.version>2.1</hamcrest.version>
         <jackson.version>2.12.3</jackson.version>
-        <java.source.version>11</java.source.version>
-        <java.target.version>11</java.target.version>
+        <java.source.version>17</java.source.version>
+        <java.target.version>17</java.target.version>
         <jupiter.version>5.7.1</jupiter.version>
-        <lombok.version>1.18.18</lombok.version>
+        <lombok.version>1.18.24</lombok.version>
         <maven.compiler.version>3.8.1</maven.compiler.version>
         <maven.exec.version>3.0.0</maven.exec.version>
         <maven.jar.version>3.2.0</maven.jar.version>
@@ -81,7 +81,7 @@
         <maven.jacoco.plugin.version>0.8.7</maven.jacoco.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <slf4j.version>1.7.32</slf4j.version>
+        <slf4j.version>1.7.34</slf4j.version>
         <mockito-core.version>3.10.0</mockito-core.version>
         <surefire-provider.version>1.3.2</surefire-provider.version>
         <mockito-junit-jupiter.version>2.23.0</mockito-junit-jupiter.version>


### PR DESCRIPTION
Updated project to build for Java 17 (Latest LTS)
Updated dependencies, lombok required for Java17
Docker build files use Graal 22.1 Java 17 releases now

Local builds work with Liberica NIK 22.1-R17 release