### PR TITLE
Fix several storage issues and allow storageDIrectory creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ ENV JAVA_HOME=/opt/graalvm
 COPY --chown=ksml:0 --from=graal-builder /opt/graal/ /opt/graal/
 
 WORKDIR /home/ksml
-USER 1024:0
+USER 1024
 #There is no more GraalPy command here and no venv
 #RUN graalpy -m venv graalenv && \
 #    echo "source $HOME/graalenv/bin/activate" >> ~/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,7 @@ ENV PATH=/opt/graal/bin:$PATH \
 RUN set -eux \
     	&& microdnf upgrade -y --nodocs \
         && microdnf install -y --nodocs procps tar unzip gzip zlib openssl-devel gcc gcc-c++ make patch glibc-langpack-en libxcrypt shadow-utils \
-	&& groupadd --gid 1024 ksml \
-        && useradd -g ksml -u 1024 -d "$KSML_HOME" -ms /bin/sh -f -1 ksml \
+        && useradd -g 0 -u 1024 -d "$KSML_HOME" -ms /bin/sh -f -1 ksml \
         && chown -R ksml:0 "$KSML_HOME" /opt                               \
         && chmod -R g=u /home /opt
 
@@ -73,7 +72,7 @@ ENV JAVA_HOME=/opt/graalvm
 COPY --chown=ksml:0 --from=graal-builder /opt/graal/ /opt/graal/
 
 WORKDIR /home/ksml
-USER 1024
+USER 1024:0
 #There is no more GraalPy command here and no venv
 #RUN graalpy -m venv graalenv && \
 #    echo "source $HOME/graalenv/bin/activate" >> ~/.bashrc

--- a/examples/ksml-runner.yaml
+++ b/examples/ksml-runner.yaml
@@ -3,6 +3,7 @@ ksml:
   configDirectory: .              # When not set defaults to the working directory
   schemaDirectory: .              # When not set defaults to the config directory
   storageDirectory: /tmp          # When not set defaults to the default JVM temp directory
+  createStorageDirectory: false   # When set to true, the storage directory will be created if it does not exist
 
   # This section defines if a REST endpoint is opened on the KSML runner, through which
   # state stores and/or readiness / liveness probes can be accessed.

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/config/KSMLConfig.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/config/KSMLConfig.java
@@ -21,10 +21,18 @@ package io.axual.ksml.runner.config;
  */
 
 
+import com.google.common.collect.ImmutableMap;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.collect.ImmutableMap;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
 import io.axual.ksml.data.notation.binary.JsonNodeNativeMapper;
 import io.axual.ksml.generator.YAMLObjectMapper;
 import io.axual.ksml.runner.exception.ConfigException;
@@ -32,12 +40,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.jackson.Jacksonized;
 import lombok.extern.slf4j.Slf4j;
