### PR TITLE
Update to GraalVM for JDK 21 Community

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,18 +17,15 @@ jobs:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: download GraalVM
         run: |
-          download_url="https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.0/graalvm-ce-java17-linux-amd64-22.3.0.tar.gz"
+          download_url="https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.1/graalvm-community-jdk-21.0.1_linux-x64_bin.tar.gz"
           wget -O $RUNNER_TEMP/graal_package.tar.gz $download_url
       - name: Set up GraalVM
         uses: actions/setup-java@v3
         with:
           distribution: 'jdkfile'
           jdkFile: ${{ runner.temp }}/graal_package.tar.gz
-          java-version: '17'
+          java-version: '21'
           architecture: x64
-      - name: install GraalVM Python runtime
-        run: |
-          gu install python
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,15 +82,17 @@ USER ksml
 # Step 5: Create the KSML Runner image
 FROM ksml-graal AS ksml
 COPY --chown=ksml:0 --from=builder /project_dir/ksml-runner/target/libs/ /opt/ksml/libs/
+COPY --chown=ksml:0 --from=builder /project_dir/graalpy-module-collection/target/modules/ /opt/ksml/modules/
 COPY --chown=ksml:0 --from=builder /project_dir/ksml-runner/target/ksml-runner*.jar /opt/ksml/ksml.jar
 
-ENTRYPOINT ["java", "-jar", "/opt/ksml/ksml.jar"]
+ENTRYPOINT ["java", "--upgrade-module-path", "/opt/ksml/modules", "-jar", "/opt/ksml/ksml.jar"]
 
 
 # Step 6: Create the KSML Data Generator image
 FROM ksml-graal AS ksml-datagen
 COPY --chown=ksml:0 --from=builder /project_dir/ksml-data-generator/target/libs/ /opt/ksml/libs/
+COPY --chown=ksml:0 --from=builder /project_dir/graalpy-module-collection/target/modules/ /opt/ksml/modules/
 COPY --chown=ksml:0 --from=builder /project_dir/ksml-data-generator/target/ksml-data-generator-*.jar /opt/ksml/ksml-data-generator.jar
 
-ENTRYPOINT ["java", "-jar", "/opt/ksml/ksml-data-generator.jar"]
+ENTRYPOINT ["java", "--upgrade-module-path", "/opt/ksml/modules", "-jar", "/opt/ksml/ksml-data-generator.jar"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN set -eux \
 # Step 2: Download Graal and Maven into the base image
 FROM base AS graal-builder
 ARG TARGETARCH
-ARG GRAALVM_JDK_VERSION=17.0.8
+ARG GRAALVM_JDK_VERSION=21.0.1
 ARG MAVEN_VERSION=3.9.5
 
 RUN set -eux \
@@ -50,11 +50,10 @@ RUN set -eux \
     && mkdir -p /opt/maven \
     && MVN_PKG=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
     && curl --fail --silent --location --retry 3 ${MVN_PKG} | gunzip | tar x -C /opt/maven --strip-components=1 \
+#   && GRAALVM_PKG=https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-21.0.1/graalvm-community-jdk-21.0.1_linux-x64_bin.tar.gz
     && GRAALVM_PKG=https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${GRAALVM_JDK_VERSION}/graalvm-community-jdk-${GRAALVM_JDK_VERSION}_linux-${JAVA_ARCH}_bin.tar.gz \
     && mkdir -p /opt/graal \
-    && curl --fail --silent --location --retry 3 ${GRAALVM_PKG} | gunzip | tar x -C /opt/graal --strip-components=1 \
-    && gu -A install python
-
+    && curl --fail --silent --location --retry 3 ${GRAALVM_PKG} | gunzip | tar x -C /opt/graal --strip-components=1
 
 # Step 3: Build the KSML Project, cache the M2 repository location
 FROM graal-builder AS builder
@@ -75,8 +74,9 @@ COPY --chown=ksml:0 --from=graal-builder /opt/graal/ /opt/graal/
 
 WORKDIR /home/ksml
 USER ksml
-RUN graalpy -m venv graalenv && \
-    echo "source $HOME/graalenv/bin/activate" >> ~/.bashrc
+#There is no more GraalPy command here and no venv
+#RUN graalpy -m venv graalenv && \
+#    echo "source $HOME/graalenv/bin/activate" >> ~/.bashrc
 
 
 # Step 5: Create the KSML Runner image

--- a/examples/run.sh
+++ b/examples/run.sh
@@ -14,4 +14,4 @@ BASEDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 # Give kafka-setup some time to create all the topics
 sleep 2
-docker run --name ksml-example --rm -ti -v "${BASEDIR}":/ksml -w /ksml --network ksml_example axual/ksml:snapshot
+docker run --name ksml-example --rm -ti -v "${BASEDIR}":/ksml -w /ksml --network ksml_example axual/ksml:local

--- a/graalpy-module-collection/pom.xml
+++ b/graalpy-module-collection/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.axual.ksml</groupId>
+        <artifactId>ksml-parent</artifactId>
+        <version>0.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>graalpy-module-collection</artifactId>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.graalvm.polyglot</groupId>
+            <artifactId>polyglot</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.truffle</groupId>
+            <artifactId>truffle-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.graalvm.python</groupId>
+            <artifactId>python-language</artifactId>
+            <version>23.1.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.python</groupId>
+            <artifactId>python-resources</artifactId>
+            <version>23.1.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.truffle</groupId>
+            <artifactId>truffle-runtime</artifactId>
+            <version>23.1.1</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>
+                                ${project.build.directory}/modules
+                            </outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/graalpy-module-collection/src/main/java/module-info.java
+++ b/graalpy-module-collection/src/main/java/module-info.java
@@ -1,0 +1,4 @@
+module graalpy.module.collection {
+    requires org.graalvm.truffle;
+    requires org.graalvm.polyglot;
+}

--- a/ksml-data-generator/pom.xml
+++ b/ksml-data-generator/pom.xml
@@ -15,8 +15,8 @@
     <name>KSML Data Generator</name>
 
     <properties>
-        <maven.compiler.target>17</maven.compiler.target>
-        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -99,7 +99,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven.compiler.plugin.version}</version>
                 <configuration>
