### PR TITLE
Update build to not run sonarscan on forks

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,8 +48,7 @@ jobs:
       - name: Build and test for PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=ksml
+        run: mvn -B verify
         if: ${{ github.event.pull_request.head.repo.fork && github.repository == 'Axual/ksml'}}
       - name: verify contents of workspace
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,17 +38,18 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      - name: Build and test coverage
+      - name: Build and test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           ADDITIONAL_MAVEN_ARGS: ${{ github.repository == 'Axual/ksml' && ' org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=ksml' || '' }}
         run: mvn -B verify $ADDITIONAL_MAVEN_ARGS
         if: ${{ !github.event.pull_request.head.repo.fork }}
-      - name: Build and test but no coverage, PR only
+      - name: Build and test for PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-        run: mvn -B verify
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=ksml
         if: ${{ github.event.pull_request.head.repo.fork && github.repository == 'Axual/ksml'}}
       - name: verify contents of workspace
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,13 +42,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=ksml
+          ADDITIONAL_MAVEN_ARGS: ${{ github.repository == 'Axual/ksml' && ' org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=ksml' || '' }}
+        run: mvn -B verify $ADDITIONAL_MAVEN_ARGS
         if: ${{ !github.event.pull_request.head.repo.fork }}
       - name: Build and test but no coverage, PR only
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B verify
-        if: ${{ github.event.pull_request.head.repo.fork }}
+        if: ${{ github.event.pull_request.head.repo.fork && github.repository == 'Axual/ksml'}}
       - name: verify contents of workspace
         run: |
           ls -l  ${{ github.workspace }}


### PR DESCRIPTION
If you fork the project the action in your forks fail because of missing Sonarcloud credentials.
This fix checks the repository name, and if it isn't _Axual/ksml_ it won't set the extra commands for a maven sonar scan