### PR TITLE
Implement Readiness service and probes

### DIFF
--- a/ksml-query/src/main/java/io/axual/ksml/rest/server/ComponentState.java
+++ b/ksml-query/src/main/java/io/axual/ksml/rest/server/ComponentState.java
@@ -4,7 +4,7 @@ package io.axual.ksml.rest.server;
  * ========================LICENSE_START=================================
  * KSML Queryable State Store
  * %%
- * Copyright (C) 2021 - 2023 Axual B.V.
+ * Copyright (C) 2021 - 2024 Axual B.V.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,17 +20,10 @@ package io.axual.ksml.rest.server;
  * =========================LICENSE_END==================================
  */
 
-import org.apache.kafka.common.serialization.Serializer;
-import org.apache.kafka.streams.KeyQueryMetadata;
-import org.apache.kafka.streams.StoreQueryParameters;
-import org.apache.kafka.streams.StreamsMetadata;
-
-import java.util.Collection;
-
-public interface StreamsQuerier {
-    Collection<StreamsMetadata> allMetadataForStore(String storeName);
-
-    <K> KeyQueryMetadata queryMetadataForKey(String storeName, K key, Serializer<K> keySerializer);
-
-    <T> T store(StoreQueryParameters<T> storeQueryParameters);
+public enum ComponentState {
+    STARTING,
+    STARTED,
+    STOPPING,
+    STOPPED,
+    FAILED
 }

--- a/ksml-query/src/main/java/io/axual/ksml/rest/server/ComponentState.java
+++ b/ksml-query/src/main/java/io/axual/ksml/rest/server/ComponentState.java
@@ -20,10 +20,32 @@ package io.axual.ksml.rest.server;
  * =========================LICENSE_END==================================
  */
 
+/**
+ * Indicates the state a KSML component or subcomponent is in
+ */
 public enum ComponentState {
+    /**
+     * The component is not relevant or used
+     */
+    NOT_APPLICABLE,
+    /**
+     * The component is still starting
+     */
     STARTING,
+    /**
+     * The component is in a started state, can be considered active
+     */
     STARTED,
+    /**
+     * The component is shutting down
+     */
     STOPPING,
+    /**
+     * The component has stopped gracefully
+     */
     STOPPED,
+    /**
+     * The component is in a failed state
+     */
     FAILED
 }

--- a/ksml-query/src/main/java/io/axual/ksml/rest/server/GlobalState.java
+++ b/ksml-query/src/main/java/io/axual/ksml/rest/server/GlobalState.java
@@ -26,16 +26,16 @@ public enum GlobalState {
 
     INSTANCE;
 
-    private StreamsQuerier querier;
+    private KsmlQuerier ksmlQuerier;
     private HostInfo hostInfo;
 
-    public void set(StreamsQuerier querier, HostInfo hostInfo) {
-        this.querier = querier;
+    public synchronized void set(KsmlQuerier ksmlQuerier, HostInfo hostInfo) {
+        this.ksmlQuerier = ksmlQuerier;
         this.hostInfo = hostInfo;
     }
 
-    public StreamsQuerier querier() {
-        return querier;
+    public synchronized KsmlQuerier querier() {
+        return ksmlQuerier;
     }
 
     public HostInfo hostInfo() {

--- a/ksml-query/src/main/java/io/axual/ksml/rest/server/KeyValueStoreResource.java
+++ b/ksml-query/src/main/java/io/axual/ksml/rest/server/KeyValueStoreResource.java
@@ -71,7 +71,7 @@ public class KeyValueStoreResource extends StoreResource {
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     public KeyValueBean getKey(@PathParam("storeName") final String storeName,
                                @PathParam("key") final String key) {
-        KeyQueryMetadata metadataForKey = querier.queryMetadataForKey(storeName, key, new StringSerializer());
+        KeyQueryMetadata metadataForKey = querier().queryMetadataForKey(storeName, key, new StringSerializer());
 
         if (metadataForKey.activeHost().host().equals(thisInstance.host()) && metadataForKey.activeHost().port() == thisInstance.port()) {
             log.info("Querying local store {} for key {}", storeName, key);
@@ -98,7 +98,7 @@ public class KeyValueStoreResource extends StoreResource {
     public KeyValueBean getKeyLocal(@PathParam("storeName") final String storeName,
                                     @PathParam("key") final String key) {
         log.info("Querying local store {} for key {}", storeName, key);
-        var stateStore = querier.store(
+        var stateStore = getStore(
                 StoreQueryParameters.fromNameAndType(storeName, QueryableStoreTypes.keyValueStore()));
         Object value = stateStore.get(key);
         log.info("Found value {}", value);

--- a/ksml-query/src/main/java/io/axual/ksml/rest/server/KsmlQuerier.java
+++ b/ksml-query/src/main/java/io/axual/ksml/rest/server/KsmlQuerier.java
@@ -20,26 +20,21 @@ package io.axual.ksml.rest.server;
  * =========================LICENSE_END==================================
  */
 
-import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.KeyQueryMetadata;
+import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.StreamsMetadata;
 
 import java.util.Collection;
 
-@Slf4j
-public class StoreQuerier {
-    private final StreamsQuerier streamsQuerier;
+public interface KsmlQuerier {
+    Collection<StreamsMetadata> allMetadataForStore(String storeName);
 
-    public StoreQuerier(StreamsQuerier streamsQuerier) {
-        this.streamsQuerier = streamsQuerier;
-    }
+    <K> KeyQueryMetadata queryMetadataForKey(String storeName, K key, Serializer<K> keySerializer);
 
-    public Collection<StreamsMetadata> metadataForStore(String storeName) {
-        return streamsQuerier.allMetadataForStore(storeName);
-    }
+    <T> T store(StoreQueryParameters<T> storeQueryParameters);
 
-    public <K> KeyQueryMetadata metadataForKey(String storeName, K key, Serializer<K> serializer) {
-        return streamsQuerier.queryMetadataForKey(storeName, key, serializer);
-    }
+    ComponentState getStreamRunnerState();
+
+    ComponentState getProducerState();
 }

--- a/ksml-query/src/main/java/io/axual/ksml/rest/server/KsmlQuerier.java
+++ b/ksml-query/src/main/java/io/axual/ksml/rest/server/KsmlQuerier.java
@@ -27,14 +27,51 @@ import org.apache.kafka.streams.StreamsMetadata;
 
 import java.util.Collection;
 
+/**
+ * Class to transfer data from the KSML components to the REST services.
+ */
 public interface KsmlQuerier {
+    /**
+     * Get all the Streams Metadata for a specific store
+     *
+     * @param storeName the name of the store
+     * @return a collection of Streams Metadata
+     */
     Collection<StreamsMetadata> allMetadataForStore(String storeName);
 
+    /**
+     * Get the metadata for a store and a specific key. For example which instance is assigned to the partition for the key
+     *
+     * @param storeName     the name of the store containing the key
+     * @param key           the specific key for which the metadata is needed
+     * @param keySerializer the serializer needed to convert the key to bytes
+     * @param <K>           The type of the key
+     * @return the Metadata for the specified store and key
+     */
     <K> KeyQueryMetadata queryMetadataForKey(String storeName, K key, Serializer<K> keySerializer);
 
+
+    /**
+     * Get a specific store using the provided
+     *
+     * @param storeQueryParameters the parameters to find the correct store
+     * @param <T>                  the type of Store to return
+     * @return the Store found
+     * @throws org.apache.kafka.streams.errors.UnknownStateStoreException if the store does not exist
+     */
     <T> T store(StoreQueryParameters<T> storeQueryParameters);
 
+    /**
+     * Get the {@link ComponentState} for the Kafka Streams component of KSML
+     *
+     * @return the {@link ComponentState} for the Kafka Streams component, and {@link ComponentState#NOT_APPLICABLE} if the component isn't used
+     */
     ComponentState getStreamRunnerState();
 
+    /**
+     * Get the {@link ComponentState} for the Producer component of KSML
+     *
+     * @return the {@link ComponentState} for the Producer component, and {@link ComponentState#NOT_APPLICABLE} if the component isn't used
+     */
     ComponentState getProducerState();
 }

--- a/ksml-query/src/main/java/io/axual/ksml/rest/server/ReadyResource.java
+++ b/ksml-query/src/main/java/io/axual/ksml/rest/server/ReadyResource.java
@@ -1,0 +1,54 @@
+package io.axual.ksml.rest.server;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Queryable State Store
+ * %%
+ * Copyright (C) 2021 - 2024 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Path("ready")
+public class ReadyResource {
+    @GET()
+    public Response getReadyState() {
+        final var querier = GlobalState.INSTANCE.querier();
+        if (querier == null) {
+            // Service has not started yet
+            return Response.serverError().build();
+        }
+
+        final var producerRunning = switch (querier.getProducerState()) {
+            case STARTING, STARTED, STOPPING, STOPPED -> true;
+            default -> false;
+        };
+        final var streamsRunning = switch (querier.getStreamRunnerState()) {
+            case STARTING, STARTED, STOPPING, STOPPED -> true;
+            default -> false;
+        };
+
+        if (streamsRunning && producerRunning) {
+            return Response.noContent().build();
+        } else {
+            return Response.serverError().build();
+        }
+    }
+}

--- a/ksml-query/src/main/java/io/axual/ksml/rest/server/RestServer.java
+++ b/ksml-query/src/main/java/io/axual/ksml/rest/server/RestServer.java
@@ -54,6 +54,7 @@ public class RestServer implements AutoCloseable {
 
         // configure REST service
         ResourceConfig rc = new ResourceConfig();
+        rc.register(ReadyResource.class);
         rc.register(KeyValueStoreResource.class);
         rc.register(WindowedKeyValueStoreResource.class);
         rc.register(RestServerExceptionMapper.class);
@@ -68,14 +69,17 @@ public class RestServer implements AutoCloseable {
         config.addHttpHandler(handler, "/");
     }
 
-    public String start(StreamsQuerier querier) {
+    public String start() {
         try {
-            GlobalState.INSTANCE.set(querier, hostInfo);
             server.start();
             return Utils.getHostIPForDiscovery();
         } catch (IOException e) {
             return null;
         }
+    }
+
+    public void initGlobalQuerier(KsmlQuerier ksmlQuerier) {
+        GlobalState.INSTANCE.set(ksmlQuerier, hostInfo);
     }
 
     @Override

--- a/ksml-query/src/main/java/io/axual/ksml/rest/server/RestServerExceptionMapper.java
+++ b/ksml-query/src/main/java/io/axual/ksml/rest/server/RestServerExceptionMapper.java
@@ -20,6 +20,7 @@ package io.axual.ksml.rest.server;
  * =========================LICENSE_END==================================
  */
 
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
@@ -27,6 +28,10 @@ import jakarta.ws.rs.ext.ExceptionMapper;
 public class RestServerExceptionMapper implements ExceptionMapper<Throwable> {
     @Override
     public Response toResponse(Throwable throwable) {
+        if (throwable instanceof WebApplicationException) {
+            return ((WebApplicationException) throwable).getResponse();
+        }
+
         var message = throwable.getMessage();
         var status = 500;
 

--- a/ksml-query/src/main/java/io/axual/ksml/rest/server/WindowedKeyValueStoreResource.java
+++ b/ksml-query/src/main/java/io/axual/ksml/rest/server/WindowedKeyValueStoreResource.java
@@ -48,7 +48,7 @@ public class WindowedKeyValueStoreResource extends StoreResource {
     public List<WindowedKeyValueBean> getAll(@PathParam("storeName") final String storeName) {
         var result = getAllLocal(storeName);
         log.info("Querying remote stores....");
-        querier.allMetadataForStore(storeName)
+        querier().allMetadataForStore(storeName)
                 .stream()
                 .filter(sm -> !(sm.host().equals(thisInstance.host()) && sm.port() == thisInstance.port())) //only query remote node stores
                 .forEach(remoteInstance -> {
@@ -88,7 +88,7 @@ public class WindowedKeyValueStoreResource extends StoreResource {
     public WindowedKeyValueBean getKey(@PathParam("storeName") final String storeName,
                                        @PathParam("key") final String key,
                                        @PathParam("timestamp") final Long timestamp) {
-        KeyQueryMetadata metadataForKey = querier.queryMetadataForKey(storeName, key, new StringSerializer());
+        KeyQueryMetadata metadataForKey = querier().queryMetadataForKey(storeName, key, new StringSerializer());
 
         if (metadataForKey.activeHost().host().equals(thisInstance.host()) && metadataForKey.activeHost().port() == thisInstance.port()) {
             log.info("Querying local store {} for key {}", storeName, key);
@@ -116,7 +116,7 @@ public class WindowedKeyValueStoreResource extends StoreResource {
                                             @PathParam("key") final String key,
                                             @PathParam("timestamp") final Long timestamp) {
         log.info("Querying local store {} for key {}", storeName, key);
-        var stateStore = querier.store(
+        var stateStore = getStore(
                 StoreQueryParameters.fromNameAndType(storeName, QueryableStoreTypes.windowStore()));
         var iterator = stateStore.fetch(key, key, Instant.ofEpochMilli(timestamp), Instant.ofEpochMilli(timestamp));
         KeyValue<Windowed<Object>, Object> latest = null;

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/KSMLRunner.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/KSMLRunner.java
@@ -23,11 +23,30 @@ package io.axual.ksml.runner;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.KeyQueryMetadata;
+import org.apache.kafka.streams.StoreQueryParameters;
+import org.apache.kafka.streams.StreamsMetadata;
+import org.apache.kafka.streams.state.HostInfo;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import io.axual.ksml.client.serde.ResolvingDeserializer;
 import io.axual.ksml.client.serde.ResolvingSerializer;
 import io.axual.ksml.data.mapper.DataObjectFlattener;
-import io.axual.ksml.data.mapper.DataTypeSchemaMapper;
-import io.axual.ksml.data.mapper.NativeDataObjectMapper;
 import io.axual.ksml.data.notation.NotationLibrary;
 import io.axual.ksml.data.notation.avro.AvroNotation;
 import io.axual.ksml.data.notation.avro.AvroSchemaLoader;
@@ -45,14 +64,15 @@ import io.axual.ksml.data.notation.xml.XmlDataObjectConverter;
 import io.axual.ksml.data.notation.xml.XmlNotation;
 import io.axual.ksml.data.notation.xml.XmlSchemaLoader;
 import io.axual.ksml.data.parser.ParseNode;
-import io.axual.ksml.data.mapper.DataTypeFlattener;
 import io.axual.ksml.data.schema.SchemaLibrary;
 import io.axual.ksml.definition.parser.TopologyDefinitionParser;
 import io.axual.ksml.execution.ErrorHandler;
 import io.axual.ksml.execution.ExecutionContext;
 import io.axual.ksml.execution.FatalError;
 import io.axual.ksml.generator.TopologyDefinition;
+import io.axual.ksml.rest.server.ComponentState;
 import io.axual.ksml.rest.server.RestServer;
+import io.axual.ksml.rest.server.KsmlQuerier;
 import io.axual.ksml.runner.backend.KafkaProducerRunner;
 import io.axual.ksml.runner.backend.KafkaStreamsRunner;
 import io.axual.ksml.runner.backend.Runner;
@@ -61,19 +81,6 @@ import io.axual.ksml.runner.config.KSMLRunnerConfig;
 import io.axual.ksml.runner.exception.ConfigException;
 import io.axual.ksml.runner.prometheus.PrometheusExport;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.utils.Utils;
-import org.apache.kafka.streams.state.HostInfo;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 @Slf4j
 public class KSMLRunner {
@@ -106,6 +113,16 @@ public class KSMLRunner {
             }
 
             KsmlInfo.registerKsmlAppInfo(config.getApplicationId());
+
+            // Start the appserver if needed
+            final var appServer = ksmlConfig.getApplicationServerConfig();
+            RestServer restServer = null;
+            // Start rest server to provide service endpoints
+            if (appServer.isEnabled()) {
+                HostInfo hostInfo = new HostInfo(appServer.getHost(), appServer.getPort());
+                restServer = new RestServer(hostInfo);
+                restServer.start();
+            }
 
             // Set up the notation library with all known notations and type override classes
             final var nativeMapper = new DataObjectFlattener(true);
@@ -182,18 +199,14 @@ public class KSMLRunner {
                     final var executorService = Executors.newFixedThreadPool(2);
                     final var producerFuture = producer == null ? null : executorService.submit(producer);
                     final var streamsFuture = streams == null ? null : executorService.submit(streams);
-                    RestServer restServer = null;
 
                     try {
                         // Allow the runner(s) to start
                         Utils.sleep(2000);
 
-                        final var appServer = ksmlConfig.getApplicationServerConfig();
-                        if (streamsFuture != null && appServer != null && appServer.isEnabled()) {
+                        if (streamsFuture != null && restServer != null) {
                             // Run with the REST server
-                            HostInfo hostInfo = new HostInfo(appServer.getHost(), appServer.getPort());
-                            restServer = new RestServer(hostInfo);
-                            restServer.start(streams.getQuerier());
+                            restServer.initGlobalQuerier(getQuerier(streams, producer));
                         }
 
                         while (producerFuture == null || !producerFuture.isDone() || streamsFuture == null || !streamsFuture.isDone()) {
@@ -241,6 +254,60 @@ public class KSMLRunner {
             log.error("Unhandled exception", t);
             throw FatalError.reportAndExit(t);
         }
+    }
+
+    protected static KsmlQuerier getQuerier(KafkaStreamsRunner streamsRunner, KafkaProducerRunner producerRunner) {
+        return new KsmlQuerier() {
+            @Override
+            public Collection<StreamsMetadata> allMetadataForStore(String storeName) {
+                if (streamsRunner == null) {
+                    return List.of();
+                }
+                return streamsRunner.getKafkaStreams().streamsMetadataForStore(storeName);
+            }
+
+            @Override
+            public <K> KeyQueryMetadata queryMetadataForKey(String storeName, K key, Serializer<K> keySerializer) {
+                if (streamsRunner == null) {
+                    return null;
+                }
+                return streamsRunner.getKafkaStreams().queryMetadataForKey(storeName, key, keySerializer);
+            }
+
+            @Override
+            public <T> T store(StoreQueryParameters<T> storeQueryParameters) {
+                if (streamsRunner == null) {
+                    return null;
+                }
+                return streamsRunner.getKafkaStreams().store(storeQueryParameters);
+            }
+
+            @Override
+            public ComponentState getStreamRunnerState() {
+                if (streamsRunner == null) {
+                    return ComponentState.STARTED;
+                }
+                return stateConverter(streamsRunner.getState());
+            }
+
+            @Override
+            public ComponentState getProducerState() {
+                if (producerRunner == null) {
+                    return ComponentState.STARTED;
+                }
+                return stateConverter(producerRunner.getState());
+            }
+
+            ComponentState stateConverter(Runner.State state) {
+                return switch (state) {
+                    case STARTING -> ComponentState.STARTING;
+                    case STARTED -> ComponentState.STARTED;
+                    case STOPPING -> ComponentState.STOPPING;
+                    case STOPPED -> ComponentState.STOPPED;
+                    case FAILED -> ComponentState.FAILED;
+                };
+            }
+        };
     }
 
     private static String determineTitle() {

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/backend/IntervalSchedule.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/backend/IntervalSchedule.java
@@ -66,6 +66,10 @@ public class IntervalSchedule {
         }
     }
 
+    public boolean hasScheduledItems() {
+        return !scheduledProducers.isEmpty();
+    }
+
     /**
      * Inner data class to keep a scheduled producer and the time it should be returned.
      */

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/backend/KafkaProducerRunner.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/backend/KafkaProducerRunner.java
@@ -77,7 +77,7 @@ public class KafkaProducerRunner implements Runner {
 
         try (final Producer<byte[], byte[]> producer = createProducer(getProducerConfigs())) {
             log.info("Starting Kafka producer(s)");
-            while (!stopRunning.get() && !hasFailed.get()) {
+            while (!stopRunning.get() && !hasFailed.get() && scheduler.hasScheduledItems()) {
                 var scheduledGenerator = scheduler.getScheduledItem();
                 if (scheduledGenerator != null) {
                     scheduledGenerator.producer().produceMessage(producer);

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/backend/KafkaStreamsRunner.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/backend/KafkaStreamsRunner.java
@@ -21,17 +21,12 @@ package io.axual.ksml.runner.backend;
  */
 
 
-import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.KeyQueryMetadata;
-import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.StreamsMetadata;
 import org.apache.kafka.streams.TopologyConfig;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -43,14 +38,15 @@ import io.axual.ksml.client.producer.ResolvingProducerConfig;
 import io.axual.ksml.execution.ExecutionContext;
 import io.axual.ksml.execution.ExecutionErrorHandler;
 import io.axual.ksml.generator.TopologyDefinition;
-import io.axual.ksml.rest.server.StreamsQuerier;
 import io.axual.ksml.runner.config.ApplicationServerConfig;
 import io.axual.ksml.runner.streams.KSMLClientSupplier;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class KafkaStreamsRunner implements Runner {
+    @Getter
     private final KafkaStreams kafkaStreams;
     private final AtomicBoolean stopRunning = new AtomicBoolean(false);
 
@@ -119,25 +115,6 @@ public class KafkaStreamsRunner implements Runner {
             case PENDING_SHUTDOWN -> State.STOPPING;
             case NOT_RUNNING -> State.STOPPED;
             case PENDING_ERROR, ERROR -> State.FAILED;
-        };
-    }
-
-    public StreamsQuerier getQuerier() {
-        return new StreamsQuerier() {
-            @Override
-            public Collection<StreamsMetadata> allMetadataForStore(String storeName) {
-                return kafkaStreams.streamsMetadataForStore(storeName);
-            }
-
-            @Override
-            public <K> KeyQueryMetadata queryMetadataForKey(String storeName, K key, Serializer<K> keySerializer) {
-                return kafkaStreams.queryMetadataForKey(storeName, key, keySerializer);
-            }
-
-            @Override
-            public <T> T store(StoreQueryParameters<T> storeQueryParameters) {
-                return kafkaStreams.store(storeQueryParameters);
-            }
         };
     }
 

--- a/packaging/helm-charts/ksml/templates/statefulset.yaml
+++ b/packaging/helm-charts/ksml/templates/statefulset.yaml
@@ -45,6 +45,18 @@ spec:
             - name: metrics
               containerPort: {{ .Values.prometheus.port }}
               protocol: TCP
+          {{- if .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          {{- end }}
           env:
             - name: "KSML_K8S_POD_NAME"
               valueFrom:

--- a/packaging/helm-charts/ksml/values.schema.json
+++ b/packaging/helm-charts/ksml/values.schema.json
@@ -190,6 +190,15 @@
         "nameOverride": {
             "type": "string"
         },
+        "startupProbe": {
+            "type": "object"
+        },
+        "readinessProbe": {
+            "type": "object"
+        },
+        "livenessProbe": {
+            "type": "object"
+        },
         "nodeSelector": {
             "type": "object"
         },

--- a/packaging/helm-charts/ksml/values.yaml
+++ b/packaging/helm-charts/ksml/values.yaml
@@ -82,6 +82,30 @@ schemaDefinitions: {}
   # my-schema.avsc: |
   #   ...
 
+# The startup probe for the KSML containers
+startupProbe:
+  httpGet:
+    path: /ready
+    port: http
+  failureThreshold: 30
+  periodSeconds: 2
+
+# The readiness probe for the KSML containers
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: http
+  failureThreshold: 2
+  periodSeconds: 5
+
+# The readiness probe for the KSML containers
+livenessProbe:
+  httpGet:
+    path: /ready
+    port: http
+  failureThreshold: 2
+  periodSeconds: 5
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/packaging/helm-charts/ksml/values.yaml
+++ b/packaging/helm-charts/ksml/values.yaml
@@ -87,24 +87,53 @@ startupProbe:
   httpGet:
     path: /ready
     port: http
+  # -- Minimum consecutive failures for the probe to be considered failed.
+  # A failed startupProbe will mark the container as unhealthy and triggers a restart for that specific container.
   failureThreshold: 30
-  periodSeconds: 2
+  # -- Number of seconds after the container has started before startyp probes are initiated.
+  initialDelaySeconds: 2
+  # -- How often (in seconds) to perform the probe.
+  periodSeconds: 1
+  # -- Minimum consecutive successes for the probe to be considered successful after having failed.
+  successThreshold: 1
+  # -- Number of seconds after which the probe times out.
+  timeoutSeconds: 1
 
 # The readiness probe for the KSML containers
 readinessProbe:
+  # The service definition to call to determine readiness.
   httpGet:
     path: /ready
     port: http
-  failureThreshold: 2
-  periodSeconds: 5
+  # -- Minimum consecutive failures for the probe to be considered failed after having succeeded.
+  # A failed readinessProbe will cause the container to move to the `NotReady` state.
+  failureThreshold: 4
+  # -- Number of seconds after the container has started before readiness probes are initiated.
+  initialDelaySeconds: 20
+  # -- How often (in seconds) to perform the probe.
+  periodSeconds: 10
+  # -- Minimum consecutive successes for the probe to be considered successful after having failed.
+  successThreshold: 1
+  # -- Number of seconds after which the probe times out.
+  timeoutSeconds: 1
 
 # The readiness probe for the KSML containers
 livenessProbe:
+  # The service definition to call to determine liveness.
   httpGet:
     path: /ready
     port: http
-  failureThreshold: 2
-  periodSeconds: 5
+  # -- Minimum consecutive failures for the probe to be considered failed after having succeeded.
+  # A failed livenessProbe will cause the container to be restarted.
+  failureThreshold: 4
+  # -- Number of seconds after the container has started before liveness probes are initiated.
+  initialDelaySeconds: 30
+  # -- How often (in seconds) to perform the probe.
+  periodSeconds: 10
+  # -- Minimum consecutive successes for the probe to be considered successful after having failed.
+  successThreshold: 1
+  # -- Number of seconds after which the probe times out.
+  timeoutSeconds: 1
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
A Readiness service has been added to the KSML service, reachable on path `/ready`
The helm charts have been updated with default readiness, liveness and startup probes.

The KSML Runner has been updated to start the RestServer as soon as possible to provide the services.
The existing services has been updated to provide Service Unavailable (503) statuses during startup.
Queries to a non existent state store will result in a Not Found (404) status.

The RestServer now handles WebApplicationExceptions explicitly, returning the corresponding status codes

The StreamsQuerier interface has been renamed KsmlQuerier since it also supplies other information.

Removed the StoreQuerier class, as it was not used by any component.