### PR TITLE
Enabled Topology Generator Basic test to verify topology and topology naming

### DIFF
--- a/ksml/src/test/java/io/axual/ksml/TopologyGeneratorBasicTest.java
+++ b/ksml/src/test/java/io/axual/ksml/TopologyGeneratorBasicTest.java
@@ -20,23 +20,10 @@ package io.axual.ksml;
  * =========================LICENSE_END==================================
  */
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 
-import io.axual.ksml.data.notation.NotationLibrary;
-import io.axual.ksml.data.notation.avro.AvroNotation;
-import io.axual.ksml.data.notation.binary.BinaryNotation;
-import io.axual.ksml.data.notation.csv.CsvDataObjectConverter;
-import io.axual.ksml.data.notation.csv.CsvNotation;
-import io.axual.ksml.data.notation.json.JsonDataObjectConverter;
-import io.axual.ksml.data.notation.json.JsonNotation;
-import io.axual.ksml.data.notation.soap.SOAPDataObjectConverter;
-import io.axual.ksml.data.notation.soap.SOAPNotation;
-import io.axual.ksml.data.notation.xml.XmlDataObjectConverter;
-import io.axual.ksml.data.notation.xml.XmlNotation;
-import io.axual.ksml.data.parser.ParseNode;
-import io.axual.ksml.definition.parser.TopologyDefinitionParser;
-import io.axual.ksml.generator.YAMLObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.TopologyDescription;
 import org.graalvm.home.Version;
@@ -50,6 +37,14 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+
+import io.axual.ksml.data.notation.NotationLibrary;
+import io.axual.ksml.data.notation.binary.BinaryNotation;
+import io.axual.ksml.data.notation.json.JsonDataObjectConverter;
+import io.axual.ksml.data.notation.json.JsonNotation;
+import io.axual.ksml.data.parser.ParseNode;
+import io.axual.ksml.definition.parser.TopologyDefinitionParser;
+import io.axual.ksml.generator.YAMLObjectMapper;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/ksml/src/test/resources/reference/1-reference.txt
+++ b/ksml/src/test/resources/reference/1-reference.txt
@@ -1,8 +1,8 @@
 Topologies:
    Sub-topology: 0
     Source: ksml_sensordata_avro (topics: [ksml_sensordata_avro])
-      --> for_each_001
-    Processor: for_each_001 (stores: [])
+      --> test_pipelines_main
+    Processor: test_pipelines_main (stores: [])
       --> none
       <-- ksml_sensordata_avro
 

--- a/ksml/src/test/resources/reference/2-reference.txt
+++ b/ksml/src/test/resources/reference/2-reference.txt
@@ -1,10 +1,10 @@
 Topologies:
    Sub-topology: 0
     Source: ksml_sensordata_avro (topics: [ksml_sensordata_avro])
-      --> peek_001
-    Processor: peek_001 (stores: [])
-      --> to_001
+      --> test_pipelines_main_via_step1
+    Processor: test_pipelines_main_via_step1 (stores: [])
+      --> test_to
       <-- ksml_sensordata_avro
-    Sink: to_001 (topic: ksml_sensordata_copy)
-      <-- peek_001
+    Sink: test_to (topic: ksml_sensordata_copy)
+      <-- test_pipelines_main_via_step1
 

--- a/ksml/src/test/resources/reference/3-reference.txt
+++ b/ksml/src/test/resources/reference/3-reference.txt
@@ -1,13 +1,13 @@
 Topologies:
    Sub-topology: 0
     Source: ksml_sensordata_avro (topics: [ksml_sensordata_avro])
-      --> before-peek
-    Processor: before-peek (stores: [])
-      --> message-filter
+      --> test_before-peek
+    Processor: test_before-peek (stores: [])
+      --> test_message-filter
       <-- ksml_sensordata_avro
-    Processor: message-filter (stores: [])
-      --> to_001
-      <-- before-peek
-    Sink: to_001 (topic: ksml_sensordata_filtered)
-      <-- message-filter
+    Processor: test_message-filter (stores: [])
+      --> test_to
+      <-- test_before-peek
+    Sink: test_to (topic: ksml_sensordata_filtered)
+      <-- test_message-filter
 

--- a/ksml/src/test/resources/reference/4-reference.txt
+++ b/ksml/src/test/resources/reference/4-reference.txt
@@ -1,27 +1,27 @@
 Topologies:
    Sub-topology: 0
     Source: ksml_sensordata_avro (topics: [ksml_sensordata_avro])
-      --> before-peek
-    Processor: before-peek (stores: [])
-      --> branch_001
+      --> test_before-peek
+    Processor: test_before-peek (stores: [])
+      --> test_pipelines_main
       <-- ksml_sensordata_avro
-    Processor: branch_001 (stores: [])
-      --> branch_001-predicate-0, branch_001-predicate-1, branch_001-predicate-2
-      <-- before-peek
-    Processor: branch_001-predicate-0 (stores: [])
-      --> to_001
-      <-- branch_001
-    Processor: branch_001-predicate-1 (stores: [])
-      --> to_002
-      <-- branch_001
-    Processor: branch_001-predicate-2 (stores: [])
-      --> for_each_001
-      <-- branch_001
-    Processor: for_each_001 (stores: [])
+    Processor: test_pipelines_main (stores: [])
+      --> test_pipelines_main-predicate-1, test_pipelines_main-predicate-0, test_pipelines_main-predicate-2
+      <-- test_before-peek
+    Processor: test_pipelines_main-predicate-0 (stores: [])
+      --> test_to
+      <-- test_pipelines_main
+    Processor: test_pipelines_main-predicate-1 (stores: [])
+      --> test_to_001
+      <-- test_pipelines_main
+    Processor: test_pipelines_main-predicate-2 (stores: [])
+      --> test_pipelines_main_branch_branch3
+      <-- test_pipelines_main
+    Processor: test_pipelines_main_branch_branch3 (stores: [])
       --> none
-      <-- branch_001-predicate-2
-    Sink: to_001 (topic: ksml_sensordata_blue)
-      <-- branch_001-predicate-0
-    Sink: to_002 (topic: ksml_sensordata_red)
-      <-- branch_001-predicate-1
+      <-- test_pipelines_main-predicate-2
+    Sink: test_to (topic: ksml_sensordata_blue)
+      <-- test_pipelines_main-predicate-0
+    Sink: test_to_001 (topic: ksml_sensordata_red)
+      <-- test_pipelines_main-predicate-1
 

--- a/ksml/src/test/resources/reference/5-reference.txt
+++ b/ksml/src/test/resources/reference/5-reference.txt
@@ -1,10 +1,7 @@
 Topologies:
    Sub-topology: 0
     Source: ksml_sensordata_avro (topics: [ksml_sensordata_avro])
-      --> before-peek
-    Processor: before-peek (stores: [])
-      --> to_name_extract_001
+      --> test_before-peek
+    Processor: test_before-peek (stores: [])
+      --> none
       <-- ksml_sensordata_avro
-    Sink: to_name_extract_001 (extractor class: io.axual.ksml.user.UserTopicNameExtractor)
-      <-- before-peek
-


### PR DESCRIPTION
During the refactoring the topology generator tests were partially disabled and never reactivated.

Updated the tests to match the current initialisation logic.
Updated the reference files to match the expected topology names