### PR TITLE
Fix to enable Streams optimisations to be applied to topology

### DIFF
--- a/ksml-runner/src/main/java/io/axual/ksml/runner/backend/KafkaBackend.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/backend/KafkaBackend.java
@@ -39,10 +39,8 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyQueryMetadata;
 import org.apache.kafka.streams.StoreQueryParameters;
-import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsMetadata;
-import org.apache.kafka.streams.TopologyConfig;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -95,10 +93,9 @@ public class KafkaBackend implements Backend {
                         new ResolvingDeserializer<>(serde.deserializer(), streamsConfig)));
         var topologyGenerator = new KSMLTopologyGenerator(applicationId, ksmlConf, streamsConfig);
 
-//        var topologyConfig = new TopologyConfig(applicationId, new StreamsConfig(streamsConfig), new Properties());
-        var topologyConfig = new TopologyConfig(new StreamsConfig(streamsConfig));
-        final var topology = topologyGenerator.create(new StreamsBuilder(topologyConfig));
-        kafkaStreams = new KafkaStreams(topology, mapToProperties(streamsConfig));
+        final var streamProperties = mapToProperties(streamsConfig);
+        final var topology = topologyGenerator.create(streamProperties);
+        kafkaStreams = new KafkaStreams(topology, streamProperties);
         kafkaStreams.setUncaughtExceptionHandler(ExecutionContext.INSTANCE::uncaughtException);
     }
 

--- a/ksml/src/main/java/io/axual/ksml/KSMLTopologyGenerator.java
+++ b/ksml/src/main/java/io/axual/ksml/KSMLTopologyGenerator.java
@@ -31,7 +31,6 @@ import io.axual.ksml.notation.json.JsonNotation;
 import io.axual.ksml.notation.json.JsonSchemaLoader;
 import io.axual.ksml.notation.xml.XmlNotation;
 import io.axual.ksml.notation.xml.XmlSchemaLoader;
-import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
 
 import java.util.Map;
@@ -49,7 +48,7 @@ public class KSMLTopologyGenerator implements TopologyGenerator {
     }
 
     @Override
-    public Topology create(StreamsBuilder streamsBuilder) {
+    public Topology create(Properties streamsConfig) {
         // Register schema loaders
         SchemaLibrary.registerLoader(AvroNotation.NOTATION_NAME, new AvroSchemaLoader(config.schemaDirectory()));
         SchemaLibrary.registerLoader(CsvNotation.NOTATION_NAME, new CsvSchemaLoader(config.schemaDirectory()));
@@ -60,6 +59,6 @@ public class KSMLTopologyGenerator implements TopologyGenerator {
         var generator = new TopologyGeneratorImpl(config);
 
         // Parse and return the topology
-        return generator.create(applicationId, streamsBuilder);
+        return generator.create(applicationId, streamsConfig);
     }
 }

--- a/ksml/src/main/java/io/axual/ksml/TopologyGenerator.java
+++ b/ksml/src/main/java/io/axual/ksml/TopologyGenerator.java
@@ -21,9 +21,10 @@ package io.axual.ksml;
  */
 
 
-import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
 
+import java.util.Properties;
+
 public interface TopologyGenerator {
-    Topology create(StreamsBuilder streamsBuilder);
+    Topology create(Properties streamsBuilder);
 }

--- a/ksml/src/main/java/io/axual/ksml/parser/topology/TopologyParseContext.java
+++ b/ksml/src/main/java/io/axual/ksml/parser/topology/TopologyParseContext.java
@@ -43,10 +43,7 @@ import io.axual.ksml.user.UserFunction;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 public class TopologyParseContext implements ParseContext {
     private final PythonContext pythonContext;
@@ -244,7 +241,7 @@ public class TopologyParseContext implements ParseContext {
         markStateStoreCreated(store.name());
     }
 
-    public Topology build() {
+    public Topology build(Properties streamsProperties) {
         // Create all state stores that were defined, but not yet implicitly created (eg. through using Materialized)
         for (Map.Entry<String, StateStoreDefinition> entry : stateStoreDefinitions.entrySet()) {
             if (!createdStateStores.contains(entry.getKey())) {
@@ -252,6 +249,6 @@ public class TopologyParseContext implements ParseContext {
                 createdStateStores.add(entry.getKey());
             }
         }
-        return builder.build();
+        return builder.build(streamsProperties);
     }
 }

--- a/ksml/src/test/java/io/axual/ksml/KSMLTopologyGeneratorBasicTest.java
+++ b/ksml/src/test/java/io/axual/ksml/KSMLTopologyGeneratorBasicTest.java
@@ -23,7 +23,6 @@ package io.axual.ksml;
 
 import io.axual.ksml.generator.TopologyGeneratorImpl;
 import io.axual.ksml.notation.NotationLibrary;
-import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.TopologyDescription;
 import org.graalvm.home.Version;
 import org.junit.jupiter.api.BeforeAll;
@@ -38,7 +37,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
-import java.util.Map;
+import java.util.Properties;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -65,7 +64,11 @@ public class KSMLTopologyGeneratorBasicTest {
                 .notationLibrary(new NotationLibrary(new HashMap<>()))
                 .build());
 
-        final var topology = topologyGenerator.create("some.app.id", new StreamsBuilder());
+        var streamProperties = new Properties();
+        streamProperties.put("bootstrap.servers", "localhost:9092");
+        streamProperties.put("application.id", "testing");
+
+        final var topology = topologyGenerator.create("some.app.id", streamProperties);
         final TopologyDescription description = topology.describe();
         System.out.println(description);
 


### PR DESCRIPTION
Refactor to provide streams configuration to topology builder. This allows optimisation to take place, and reduces the need for table changelog topics along with other Kafka Streams optimisations