### PR TITLE
Separate liveness, readiness and startup services

### DIFF
--- a/ksml-query/src/main/java/io/axual/ksml/rest/server/ComponentState.java
+++ b/ksml-query/src/main/java/io/axual/ksml/rest/server/ComponentState.java
@@ -29,6 +29,10 @@ public enum ComponentState {
      */
     NOT_APPLICABLE,
     /**
+     * The component is created, but did not went into start yet
+     */
+    CREATED,
+    /**
      * The component is still starting
      */
     STARTING,
@@ -47,5 +51,5 @@ public enum ComponentState {
     /**
      * The component is in a failed state
      */
-    FAILED
+    FAILED;
 }

--- a/ksml-query/src/main/java/io/axual/ksml/rest/server/RestServer.java
+++ b/ksml-query/src/main/java/io/axual/ksml/rest/server/RestServer.java
@@ -54,6 +54,8 @@ public class RestServer implements AutoCloseable {
 
         // configure REST service
         ResourceConfig rc = new ResourceConfig();
+        rc.register(StartupResource.class);
+        rc.register(LivenessResource.class);
         rc.register(ReadyResource.class);
         rc.register(KeyValueStoreResource.class);
         rc.register(WindowedKeyValueStoreResource.class);

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/KSMLRunner.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/KSMLRunner.java
@@ -304,6 +304,7 @@ public class KSMLRunner {
 
             ComponentState stateConverter(Runner.State state) {
                 return switch (state) {
+                    case CREATED -> ComponentState.CREATED;
                     case STARTING -> ComponentState.STARTING;
                     case STARTED -> ComponentState.STARTED;
                     case STOPPING -> ComponentState.STOPPING;

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/backend/Runner.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/backend/Runner.java
@@ -21,13 +21,29 @@ package io.axual.ksml.runner.backend;
  */
 
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 public interface Runner extends Runnable {
     enum State {
-        STARTING,
-        STARTED,
-        STOPPING,
-        STOPPED,
-        FAILED
+        CREATED(1, 2, 5), // Ordinal 0
+        STARTING(2, 3, 4, 5), // Ordinal 1
+        STARTED(1, 3, 4, 5), // Ordinal 2
+        STOPPING(4, 5), // Ordinal 3
+        STOPPED, // Ordinal 4
+        FAILED // Ordinal 5
+        ;
+
+        State(final Integer... validNextStates) {
+            this.validNextStates.addAll(Arrays.asList(validNextStates));
+        }
+
+        private final Set<Integer> validNextStates = new HashSet<>();
+
+        public boolean isValidNextState(State nextState) {
+            return validNextStates.contains(nextState.ordinal());
+        }
     }
 
     State getState();

--- a/packaging/helm-charts/ksml/values.yaml
+++ b/packaging/helm-charts/ksml/values.yaml
@@ -85,7 +85,7 @@ schemaDefinitions: {}
 # The startup probe for the KSML containers
 startupProbe:
   httpGet:
-    path: /ready
+    path: /startup
     port: http
   # -- Minimum consecutive failures for the probe to be considered failed.
   # A failed startupProbe will mark the container as unhealthy and triggers a restart for that specific container.
@@ -121,7 +121,7 @@ readinessProbe:
 livenessProbe:
   # The service definition to call to determine liveness.
   httpGet:
-    path: /ready
+    path: /live
     port: http
   # -- Minimum consecutive failures for the probe to be considered failed after having succeeded.
   # A failed livenessProbe will cause the container to be restarted.


### PR DESCRIPTION
After testing with the ready service for liveness, readiness and startup it became clear that all have different definitions in KSML.

Added the CREATED state to the ComponentState enum.

ProducerRunner now uses states CREATED->STARTING->STARTED->STOPPING->STOPPED or FAILED in case of failures
StreamsRunner now maps the internal Streams state 
- KafkaStreams.State CREATED -> ComponentState.CREATED;
- KafkaStreams.State REBALANCING -> ComponentState.STARTING;
- KafkaStreams.State RUNNING -> ComponentState.STARTED;
- KafkaStreams.State PENDING_SHUTDOWN -> ComponentState.STOPPING;
- KafkaStreams.State NOT_RUNNING -> ComponentState.STOPPED;
- KafkaStreams.State PENDING_ERROR, ERROR -> ComponentState.FAILED;

Startup service
- Returns HTTP Status 500 if both ProducerRunner AND StreamsRunner are in state NOT_APPLICABLE (misconfiguration)
- Returns HTTP Status 204 if ProducerRunner AND StreamsRunner is in state NOT_APPLICABLE, STARTING, STARTED, STOPPING, STOPPED
- Returns HTTP Status 500 in other scenarios

Readiness service
- Returns HTTP Status 500 if both ProducerRunner AND StreamsRunner are in state NOT_APPLICABLE (misconfiguration)
- Returns HTTP Status 204 if ProducerRunner is in state NOT_APPLICABLE, STARTED, STOPPING, STOPPED and StreamsRunner is in state NOT_APPLICABLE or STARTED (allows for one to be disabled and the other started, or the ProducerRunner to gracefully stop)
- Returns HTTP Status 500 in other scenarios

Liveness service
- Returns HTTP Status 500 if both ProducerRunner AND StreamsRunner are in state NOT_APPLICABLE (misconfiguration)
- Returns HTTP Status 500 if ProducerRunner is in state FAILED OR StreamsRunner is in state FAILED or STOPPED
- Returns HTTP Status 204 in other scenarios