-
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.Map;
 
 @Slf4j
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -78,9 +80,25 @@ public class KSMLConfig {
     private Map<String, Object> schemas;
 
     private String getDirectory(String configVariable, String directory) {
+        return getDirectory(configVariable, directory, false);
+    }
+
+    private String getDirectory(String configVariable, String directory, boolean createIfNotExist) {
         final var configPath = Paths.get(directory);
-        if (Files.notExists(configPath) || !Files.isDirectory(configPath)) {
-            throw new ConfigException(configVariable, directory, "The provided path does not exist or is not a directory");
+        if (Files.notExists(configPath)) {
+            if (createIfNotExist) {
+                log.info("Directory {} does not exists, creating ", configPath);
+                try {
+                    Files.createDirectories(configPath);
+                } catch (IOException e) {
+                    throw new ConfigException(configVariable, directory, "Could not create the directory", e);
+                }
+            } else {
+                throw new ConfigException(configVariable, directory, "The provided path does not exist");
+            }
+        }
+        if (!Files.isDirectory(configPath)) {
+            throw new ConfigException(configVariable, directory, "The provided path is not a directory");
         }
         return configPath.toAbsolutePath().normalize().toString();
     }
@@ -94,7 +112,7 @@ public class KSMLConfig {
     }
 
     public String storageDirectory() {
-        return getDirectory("storageDirectory", storageDirectory != null ? storageDirectory : System.getProperty("java.io.tmpdir"));
+        return getDirectory("storageDirectory", storageDirectory != null ? storageDirectory : System.getProperty("java.io.tmpdir"), true);
     }
 
     public ApplicationServerConfig applicationServerConfig() {

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/config/KSMLConfig.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/config/KSMLConfig.java
@@ -60,9 +60,14 @@ public class KSMLConfig {
     @Builder.Default
     @Getter
     private PrometheusConfig prometheusConfig = DEFAULT_PROMETHEUS_CONFIG;
+
     private String configDirectory;
     private String schemaDirectory;
     private String storageDirectory;
+
+    @Builder.Default
+    private boolean createStorageDirectory = false;
+
     @Getter
     @Builder.Default
     private boolean enableProducers = true;
@@ -112,7 +117,7 @@ public class KSMLConfig {
     }
 
     public String storageDirectory() {
-        return getDirectory("storageDirectory", storageDirectory != null ? storageDirectory : System.getProperty("java.io.tmpdir"), true);
+        return getDirectory("storageDirectory", storageDirectory != null ? storageDirectory : System.getProperty("java.io.tmpdir"), createStorageDirectory);
     }
 
     public ApplicationServerConfig applicationServerConfig() {

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/exception/ConfigException.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/exception/ConfigException.java
@@ -28,6 +28,9 @@ public class ConfigException extends RunnerException {
     public ConfigException(String message) {
         super(message);
     }
+    public ConfigException(String message, Throwable cause) {
+        super(message, cause);
+    }
 
     public ConfigException(String configKey, Object configValue) {
         this(configKey, configValue, DEFAULT_MESSAGE);
@@ -35,5 +38,8 @@ public class ConfigException extends RunnerException {
 
     public ConfigException(String configKey, Object configValue, String message) {
         this(message + String.format(MESSAGE_DETAIL_FORMAT, configKey, configValue != null ? configValue : "null"));
+    }
+    public ConfigException(String configKey, Object configValue, String message, Throwable cause) {
+        this(message + String.format(MESSAGE_DETAIL_FORMAT, configKey, configValue != null ? configValue : "null"), cause);
     }
 }

--- a/packaging/helm-charts/ksml/templates/configmap-runner.yaml
+++ b/packaging/helm-charts/ksml/templates/configmap-runner.yaml
@@ -9,7 +9,8 @@ data:
     ksml:
       configDirectory: {{ .Values.ksmlRunnerConfig.definitionDirectory | quote }}
       schemaDirectory: {{ .Values.ksmlRunnerConfig.schemaDirectory | quote }}
-      storageDirectory: "/ksml-store"
+      storageDirectory: {{ .Values.ksmlRunnerConfig.storageDirectory | quote }}
+      createStorageDirectory: {{ .Values.ksmlRunnerConfig.createStorageDirectory  }}
       enableProducers: {{ .Values.ksmlRunnerConfig.producersEnabled }}
       enablePipelines: {{ .Values.ksmlRunnerConfig.pipelinesEnabled }}
       errorHandling:

--- a/packaging/helm-charts/ksml/templates/statefulset.yaml
+++ b/packaging/helm-charts/ksml/templates/statefulset.yaml
@@ -87,6 +87,11 @@ spec:
         - name: ksml-logging
           configMap:
             name: {{ include "ksml.fullname" . }}-logging
+        {{- if not .Values.store.spec }}
+        - name: ksml-store
+          emptyDir:
+            sizeLimit: 10Mi
+        {{- end }}
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -111,8 +116,14 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- end }}
+
+  {{- if .Values.store.spec }}
   volumeClaimTemplates:
     - metadata:
         name: ksml-store
       spec:
         {{- toYaml .Values.store.spec | nindent 8 }}
+  {{- end }}
+  {{- with .Values.volumeClaimTemplates }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/packaging/helm-charts/ksml/values.schema.json
+++ b/packaging/helm-charts/ksml/values.schema.json
@@ -93,6 +93,12 @@
                 "schemaDirectory": {
                     "type": "string"
                 },
+                "storageDirectory": {
+                    "type": "string"
+                },
+                "createStorageDirectory": {
+                    "type": "boolean"
+                },
                 "producersEnabled": {
                     "type": "boolean"
                 },
@@ -146,6 +152,7 @@
             "required": [
                 "definitionDirectory",
                 "schemaDirectory",
+                "storageDirectory",
                 "definitions",
                 "kafka"
             ]
@@ -296,6 +303,9 @@
             "type": "array"
         },
         "volumeMounts": {
+            "type": "array"
+        },
+        "volumeClaimTemplates": {
             "type": "array"
         },
         "volumes": {

--- a/packaging/helm-charts/ksml/values.yaml
+++ b/packaging/helm-charts/ksml/values.yaml
@@ -25,6 +25,11 @@ ksmlRunnerConfig:
   definitionDirectory: '/ksml'
   # -- Directory containing the Schema files. This should only be changed if an external volume mount is used.
   schemaDirectory: '/ksml'
+  # -- Directory containing the stateful data . This should only be changed if an external volume mount is used.
+  storageDirectory: '/ksml-store/data'
+  # -- Create the storageDirectory if it does not exist
+  createStorageDirectory: true
+
 
   # -- KSML Error handling settings. Error Handling can be defined for consume, produce and processing errors.
   errorHandling:
@@ -217,6 +222,10 @@ volumeMounts: []
 #   mountPath: "/etc/foo"
 #   readOnly: true
 
+# Additional volumeClaimTemplates for the stateful
+volumeClaimTemplates: []
+
+
 # -- Selector which must match a node's labels for the pod to be scheduled on that node.
 nodeSelector: {}
 
@@ -262,11 +271,12 @@ logging:
 
 # -- Configure the storage specification for the volumeClaimTemplates
 store:
-  spec:
-    accessModes: [ "ReadWriteOnce" ]
-    resources:
-      requests:
-        storage: 1Gi
+  # -- Specifications of the volymeClaimTemplate
+  spec: {}
+#    accessModes: [ "ReadWriteOnce" ]
+#    resources:
+#      requests:
+#        storage: 1Gi
 
 # -- KSML prometheus server port defined in the statefulset. Note that this must match the port defined in ksmlRunnerConfig.
 prometheus:


### PR DESCRIPTION
There were several issues related to the state storage.
The first was that the Kubernetes mounted volume did not match the ownership as the default user in the KSML image.
This was fixed by creating the KSML user with primary group 0 (root)

There is also a change that will allow KSML to create the storage directory if it does not exist.
A new  config parameter has been added to enable creation of the storage directory