### PR TITLE
Add runtime dependencies to KSML image

### DIFF
--- a/ksml-runner/pom.xml
+++ b/ksml-runner/pom.xml
@@ -161,7 +161,7 @@
                             <goal>copy-dependencies</goal>
                         </goals>
                         <configuration>
-                            <includeScope>compile</includeScope>
+                            <includeScope>runtime</includeScope>
                             <outputDirectory>
                                 ${project.build.directory}/libs
                             </outputDirectory>


### PR DESCRIPTION
Set dependency plugin to also download runtime dependencies. 
This allows the compression libraries to be available again