### PR TITLE
Fix logic issue with Prometheus Export and ServiceMonitor

### DIFF
--- a/packaging/helm-charts/ksml/.helmignore
+++ b/packaging/helm-charts/ksml/.helmignore
@@ -25,3 +25,4 @@
 *.tgz
 *.tbz
 
+workspace/

--- a/packaging/helm-charts/ksml/README.md
+++ b/packaging/helm-charts/ksml/README.md
@@ -266,7 +266,6 @@ resources:
 ksmlRunnerConfig:
   definitions:
     generate: generator.yaml
-#    inspect: peek.yaml
   kafka:
     application.id: example.datagen
 

--- a/packaging/helm-charts/ksml/README.md
+++ b/packaging/helm-charts/ksml/README.md
@@ -153,8 +153,7 @@ resources:
 
 ksmlRunnerConfig:
   definitions:
-#    generate: generator.yaml
-    inspect: peek.yaml
+    generate: generator.yaml
   kafka:
     application.id: example.datagen
 
@@ -266,8 +265,8 @@ resources:
 
 ksmlRunnerConfig:
   definitions:
-#    generate: generator.yaml
-    inspect: peek.yaml
+    generate: generator.yaml
+#    inspect: peek.yaml
   kafka:
     application.id: example.datagen
 

--- a/packaging/helm-charts/ksml/templates/NOTES.txt
+++ b/packaging/helm-charts/ksml/templates/NOTES.txt
@@ -1,1 +1,5 @@
 Thank you for installing {{ .Chart.Name }}-{{ .Chart.Version }}
+{{ if and .Values.serviceMonitor.enabled (not .Values.prometheus.enabled) }}
+The service monitor has been disabled because Prometheus is not enabled.
+Use prometheus.enabled: true to enable the service monitor
+{{- end }}

--- a/packaging/helm-charts/ksml/templates/service.yaml
+++ b/packaging/helm-charts/ksml/templates/service.yaml
@@ -11,9 +11,11 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if .Values.prometheus.enabled }}
     - port: {{ .Values.prometheus.port }}
       targetPort: metrics
       protocol: TCP
       name: metrics
+    {{- end }}
   selector:
     {{- include "ksml.selectorLabels" . | nindent 4 }}

--- a/packaging/helm-charts/ksml/templates/servicemonitor.yaml
+++ b/packaging/helm-charts/ksml/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.serviceMonitor.enabled }}
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" )  .Values.prometheus.enabled .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/packaging/helm-charts/ksml/templates/statefulset.yaml
+++ b/packaging/helm-charts/ksml/templates/statefulset.yaml
@@ -42,9 +42,11 @@ spec:
             - name: http
               containerPort: {{ .Values.applicationServer.port }}
               protocol: TCP
+            {{- if .Values.prometheus.enabled }}
             - name: metrics
               containerPort: {{ .Values.prometheus.port }}
               protocol: TCP
+            {{- end }}
           {{- if .Values.startupProbe }}
           startupProbe:
             {{- toYaml .Values.startupProbe | nindent 12 }}

--- a/packaging/helm-charts/ksml/values.yaml
+++ b/packaging/helm-charts/ksml/values.yaml
@@ -313,8 +313,8 @@ prometheus:
 
 serviceMonitor:
   # -- Enables creation of Prometheus Operator [ServiceMonitor](https://prometheus-operator.dev/docs/operator/api/#monitoring.coreos.com/v1.ServiceMonitor).
-  # Ignored if API `monitoring.coreos.com/v1` is not available.
-  enabled: true
+  # Ignored if API `monitoring.coreos.com/v1` is not available or if prometheus is disabled.
+  enabled: false
   # -- Interval at which metrics should be scraped.
   interval: 30s
   # -- Timeout after which the scrape is ended.


### PR DESCRIPTION
This PR contains several changes to make sure ServiceMonitor and Prometheus export settings match:

- Update KSML ServiceMonitor to be disabled if Prometheus export is not configured.
- Added a warning in the nodes if ServiceMonitor is enabled, but Prometheus is not. 
- Statefulset and service will only define metrics port if Prometheus is enabled
- Update example in Helm Readme, it used the wrong filename in the definition