### PR TITLE
Add group as alias for group.id in patterns

### DIFF
--- a/ksml-kafka-clients/pom.xml
+++ b/ksml-kafka-clients/pom.xml
@@ -52,7 +52,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+        <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
             <scope>test</scope>
         </dependency>

--- a/ksml-kafka-clients/src/main/java/io/axual/ksml/client/resolving/GroupPatternResolver.java
+++ b/ksml-kafka-clients/src/main/java/io/axual/ksml/client/resolving/GroupPatternResolver.java
@@ -20,11 +20,21 @@ package io.axual.ksml.client.resolving;
  * =========================LICENSE_END==================================
  */
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.Map;
+
 public class GroupPatternResolver extends PatternResolver implements GroupResolver {
     public static final String DEFAULT_PLACEHOLDER_VALUE = "group.id";
+    public static final String PLACEHOLDER_ALIAS = "group";
 
     public GroupPatternResolver(String groupPattern, Map<String, String> defaultValues) {
-        super(groupPattern, DEFAULT_PLACEHOLDER_VALUE, defaultValues);
+        super(replaceAliases(groupPattern), DEFAULT_PLACEHOLDER_VALUE, defaultValues);
+    }
+
+    private static String replaceAliases(String pattern) {
+        var defaultPlaceholderPattern = "{" + DEFAULT_PLACEHOLDER_VALUE + "}";
+        var aliasPlaceholderPattern = "{" + PLACEHOLDER_ALIAS + "}";
+        return StringUtils.replace(pattern, aliasPlaceholderPattern, defaultPlaceholderPattern);
     }
 }

--- a/ksml-kafka-clients/src/test/java/io/axual/ksml/client/resolving/GroupPatternResolverTest.java
+++ b/ksml-kafka-clients/src/test/java/io/axual/ksml/client/resolving/GroupPatternResolverTest.java
@@ -1,0 +1,50 @@
+package io.axual.ksml.client.resolving;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class GroupPatternResolverTest {
+
+    public static final String PATTERN_WITH_DEFAULT_PLACEHOLDER = "{tenant}-{instance}-{environment}-{group.id}";
+    public static final String PATTERN_WITH_ALIAS_PLACEHOLDER = "{tenant}-{instance}-{environment}-{group}";
+    public static final String TENANT = "kmsl";
+    public static final String INSTANCE = "testing";
+    public static final String ENVIRONMENT = "test";
+
+    public static final String GROUP_ID = "some.testing-group";
+    public static final String RESOLVED_GROUP_ID = "%s-%s-%s-%s".formatted(TENANT, INSTANCE, ENVIRONMENT, GROUP_ID);
+
+    public static final Map<String, String> BASE_CONFIG = Map.of(
+            "tenant", TENANT,
+            "instance", INSTANCE,
+            "environment", ENVIRONMENT);
+
+    @ParameterizedTest
+    @DisplayName("Resolve groups")
+    @ValueSource(strings = {PATTERN_WITH_DEFAULT_PLACEHOLDER, PATTERN_WITH_ALIAS_PLACEHOLDER})
+    void resolveValidPatternAndData(String pattern) {
+        var resolver = new GroupPatternResolver(pattern, BASE_CONFIG);
+        var resolved = resolver.resolve(GROUP_ID);
+        assertEquals(RESOLVED_GROUP_ID, resolved);
+
+        var unresolved = resolver.unresolve(RESOLVED_GROUP_ID);
+        assertEquals(GROUP_ID, unresolved);
+    }
+
+    @ParameterizedTest
+    @DisplayName("Pattern null causes exception")
+    @NullSource
+    @ValueSource(strings = {"", "nothing-here", "{group.id"})
+    void nullPatternException(String pattern) {
+        assertThrows(IllegalArgumentException.class, () -> new GroupPatternResolver(pattern, BASE_CONFIG));
+    }
+
+}


### PR DESCRIPTION
Added an alias support for group id patterns. Axual deployments can use the pattern {group} as equivalent to {group.id}
