### PR TITLE
Update the print statements in examples with Python 3 syntax

### DIFF
--- a/examples/01-demo-inspect.yaml
+++ b/examples/01-demo-inspect.yaml
@@ -9,7 +9,7 @@ streams:
 functions:
   print_message:
     type: forEach
-    code: "print('key='+(key if isinstance(key,str) else str(key))+', value='+(value if isinstance(value,str) else str(value)))"
+    code: "print('key=' + str(key) + ', value=' + str(value))"
 
 pipelines:
   main:

--- a/examples/02-demo-copy.yaml
+++ b/examples/02-demo-copy.yaml
@@ -13,7 +13,7 @@ streams:
 functions:
   print_message:
     type: forEach
-    code: "print('key='+(key if isinstance(key,str) else str(key))+', value='+(value if isinstance(value,str) else str(value)))"
+    code: "print('key=' + str(key) + ', value=' + str(value))"
 
 pipelines:
   # The main pipeline reads messages, outputs them and saves a copy in a target topic

--- a/examples/03-demo-filter.yaml
+++ b/examples/03-demo-filter.yaml
@@ -11,7 +11,7 @@ streams:
 functions:
   print_message:
     type: forEach
-    code: "print('key='+(key if isinstance(key,str) else str(key))+', value='+(value if isinstance(value,str) else str(value)))"
+    code: "print('key=' + str(key) + ', value=' + str(value))"
 
   filter_message:
     type: predicate

--- a/examples/04-demo-branch.yaml
+++ b/examples/04-demo-branch.yaml
@@ -15,7 +15,7 @@ streams:
 functions:
   print_message:
     type: forEach
-    code: "print('SOURCE key='+(key if isinstance(key,str) else str(key))+', value='+(value if isinstance(value,str) else str(value)))"
+    code: "print('SOURCE key=' + str(key) + ', value=' + str(value))"
 
 pipelines:
   main:
@@ -38,9 +38,9 @@ pipelines:
     from: sensor_red
     forEach:
       type: forEach
-      code: "print('RED key='+(key if isinstance(key,str) else str(key))+', value='+(value if isinstance(value,str) else str(value)))"
+      code: "print('RED key=' + str(key) + ', value=' + str(value))"
   blue_flow:
     from: sensor_blue
     forEach:
       type: forEach
-      code: "print('BLUE key='+(key if isinstance(key,str) else str(key))+', value='+(value if isinstance(value,str) else str(value)))"
+      code: "print('BLUE key=' + str(key) + ', value=' + str(value))"

--- a/examples/05-demo-dynamicrouting.yaml
+++ b/examples/05-demo-dynamicrouting.yaml
@@ -19,7 +19,7 @@ streams:
 functions:
   print_message:
     type: forEach
-    code: "print('key='+(key if isinstance(key,str) else str(key))+', value='+(value if isinstance(value,str) else str(value)))"
+    code: "print('key=' + str(key) + ', value=' + str(value))"
 
 pipelines:
   main:

--- a/examples/06-demo-double.yaml
+++ b/examples/06-demo-double.yaml
@@ -19,7 +19,7 @@ streams:
 functions:
   print_message:
     type: forEach
-    code: "print('key='+(key if isinstance(key,str) else str(key))+', value='+(value if isinstance(value,str) else str(value)))"
+    code: "print('key=' + str(key) + ', value=' + str(value))"
 
   doubleEveryRecord:
     type: keyValueToKeyValueListTransformer

--- a/examples/07-demo-convert.yaml
+++ b/examples/07-demo-convert.yaml
@@ -9,7 +9,7 @@ streams:
 functions:
   print_message:
     type: forEach
-    code: "print('key='+(key if isinstance(key,str) else str(key))+', value='+(value if isinstance(value,str) else str(value)))"
+    code: "print('key=' + str(key) + ', value=' + str(value))"
 
 pipelines:
   # The main pipeline reads messages, converts to json, outputs them, and saves to a target topic

--- a/examples/08-demo-count.yaml
+++ b/examples/08-demo-count.yaml
@@ -13,7 +13,7 @@ streams:
 functions:
   print_message:
     type: forEach
-    code: "print('key='+(key if isinstance(key,str) else str(key))+', value='+(value if isinstance(value,str) else str(value)))"
+    code: "print('key=' + str(key) + ', value=' + str(value))"
 
 pipelines:
   main:

--- a/examples/09-demo-aggregate.yaml
+++ b/examples/09-demo-aggregate.yaml
@@ -9,7 +9,7 @@ streams:
 functions:
   print_message:
     type: forEach
-    code: "print('key='+(key if isinstance(key,str) else str(key))+', value='+(value if isinstance(value,str) else str(value)))"
+    code: "print('key=' + str(key) + ', value=' + str(value))"
 
 stores:
   owner_count:

--- a/examples/10-demo-queryabletable.yaml
+++ b/examples/10-demo-queryabletable.yaml
@@ -15,7 +15,7 @@ tables:
 functions:
   print_message:
     type: forEach
-    code: "print('key='+(key if isinstance(key,str) else str(key))+', value='+(value if isinstance(value,str) else str(value)))"
+    code: "print('key=' + str(key) + ', value=' + str(value))"
 
 pipelines:
   main:


### PR DESCRIPTION
The examples dated back to Jython days when Python 3 syntax was not yet supported. Now that we do support it, we can simplify the print_message syntax.