### PR TITLE
Use custom properties file to get version information

### DIFF
--- a/ksml-runner/src/main/resources/ksml/ksml-info.properties
+++ b/ksml-runner/src/main/resources/ksml/ksml-info.properties
@@ -1,0 +1,3 @@
+name=${project.name}
+version=${project.version}
+buildTime=${maven.build.timestamp}

--- a/ksml-runner/src/test/resources/ksml/ksml-info.properties
+++ b/ksml-runner/src/test/resources/ksml/ksml-info.properties
@@ -1,0 +1,3 @@
+name=ksml-for-testing
+version=testing
+buildTime=2024-01-01T01:00:00Z

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
         <maven.enforcer.plugin.version>3.4.1</maven.enforcer.plugin.version>
         <maven.exec.plugin.version>3.2.0</maven.exec.plugin.version>
         <maven.license.plugin.version>2.4.0</maven.license.plugin.version>
+        <maven.resources.plugin.version>3.3.1</maven.resources.plugin.version>
 
         <maven.javadoc.plugin.version>3.6.3</maven.javadoc.plugin.version>
         <maven.surefire.plugin.version>3.2.5</maven.surefire.plugin.version>
@@ -533,6 +534,12 @@
                             <phase>process-sources</phase>
                         </execution>
                     </executions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>${maven.resources.plugin.version}</version>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
The previous implementation to get the version and name of KSML used the manifest. This didn't work with the module load, the wrong manifest was loaded.

This new implementation uses a custom properties file and the Maven Resources Plugin