### PR TITLE
Make `producers:` interval optional so we can single shot produce

### DIFF
--- a/examples/00-example-generate-sensordata.yaml
+++ b/examples/00-example-generate-sensordata.yaml
@@ -32,7 +32,7 @@ functions:
 producers:
   sensordata_avro_producer:
     generator: generate_sensordata_message
-#    interval: 444
+    interval: 444
     to:
       topic: ksml_sensordata_avro
       keyType: string

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/backend/IntervalSchedule.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/backend/IntervalSchedule.java
@@ -44,14 +44,16 @@ public class IntervalSchedule<T> {
         var firstScheduled = schedule.firstEntry();
         while (firstScheduled != null) {
             // If the scheduled item is in the future, then return no item
-            if (firstScheduled.getKey() >= System.currentTimeMillis()) return null;
+            if (firstScheduled.getKey() > System.currentTimeMillis()) {
+                return null;
+            }
 
             if (!firstScheduled.getValue().isEmpty()) {
                 // Extract the scheduled item from the list
                 var result = firstScheduled.getValue().getFirst();
                 firstScheduled.getValue().removeFirst();
 
-                // If not single shot, eschedule for the next interval
+                // If not single shot, reschedule for the next interval
                 if (result.interval() > 0) {
                     var nextTime = firstScheduled.getKey() + result.interval();
                     var items = schedule.computeIfAbsent(nextTime, ts -> new ArrayList<>());

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/backend/IntervalSchedule.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/backend/IntervalSchedule.java
@@ -36,6 +36,10 @@ public class IntervalSchedule<T> {
         items.add(new ScheduledItem<>(interval, item));
     }
 
+    public void schedule(T item) {
+        schedule(0, item);
+    }
+
     public T getScheduledItem() {
         var firstScheduled = schedule.firstEntry();
         while (firstScheduled != null) {
@@ -46,10 +50,13 @@ public class IntervalSchedule<T> {
                 // Extract the scheduled item from the list
                 var result = firstScheduled.getValue().getFirst();
                 firstScheduled.getValue().removeFirst();
-                // Reschedule for the next interval
-                var nextTime = firstScheduled.getKey() + result.interval();
-                var items = schedule.computeIfAbsent(nextTime, ts -> new ArrayList<>());
-                items.add(result);
+
+                // If not single shot, eschedule for the next interval
+                if (result.interval() > 0) {
+                    var nextTime = firstScheduled.getKey() + result.interval();
+                    var items = schedule.computeIfAbsent(nextTime, ts -> new ArrayList<>());
+                    items.add(result);
+                }
                 // Finally return the scheduled item
                 return result.item;
             }

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/backend/KafkaProducerRunner.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/backend/KafkaProducerRunner.java
@@ -95,7 +95,12 @@ public class KafkaProducerRunner implements Runner {
                     var valueSerde = NotationLibrary.get(target.valueType().notation()).serde(target.valueType().dataType(), false);
                     var valueSerializer = new ResolvingSerializer<>(valueSerde.serializer(), config.kafkaConfig);
                     var ep = new ExecutableProducer(generator, condition, target.topic(), target.keyType(), target.valueType(), keySerializer, valueSerializer);
-                    schedule.schedule(producer.interval().toMillis(), ep);
+                    if (producer.interval() == null) {
+                        // no interval: schedule single shot produce
+                        schedule.schedule(ep);
+                    } else {
+                        schedule.schedule(producer.interval().toMillis(), ep);
+                    }
                     log.info("Scheduled producer: {}", name);
                 });
             });

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/backend/IntervalScheduleTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/backend/IntervalScheduleTest.java
@@ -1,0 +1,67 @@
+package io.axual.ksml.runner.backend;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class IntervalScheduleTest {
+
+    private IntervalSchedule<String> intervalSchedule;
+
+    @BeforeEach
+    void setup() {
+        intervalSchedule = new IntervalSchedule<>();
+    }
+
+    @Test
+    @DisplayName("An item can be scheduled repeatedly")
+    void scheduledOnInterval() throws InterruptedException {
+        // if we schedule with interval 200ms
+        intervalSchedule.schedule(200L, "test");
+
+        // at first the item is returned straight away
+        assertEquals("test", intervalSchedule.getScheduledItem());
+
+        // then for the duration of the interval, nothing is returned
+        assertNull(intervalSchedule.getScheduledItem(), "should not return item before interval");
+
+        // after the interval expires, the same item is returned again
+        Thread.sleep(500);
+        assertEquals("test", intervalSchedule.getScheduledItem());
+    }
+
+    @Test
+    @DisplayName("An item can be scheduled single shot")
+    void singleShot() throws InterruptedException {
+        // if we schedule without interval (will set default to 0 internally)
+        intervalSchedule.schedule("test");
+
+        // the item is returned straight away
+        assertEquals("test", intervalSchedule.getScheduledItem());
+
+        // but it is not rescheduled
+        Thread.sleep(100);
+        assertNull(intervalSchedule.getScheduledItem(), "item should be returned only once");
+    }
+
+    @Test
+    @DisplayName("Order of scheduling is maintained for equal interval")
+    void maintainsOrdering() throws InterruptedException {
+        // if we schedule two items with same timeout
+        intervalSchedule.schedule(500, "test1");
+        intervalSchedule.schedule(500, "test2");
+
+        // when they are retrieved, insertion order is maintained
+        assertEquals("test1", intervalSchedule.getScheduledItem());
+        assertEquals("test2", intervalSchedule.getScheduledItem());
+        assertNull(intervalSchedule.getScheduledItem(), "should return no more items at this point");
+
+        // after the interval expires, the same items are returned in the same order
+        Thread.sleep(600);
+        assertEquals("test1", intervalSchedule.getScheduledItem());
+        assertEquals("test2", intervalSchedule.getScheduledItem());
+        assertNull(intervalSchedule.getScheduledItem(), "should return no more items at this point");
+    }
+}

--- a/ksml/src/test/java/io/axual/ksml/TopologyGeneratorBasicTest.java
+++ b/ksml/src/test/java/io/axual/ksml/TopologyGeneratorBasicTest.java
@@ -91,6 +91,19 @@ public class TopologyGeneratorBasicTest {
         assertThat(cleanDescription("fix\r\nnewlines"), is("fix\nnewlines"));
     }
 
+    @Test
+    void loadGeneratorExample() throws Exception {
+        final var uri = ClassLoader.getSystemResource("pipelines/generator-example.yaml").toURI();
+        final var path = Paths.get(uri);
+        final var definition = YAMLObjectMapper.INSTANCE.readValue(Files.readString(path), JsonNode.class);
+        final var definitions = ImmutableMap.of("definition",
+                new TopologyDefinitionParser("test").parse(ParseNode.fromRoot(definition, "test")));
+        var topologyGenerator = new TopologyGenerator("some.app.id");
+        final var topology = topologyGenerator.create(streamsBuilder, definitions);
+        final TopologyDescription description = topology.describe();
+        System.out.println(description);
+    }
+
     /**
      * Clean a description string by removing all object references ("@abcd1234") and fixing Windows line endings.
      */

--- a/ksml/src/test/resources/pipelines/generator-example.yaml
+++ b/ksml/src/test/resources/pipelines/generator-example.yaml
@@ -32,8 +32,9 @@ functions:
 producers:
   sensordata_avro_producer:
     generator: generate_sensordata_message
-#    interval: 444
+    interval: 444
     to:
       topic: ksml_sensordata_avro
       keyType: string
-      valueType: avro:SensorData
+      valueType: json
+#      valueType: avro:SensorData


### PR DESCRIPTION
While working on / thinking about testing KSML streams I noticed that the `interval:` parameter inside `producers:` was mandatory. If we want to use KSML to create tests for stream definitions I think it would be useful to be able to create single-shot producers which generate a known, fixed set of records on a stream.
This PR makes `interval:` optional; if omitted, the produce will run one time only.

Added a unit test for `IntervalSchedule` to verify behavior, tested in docker compose by changing `00-example-generate-sensordata.yaml` to have no interval, running with a local generated image and verified that only one sensordata reading was generated.