-                    <release>17</release>
+                    <release>21</release>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.projectlombok</groupId>

--- a/ksml-data-generator/pom.xml
+++ b/ksml-data-generator/pom.xml
@@ -98,16 +98,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven.compiler.plugin.version}</version>
-                <configuration>
-                    <release>21</release>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>org.projectlombok</groupId>
-                            <artifactId>lombok</artifactId>
-                            <version>${lombok.version}</version>
-                        </path>
-                    </annotationProcessorPaths>
-                </configuration>
             </plugin>
 
             <plugin>

--- a/ksml-query/pom.xml
+++ b/ksml-query/pom.xml
@@ -68,15 +68,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>org.projectlombok</groupId>
-                            <artifactId>lombok</artifactId>
-                            <version>${lombok.version}</version>
-                        </path>
-                    </annotationProcessorPaths>
-                </configuration>
             </plugin>
 
             <plugin>

--- a/ksml-reporting/pom.xml
+++ b/ksml-reporting/pom.xml
@@ -14,8 +14,8 @@
     <description>This module aggregates Jacoco coverage reports for all submodules.</description>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 

--- a/ksml-runner/pom.xml
+++ b/ksml-runner/pom.xml
@@ -86,15 +86,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>org.projectlombok</groupId>
-                            <artifactId>lombok</artifactId>
-                            <version>${lombok.version}</version>
-                        </path>
-                    </annotationProcessorPaths>
-                </configuration>
             </plugin>
 
             <plugin>

--- a/ksml-runner/pom.xml
+++ b/ksml-runner/pom.xml
@@ -14,8 +14,8 @@
     <description>A command line runner for KSML</description>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <sonar.coverage.jacoco.xmlReportPaths>../ksml-reporting/target/site/jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
     </properties>

--- a/ksml/pom.xml
+++ b/ksml/pom.xml
@@ -22,13 +22,22 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.graalvm.sdk</groupId>
-            <artifactId>graal-sdk</artifactId>
+            <groupId>org.graalvm.polyglot</groupId>
+            <artifactId>polyglot</artifactId>
         </dependency>
         <dependency>
             <groupId>org.graalvm.truffle</groupId>
             <artifactId>truffle-api</artifactId>
         </dependency>
+
+        <!-- runtime dependencies for GraalVM Python -->
+        <dependency>
+            <groupId>org.graalvm.polyglot</groupId>
+            <artifactId>python-community</artifactId>
+            <version>23.1.1</version>
+            <type>pom</type>
+        </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -190,8 +199,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <source>21</source>
+                    <target>21</target>
                     <compilerArgs>--enable-preview</compilerArgs>
                 </configuration>
             </plugin>

--- a/ksml/pom.xml
+++ b/ksml/pom.xml
@@ -21,26 +21,45 @@
     </properties>
 
     <dependencies>
