### PR TITLE
Fix NullPointer exception in PrometheusExport

### DIFF
--- a/ksml-runner/src/main/java/io/axual/ksml/runner/prometheus/PrometheusExport.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/prometheus/PrometheusExport.java
@@ -104,7 +104,7 @@ public class PrometheusExport implements Closeable {
     public synchronized void stop() {
         Optional.ofNullable(httpServer).ifPresent(HTTPServer::close);
         httpServer = null;
-        collectorList.forEach(registry::unregister);
+        Optional.ofNullable(registry).ifPresent(r -> collectorList.forEach(r::unregister));
         collectorList.clear();
     }
 

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/prometheus/PrometheusExport.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/prometheus/PrometheusExport.java
@@ -105,6 +105,7 @@ public class PrometheusExport implements Closeable {
         Optional.ofNullable(httpServer).ifPresent(HTTPServer::close);
         httpServer = null;
         Optional.ofNullable(registry).ifPresent(r -> collectorList.forEach(r::unregister));
+        registry = null;
         collectorList.clear();
     }
 


### PR DESCRIPTION
The PrometheusExport can get a NullPointer Exception if a try with resources fails and the stop is called again.

The Optional ofNullable is used to determine if the collector unregister calls can be done.