### PR TITLE
Fix excessive CPU Usage

### DIFF
--- a/ksml-runner/src/main/java/io/axual/ksml/runner/backend/KafkaProducerRunner.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/backend/KafkaProducerRunner.java
@@ -33,6 +33,7 @@ import io.axual.ksml.client.producer.ResolvingProducer;
 import io.axual.ksml.generator.TopologyDefinition;
 import io.axual.ksml.python.PythonContext;
 import io.axual.ksml.python.PythonFunction;
+import io.axual.ksml.runner.exception.RunnerException;
 import lombok.Builder;
 
 import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
@@ -84,8 +85,8 @@ public class KafkaProducerRunner implements Runner {
                 });
             });
         } catch (Exception e) {
-            log.error("Error while registering functions and producers", e);
-            hasFailed.set(true);
+            setState(State.FAILED);
+            throw new RunnerException("Error while registering functions and producers", e);
         }
 
         try (final Producer<byte[], byte[]> producer = createProducer(getProducerConfigs())) {
@@ -103,8 +104,7 @@ public class KafkaProducerRunner implements Runner {
             }
         } catch (Throwable e) {
             setState(State.FAILED);
-            hasFailed.set(true);
-            log.error("Unhandled producer exception", e);
+            throw new RunnerException("Unhandled producer exception", e);
         }
         setState(State.STOPPED);
         isRunning.set(false);

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/backend/KafkaStreamsRunner.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/backend/KafkaStreamsRunner.java
@@ -39,6 +39,7 @@ import io.axual.ksml.execution.ExecutionContext;
 import io.axual.ksml.execution.ExecutionErrorHandler;
 import io.axual.ksml.generator.TopologyDefinition;
 import io.axual.ksml.runner.config.ApplicationServerConfig;
+import io.axual.ksml.runner.exception.RunnerException;
 import io.axual.ksml.runner.streams.KSMLClientSupplier;
 import lombok.Builder;
 import lombok.Getter;
@@ -142,6 +143,9 @@ public class KafkaStreamsRunner implements Runner {
             } else {
                 log.info("Kafka Streams has stopped");
             }
+        }
+        if (getState() == State.FAILED) {
+            throw new RunnerException("Kafka Streams is in a failed state");
         }
     }
 

--- a/ksml/src/main/java/io/axual/ksml/execution/FatalError.java
+++ b/ksml/src/main/java/io/axual/ksml/execution/FatalError.java
@@ -20,43 +20,37 @@ package io.axual.ksml.execution;
  * =========================LICENSE_END==================================
  */
 
-import io.axual.ksml.exception.TopologyException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class FatalError {
+
+    public static final String NEW_LINE = System.lineSeparator();
+    public static final String LOG_ITEM_SEPARATOR = "==========="+NEW_LINE;
+
     private FatalError() {
     }
 
-    public static Throwable topologyError(String message) {
-        return reportAndExit(new TopologyException(message));
-    }
-
     public static RuntimeException reportAndExit(Throwable t) {
-        log.error("\n\n");
-        log.error("Fatal error");
-        printLineSeparator();
-        printExceptionDetails(t);
+        var messageBuilder = new StringBuilder().append(NEW_LINE);
+        messageBuilder.append("FatalError").append(NEW_LINE).append(LOG_ITEM_SEPARATOR);
+        printExceptionDetails(messageBuilder, t);
+        log.error(messageBuilder.toString());
         System.exit(1);
-        // Dummy return to resolve compiler errors
         return new RuntimeException(t.getMessage());
     }
 
-    private static void printExceptionDetails(Throwable t) {
+    private static void printExceptionDetails(StringBuilder messageBuilder, Throwable t) {
         if (t.getCause() != null) {
-            printExceptionDetails(t.getCause());
-            printLineSeparator();
-            log.error("Above error caused: {}", t.getMessage());
+            printExceptionDetails(messageBuilder, t.getCause());
+            messageBuilder.append(LOG_ITEM_SEPARATOR).append(NEW_LINE);
+            messageBuilder.append("Above error caused: ").append(t.getMessage()).append(NEW_LINE);
         } else {
-            log.error("Description: {}", t.getMessage());
+            messageBuilder.append("Description: ").append(t.getMessage()).append(NEW_LINE);
         }
-        log.error("Stack trace:");
+        messageBuilder.append("Stack trace: ").append(NEW_LINE);
         for (var ste : t.getStackTrace()) {
-            log.error("  {}::{} @ {}:{}", ste.getClassName(), ste.getMethodName(), ste.getFileName(), ste.getLineNumber());
+            messageBuilder.append("  %s::%s @ %s:%s".formatted(ste.getClassName(), ste.getMethodName(), ste.getFileName(), ste.getLineNumber())).append(NEW_LINE);
         }
-    }
-
-    private static void printLineSeparator() {
-        log.error("===========");
     }
 }


### PR DESCRIPTION
Excessive CPU usage was reported. Traced to the Runner implementations, which used a busy wait loop.

Update runners to throw exceptions and use CompletableFutures which can be joined and waited for.

Updated FatalError to use a StringBuilder to build a single error message instead of multiple log statements