+        <!-- Compile dependencies for GraalVM polyglot and truffle -->
         <dependency>
             <groupId>org.graalvm.polyglot</groupId>
             <artifactId>polyglot</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.graalvm.truffle</groupId>
             <artifactId>truffle-api</artifactId>
+            <scope>compile</scope>
         </dependency>
 
-        <!-- runtime dependencies for GraalVM Python -->
+        <!-- Compile dependencies for GraalVM Python -->
         <dependency>
-            <groupId>org.graalvm.polyglot</groupId>
-            <artifactId>python-community</artifactId>
+            <groupId>org.graalvm.python</groupId>
+            <artifactId>python-language</artifactId>
             <version>23.1.1</version>
-            <type>pom</type>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.python</groupId>
+            <artifactId>python-resources</artifactId>
+            <version>23.1.1</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.truffle</groupId>
+            <artifactId>truffle-runtime</artifactId>
+            <version>23.1.1</version>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -198,11 +217,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>21</source>
-                    <target>21</target>
-                    <compilerArgs>--enable-preview</compilerArgs>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,9 @@
         <apache.commons.text.version>1.11.0</apache.commons.text.version>
         <apache.kafka.version>3.6.0</apache.kafka.version>
         <confluent.version>7.5.2</confluent.version>
-        <graalvm.version>22.3.4</graalvm.version>
+        <graalvm.version>23.1.0</graalvm.version>
+        <graalvm.polyglot.version>23.1.1</graalvm.polyglot.version>
+        <graalvm.python.version>23.1.1</graalvm.python.version>
         <guava.version>32.0.1-jre</guava.version>
         <jackson.version>2.16.0</jackson.version>
         <jakarta.soap.version>3.0.1</jakarta.soap.version>
@@ -80,8 +82,8 @@
         <mockito-junit-jupiter.version>5.7.0</mockito-junit-jupiter.version>
 
         <!-- project and java version settings -->
-        <java.source.version>17</java.source.version>
-        <java.target.version>17</java.target.version>
+        <java.source.version>21</java.source.version>
+        <java.target.version>21</java.target.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -148,9 +150,27 @@
             </dependency>
 
             <dependency>
-                <groupId>org.graalvm.sdk</groupId>
-                <artifactId>graal-sdk</artifactId>
-                <version>${graalvm.version}</version>
+                <groupId>org.graalvm.polyglot</groupId>
+                <artifactId>polyglot</artifactId>
+                <version>${graalvm.polyglot.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.graalvm.python</groupId>
+                <artifactId>python-language</artifactId>
+                <version>${graalvm.python.version}</version>
+                <scope>runtime</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.graalvm.python</groupId>
+                <artifactId>python-resources</artifactId>
+                <version>${graalvm.python.version}</version>
+                <scope>runtime</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.graalvm.truffle</groupId>
+                <artifactId>truffle-runtime</artifactId>
+                <version>${graalvm.python.version}</version>
+                <scope>runtime</scope>
             </dependency>
             <dependency>
                 <groupId>org.graalvm.truffle</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <module>ksml-runner</module>
         <module>ksml-data-generator</module>
         <module>ksml-reporting</module>
+        <module>graalpy-module-collection</module>
     </modules>
 
     <properties>
@@ -84,6 +85,7 @@
         <!-- project and java version settings -->
         <java.source.version>21</java.source.version>
         <java.target.version>21</java.target.version>
+        <java.release.version>21</java.release.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -514,6 +516,14 @@
                 <configuration>
                     <source>${java.source.version}</source>
                     <target>${java.target.version}</target>
+                    <release>${java.release.version}</release>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Updated pom dependencies to Java 21
Added GraalVM Polyglot, GraalVM Python dependencies to pom.xml since they've been removed from GraalVM distribution.
Added new maven sub module to define and download GraalVM Polyglot, GraalVM Python and Truffle modules to make sure Java21 can find the modules.

Updated Docker build to:
- use GraalVM for JDK 21
- Copy the GraalVM, Python and Python modules to a separate directory
- Update the entrypoint to use the `upgrade-module-path` option when starting KSML and DataGen

Updated Github Actions to download and use GraalVM for JDK 21 Community

Tests run
- All unit/integration tests
- Local Docker BuildX build as described in the readme
- Run the example docker compose and run.sh using the local build images
- Manually tested the updated GitHub Action, download and build OK, failed on Sonarcloud scan. This is normal for a fork build.