### PR TITLE
Fix KSML java process not stopping on exception

### DIFF
--- a/ksml-runner/src/main/java/io/axual/ksml/runner/KSMLRunner.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/KSMLRunner.java
@@ -127,6 +127,8 @@ public class KSMLRunner {
             backendFuture.get();
             // Future, check exit state of backend
         } catch (ExecutionException | InterruptedException e) {
+            throw FatalError.reportAndExit(new KSMLExecutionException("Exception caught", e));
+        }finally {
             executorService.shutdown();
             try {
                 if (!executorService.awaitTermination(800, TimeUnit.MILLISECONDS)) {
@@ -136,7 +138,7 @@ public class KSMLRunner {
                 executorService.shutdownNow();
                 throw FatalError.reportAndExit(new KSMLExecutionException("Exception caught", e2));
             }
-            throw FatalError.reportAndExit(new KSMLExecutionException("Exception caught", e));
+
         }
     }
 }


### PR DESCRIPTION
The exception handling of KSML stops the Kafka Streams and other flows, but the executor service is not shut down in this flow.
Moved the KSMLRunner executor service shutdown to the finally block to make sure it is always stopped