### PR TITLE
Implement Kafka Streams metrics reporter with KSML tag enrichment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN set -eux \
 
 # Step 3: Download and install on top of the Graal image from Step 2. Package KSML project
 FROM --platform=$BUILDPLATFORM graal AS maven
-ARG MAVEN_VERSION=3.9.6
+ARG MAVEN_VERSION=3.9.10
 ARG TARGETARCH
 ARG BUILDARCH
 RUN set -eux \

--- a/ksml/src/main/java/io/axual/ksml/metric/KsmlMetricsReporter.java
+++ b/ksml/src/main/java/io/axual/ksml/metric/KsmlMetricsReporter.java
@@ -1,0 +1,193 @@
+package io.axual.ksml.metric;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML
+ * %%
+ * Copyright (C) 2021 - 2025 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.MetricsReporter;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.DoubleSupplier;
+
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * A Kafka MetricsReporter implementation that converts selected Kafka Streams metrics
+ * into KSML-compliant metrics using an injected {@link KsmlTagEnricher}.
+ */
+@NoArgsConstructor // Required by Kafka for reflective instantiation
+@Slf4j
+public final class KsmlMetricsReporter implements MetricsReporter {
+
+    // Kafka configuration key used to inject a KsmlTagEnricher instance into this reporter
+    public static final String ENRICHER_INSTANCE_CONFIG = "ksml.tag.enricher";
+
+    // Package-private for testing
+    MetricsRegistry registry;
+
+    private KsmlTagEnricher enricher;
+    private final Map<org.apache.kafka.common.MetricName, MetricName> registered = new ConcurrentHashMap<>();
+
+    public KsmlMetricsReporter(KsmlTagEnricher enricher) {
+        this.enricher = Objects.requireNonNull(enricher, "enricher");
+        this.registry = createRegistry();
+    }
+
+    // Package-private for testing
+    void setRegistry(MetricsRegistry registry) {
+        this.registry = registry;
+    }
+
+    // Package-private to allow override in tests
+    MetricsRegistry createRegistry() {
+        return Metrics.registry();
+    }
+
+    @Override
+    public void init(List<KafkaMetric> metrics) {
+        metrics.forEach(this::metricChange);
+    }
+
+    /**
+     * Called during reporter initialization to configure the instance.
+     * Expects the configuration map to include a reference to a {@link KsmlTagEnricher}
+     * under the 'ksml.tag.enricher' key. This enricher will be used to map Kafka metrics
+     * to KSML-enriched metrics.
+     *
+     * @param configs Configuration map passed by Kafka
+     * @throws IllegalArgumentException if the required enricher is missing or of the wrong type
+     */
+    @Override
+    public void configure(@NotNull Map<String, ?> configs) {
+        Object enricherObj = configs.get(ENRICHER_INSTANCE_CONFIG);
+        if (enricherObj == null) {
+            throw new IllegalArgumentException(
+                    "Config '%s' is required but was not found".formatted(ENRICHER_INSTANCE_CONFIG));
+        }
+        if (enricherObj instanceof KsmlTagEnricher e) {
+            this.enricher = e;
+        } else {
+            throw new IllegalArgumentException(
+                    "Config '%s' must hold a KsmlTagEnricher instance".formatted(ENRICHER_INSTANCE_CONFIG));
+        }
+
+        // Initialize registry if not set (for no-arg constructor case)
+        if (this.registry == null) {
+            this.registry = createRegistry();
+        }
+    }
+
+    /**
+     * Called when a new metric is added or an existing one is updated.
+     * If the metric is relevant, it's enriched and registered in the KSML registry.
+     */
+    @Override
+    public void metricChange(KafkaMetric kafkaMetric) {
+        if (kafkaMetric == null) {
+            log.warn("Received null kafka metric, ignoring");
+            return;
+        }
+
+        if (enricher == null) {
+            log.warn("Tag enricher not initialized, ignoring metric: {}", kafkaMetric.metricName());
+            return;
+        }
+
+        if (!enricher.isInteresting(kafkaMetric)) {
+            return;
+        }
+
+        MetricName ksmlName = enricher.toKsmlMetricName(kafkaMetric.metricName());
+        if (ksmlName == null) {
+            log.debug("Dropping metric due to missing enrichment: {}", kafkaMetric.metricName());
+            return;
+        }
+
+        try {
+            registered.compute(kafkaMetric.metricName(), (ignored, oldName) -> {
+                try {
+                    if (oldName != null) {
+                        registry.remove(oldName);
+                    }
+                    registry.registerGauge(ksmlName, createGauge(kafkaMetric));
+                    return ksmlName;
+                } catch (Exception e) {
+                    log.warn("Failed to register gauge for metric {}", ksmlName, e);
+                    return oldName; // Keep the old registration if new one fails
+                }
+            });
+        } catch (Exception ex) {
+            log.warn("Could not register metric {} due to compute operation failure", ksmlName, ex);
+        }
+    }
+
+    /**
+     * Wraps the Kafka metric value in a DoubleSupplier-compatible gauge.
+     * Package-private to allow testing.
+     *
+     * @param m Kafka metric to wrap
+     * @return a DoubleSupplier reading the metric value
+     */
+    DoubleSupplier createGauge(KafkaMetric m) {
+        return () -> {
+            try {
+                Object v = m.metricValue();
+                if (v == null) {
+                    return Double.NaN;
+                }
+                return (v instanceof Number n) ? n.doubleValue() : Double.NaN;
+            } catch (Exception e) {
+                log.debug("Failed to read metric value for {}: {}", m.metricName(), e.getMessage());
+                return Double.NaN;
+            }
+        };
+    }
+
+    /**
+     * Removes a previously registered KSML metric if it was enriched.
+     */
+    @Override
+    public void metricRemoval(KafkaMetric kafkaMetric) {
+        Optional.ofNullable(registered.remove(kafkaMetric.metricName()))
+                .ifPresent(registry::remove);
+    }
+
+    /**
+     * Closes the reporter by deregistering enriched KSML metrics.
+     */
+    @Override
+    public void close() {
+        List<MetricName> toRemove = new ArrayList<>(registered.values());
+        registered.clear();
+        toRemove.forEach(registry::remove);
+    }
+
+    // Package-private for testing
+    Map<org.apache.kafka.common.MetricName, MetricName> getRegisteredMetrics() {
+        return new ConcurrentHashMap<>(registered);
+    }
+}

--- a/ksml/src/main/java/io/axual/ksml/metric/KsmlMetricsReporter.java
+++ b/ksml/src/main/java/io/axual/ksml/metric/KsmlMetricsReporter.java
@@ -156,9 +156,6 @@ public final class KsmlMetricsReporter implements MetricsReporter {
         return () -> {
             try {
                 Object v = m.metricValue();
-                if (v == null) {
-                    return Double.NaN;
-                }
                 return (v instanceof Number n) ? n.doubleValue() : Double.NaN;
             } catch (Exception e) {
                 log.debug("Failed to read metric value for {}: {}", m.metricName(), e.getMessage());

--- a/ksml/src/main/java/io/axual/ksml/metric/KsmlTagEnricher.java
+++ b/ksml/src/main/java/io/axual/ksml/metric/KsmlTagEnricher.java
@@ -54,7 +54,7 @@ public final class KsmlTagEnricher {
     //     → namespace=my_ns, pipeline=flow2, step=null, operation=sink
     static final Pattern NODE_PATTERN = Pattern.compile(
             "^(?<ns>(?:(?!_pipelines_).)+)_pipelines_"                     // namespace (possessive with negative lookahead)
-                    + "(?<pipeline>(?:(?!(?:(?:_via_step\\d)|(?:_[^_]+$))).)+)"  // pipeline (possessive, stops before *via*step or final _op)
+                    + "(?<pipeline>(?:(?!_via_step\\d|_[^_]+$).)+)"  // pipeline (possessive, stops before *via*step or final _op)
                     + "(?:_via_step(?<step>\\d+))?"                        // optional step
                     + "_(?<op>[^_]+)$"                                     // operation (no underscores)
     );

--- a/ksml/src/main/java/io/axual/ksml/metric/KsmlTagEnricher.java
+++ b/ksml/src/main/java/io/axual/ksml/metric/KsmlTagEnricher.java
@@ -54,7 +54,7 @@ public final class KsmlTagEnricher {
     //     → namespace=my_ns, pipeline=flow2, step=null, operation=sink
     static final Pattern NODE_PATTERN = Pattern.compile(
             "^(?<ns>(?:(?!_pipelines_).)+)_pipelines_"                     // namespace (possessive with negative lookahead)
-                    + "(?<pipeline>(?:(?!_via_step\\d|_[^_]+$).)+)"  // pipeline (possessive, stops before *via*step or final _op)
+                    + "(?<pipeline>(?:(?!(?:(?:_via_step\\d)|(?:_[^_]+$))).)+)"  // pipeline (possessive, stops before *via*step or final _op)
                     + "(?:_via_step(?<step>\\d+))?"                        // optional step
                     + "_(?<op>[^_]+)$"                                     // operation (no underscores)
     );

--- a/ksml/src/main/java/io/axual/ksml/metric/KsmlTagEnricher.java
+++ b/ksml/src/main/java/io/axual/ksml/metric/KsmlTagEnricher.java
@@ -1,0 +1,177 @@
+package io.axual.ksml.metric;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML
+ * %%
+ * Copyright (C) 2021 - 2025 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.streams.TopologyDescription;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Translates Kafka Streams metrics into enriched KSML metrics by appending contextual tags
+ * such as namespace, pipeline, and operation name. his allows latency metrics to be mapped back to
+ * specific KSML processing elements.
+ */
+@Slf4j
+public final class KsmlTagEnricher {
+    public static final String STREAM_PROCESSOR_GROUP = "stream-processor-node-metrics";
+    private static final Set<String> INTERESTING_GROUPS = Set.of(STREAM_PROCESSOR_GROUP);
+    private static final String NODE_LATENCY_PREFIX = "record-e2e-latency-";
+    // Regex Explanation:
+    // Matches node names formatted as: <namespace>_pipelines_<pipeline>[_via_step<step>]_operation
+    //
+    // Examples:
+    //   - "my_ns_pipelines_flow1_via_step2_transform"
+    //     → namespace=my_ns, pipeline=flow1, step=2, operation=transform
+    //
+    //   - "my_ns_pipelines_flow2_sink"
+    //     → namespace=my_ns, pipeline=flow2, step=null, operation=sink
+    static final Pattern NODE_PATTERN = Pattern.compile(
+            "^(?<ns>.+?)_pipelines_"           // namespace  (minimal)
+                    + "(?<pipeline>.+?)"                 // pipeline   (lazy)
+                    + "(?:_via_step(?<step>\\d+))?"      // optional   _via_step<N>_
+                    + "_(?<op>[^_]+)$");                 // operation  (until end)
+
+    private final Map<String, OperationMeta> nodeToOperation;
+
+    KsmlTagEnricher(Map<String, OperationMeta> node2OperationMap) {
+        this.nodeToOperation = Map.copyOf(node2OperationMap);
+    }
+
+    record OperationMeta(String namespace, String pipeline, String operation, String step) {
+    }
+
+    public static KsmlTagEnricher from(TopologyDescription desc) {
+        if (desc == null) {
+            throw new IllegalArgumentException("TopologyDescription cannot be null");
+        }
+
+        Map<String, OperationMeta> node2Operation = new HashMap<>();
+
+        for (TopologyDescription.Subtopology st : desc.subtopologies()) {
+            for (TopologyDescription.Node node : st.nodes()) {
+                String nodeName = node.name();
+                if (nodeName == null || nodeName.length() > 500) { // Prevent ReDoS
+                    log.warn("Skipping invalid node name: {}", nodeName);
+                    continue;
+                }
+
+                try {
+                    Matcher m = NODE_PATTERN.matcher(nodeName);
+                    if (m.matches()) {
+                        String namespace = m.group("ns");
+                        String pipeline = m.group("pipeline");
+                        String operation = m.group("op");
+                        String step = m.group("step");
+
+                        // Validate extracted groups
+                        if (namespace != null && pipeline != null && operation != null) {
+                            node2Operation.put(nodeName, new OperationMeta(namespace, pipeline, operation, step));
+                        } else {
+                            log.debug("Incomplete pattern match for node: {}", nodeName);
+                        }
+                    }
+                } catch (Exception e) {
+                    log.warn("Failed to process node name: {}", nodeName, e);
+                }
+            }
+        }
+        return new KsmlTagEnricher(node2Operation);
+    }
+
+    /**
+     * Checks whether the given Kafka metric should be processed by this enricher.
+     * Only latency metrics for stream processor nodes are considered interesting.
+     */
+    public boolean isInteresting(@NotNull KafkaMetric km) {
+        var metricName = km.metricName();
+        var group = metricName.group();
+        if (group == null || !INTERESTING_GROUPS.contains(group)) return false;
+        return isNodeLatency(metricName.name());
+    }
+
+    // 10-20 × faster than allocating a Matcher for every metric change with a regex like:
+    // Pattern.compile("record-e2e-latency-(avg|max|min)")
+    private static boolean isNodeLatency(String name) {
+        return LatencyStat.of(name).isPresent();
+    }
+
+    private enum LatencyStat { AVG, MIN, MAX;
+        static Optional<LatencyStat> of(String metricName) {
+            if (!metricName.startsWith(NODE_LATENCY_PREFIX)) return Optional.empty();
+            return switch (metricName.substring(NODE_LATENCY_PREFIX.length())) {
+                case "avg" -> Optional.of(AVG);
+                case "min" -> Optional.of(MIN);
+                case "max" -> Optional.of(MAX);
+                default    -> Optional.empty();
+            };
+        }
+    }
+
+    /**
+     * Converts a Kafka metric name into a KSML-enriched metric name,
+     * adding tags for namespace, pipeline, operation, etc.
+     * Only applies to e2e latency metrics for stream processor nodes.
+     *
+     * @param kafkaName the original Kafka metric name
+     * @return enriched KSML metric name, or null if enrichment is not applicable
+     */
+    public MetricName toKsmlMetricName(
+            @NotNull org.apache.kafka.common.MetricName kafkaName) {
+
+        if (!STREAM_PROCESSOR_GROUP.equals(kafkaName.group())) return null;
+
+        String nodeId = kafkaName.tags().get("processor-node-id");
+        if (nodeId == null) {
+            log.warn("Missing processor-node-id tag in metric: {}", kafkaName);
+            return null;
+        }
+
+        OperationMeta op = nodeToOperation.get(nodeId);
+        if (op == null) {
+            log.trace("No operation mapping found for node: {}", nodeId);
+            return null;
+        }
+
+        MetricTags tags = new MetricTags()
+                .append("namespace", op.namespace)
+                .append("pipeline", op.pipeline)
+                .append("operation_name", op.operation)
+                .append("processor_node_id",  nodeId)
+                .append("unit", "ms")
+                .appendIfPresent("step", op.step);
+
+        if (isNodeLatency(kafkaName.name())) {
+            String which = kafkaName.name()
+                    .substring(NODE_LATENCY_PREFIX.length());
+            return new MetricName("record_e2e_latency_" + which + "_ms", tags);
+        }
+        return null; // not a metric we care to expose
+    }
+}

--- a/ksml/src/main/java/io/axual/ksml/metric/KsmlTagEnricher.java
+++ b/ksml/src/main/java/io/axual/ksml/metric/KsmlTagEnricher.java
@@ -54,7 +54,7 @@ public final class KsmlTagEnricher {
     //     → namespace=my_ns, pipeline=flow2, step=null, operation=sink
     static final Pattern NODE_PATTERN = Pattern.compile(
             "^(?<ns>(?:(?!_pipelines_).)+)_pipelines_"                     // namespace (possessive with negative lookahead)
-                    + "(?<pipeline>(?:(?!(?:(?:_via_step\\d)|(?:_[^_]+$))).)+)"  // pipeline (possessive, stops before *via*step or final _op)
+                    + "(?<pipeline>(?:(?!(?:_via_step\\d|_[^_]+$)).)+)"  // pipeline (possessive, stops before *via*step or final _op)
                     + "(?:_via_step(?<step>\\d+))?"                        // optional step
                     + "_(?<op>[^_]+)$"                                     // operation (no underscores)
     );

--- a/ksml/src/main/java/io/axual/ksml/metric/KsmlTagEnricher.java
+++ b/ksml/src/main/java/io/axual/ksml/metric/KsmlTagEnricher.java
@@ -53,10 +53,11 @@ public final class KsmlTagEnricher {
     //   - "my_ns_pipelines_flow2_sink"
     //     → namespace=my_ns, pipeline=flow2, step=null, operation=sink
     static final Pattern NODE_PATTERN = Pattern.compile(
-            "^(?<ns>.+?)_pipelines_"           // namespace  (minimal)
-                    + "(?<pipeline>.+?)"                 // pipeline   (lazy)
-                    + "(?:_via_step(?<step>\\d+))?"      // optional   _via_step<N>_
-                    + "_(?<op>[^_]+)$");                 // operation  (until end)
+            "^(?<ns>(?:(?!_pipelines_).)+)_pipelines_"                   // namespace (possessive with negative lookahead)
+                    + "(?<pipeline>(?:(?!_via_step\\d|_[^_]+$).)+)"      // pipeline (possessive, stops before _via_step or final _op)
+                    + "(?:_via_step(?<step>\\d+))?"                      // optional step
+                    + "_(?<op>[^_]+)$"                                   // operation (no underscores)
+    );
 
     private final Map<String, OperationMeta> nodeToOperation;
 

--- a/ksml/src/main/java/io/axual/ksml/metric/KsmlTagEnricher.java
+++ b/ksml/src/main/java/io/axual/ksml/metric/KsmlTagEnricher.java
@@ -53,10 +53,10 @@ public final class KsmlTagEnricher {
     //   - "my_ns_pipelines_flow2_sink"
     //     → namespace=my_ns, pipeline=flow2, step=null, operation=sink
     static final Pattern NODE_PATTERN = Pattern.compile(
-            "^(?<ns>(?:(?!_pipelines_).)+)_pipelines_"                   // namespace (possessive with negative lookahead)
-                    + "(?<pipeline>(?:(?!(?:_via_step\\d|_[^_]+$)).)+)"  // pipeline (possessive, stops before *via*step or final _op)
-                    + "(?:_via_step(?<step>\\d+))?"                      // optional step
-                    + "_(?<op>[^_]+)$"                                   // operation (no underscores)
+            "^(?<ns>(?:(?!_pipelines_).)+)_pipelines_"                     // namespace (possessive with negative lookahead)
+                    + "(?<pipeline>(?:(?!(?:(?:_via_step\\d)|(?:_[^_]+$))).)+)"  // pipeline (possessive, stops before *via*step or final _op)
+                    + "(?:_via_step(?<step>\\d+))?"                        // optional step
+                    + "_(?<op>[^_]+)$"                                     // operation (no underscores)
     );
 
     private final Map<String, OperationMeta> nodeToOperation;

--- a/ksml/src/main/java/io/axual/ksml/metric/KsmlTagEnricher.java
+++ b/ksml/src/main/java/io/axual/ksml/metric/KsmlTagEnricher.java
@@ -54,7 +54,7 @@ public final class KsmlTagEnricher {
     //     → namespace=my_ns, pipeline=flow2, step=null, operation=sink
     static final Pattern NODE_PATTERN = Pattern.compile(
             "^(?<ns>(?:(?!_pipelines_).)+)_pipelines_"                     // namespace (possessive with negative lookahead)
-                    + "(?<pipeline>(?:(?!(?:_via_step\\d|_[^_]+$)).)+)"  // pipeline (possessive, stops before *via*step or final _op)
+                    + "(?<pipeline>(?:(?!(?:_via_step\\d|(?:_[^_]+$))).)+)"  // pipeline (possessive, stops before *via*step or final _op)
                     + "(?:_via_step(?<step>\\d+))?"                        // optional step
                     + "_(?<op>[^_]+)$"                                     // operation (no underscores)
     );

--- a/ksml/src/main/java/io/axual/ksml/metric/MetricTags.java
+++ b/ksml/src/main/java/io/axual/ksml/metric/MetricTags.java
@@ -37,6 +37,13 @@ public class MetricTags extends ArrayList<MetricTag> {
         return append(new MetricTag(key, value));
     }
 
+    public MetricTags appendIfPresent(String key, String value) {
+        if (value != null && !value.isBlank()) {
+            return append(key, value);
+        }
+        return this;
+    }
+
     @Override
     public String toString() {
         final var result = new StringBuilder();

--- a/ksml/src/test/java/io/axual/ksml/metric/KsmlMetricsReporterTest.java
+++ b/ksml/src/test/java/io/axual/ksml/metric/KsmlMetricsReporterTest.java
@@ -293,7 +293,7 @@ class KsmlMetricsReporterIntegrationTest {
                         }
 
                         @Override
-                        public void process(org.apache.kafka.streams.processor.api.Record<Object, Object> record) {
+                        public void process(org.apache.kafka.streams.processor.api.Record<Object, Object> kafkaRecord) {
                             // No-op for test purposes
                         }
 

--- a/ksml/src/test/java/io/axual/ksml/metric/KsmlMetricsReporterTest.java
+++ b/ksml/src/test/java/io/axual/ksml/metric/KsmlMetricsReporterTest.java
@@ -1,0 +1,369 @@
+package io.axual.ksml.metric;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML
+ * %%
+ * Copyright (C) 2021 - 2025 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.jmx.JmxReporter;
+
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.Measurable;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyDescription;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.apache.kafka.streams.processor.api.Processor;
+
+import java.lang.management.ManagementFactory;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.DoubleSupplier;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import lombok.extern.slf4j.Slf4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+class KsmlMetricsReporterIntegrationTest {
+
+    private static final String JMX_DOMAIN = "ksml";
+    private static final String SOURCE_TOPIC = "input-topic";
+    private static final String SINK_TOPIC = "output-topic";
+
+    private MetricsRegistry metricsRegistry;
+    private MBeanServer mBeanServer;
+    private JmxReporter jmxReporter;
+    private KsmlMetricsReporter reporter;
+
+    private final List<TopologyTestDriver> drivers = new CopyOnWriteArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        MetricRegistry underlying = new MetricRegistry();
+        metricsRegistry = new MetricsRegistry(underlying);
+        mBeanServer = ManagementFactory.getPlatformMBeanServer();
+
+        jmxReporter = JmxReporter.forRegistry(underlying)
+                .inDomain(JMX_DOMAIN)
+                .createsObjectNamesWith(new MetricObjectNameFactory(List.of()))
+                .build();
+        jmxReporter.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        drivers.forEach(driver -> {
+            try {
+                driver.close();
+            } catch (Exception e) {
+                log.warn("Failed to close TopologyTestDriver", e);
+            }
+        });
+
+        if (jmxReporter != null) {
+            try {
+                jmxReporter.stop();
+                jmxReporter.close();
+            } catch (Exception e) {
+                log.warn("Failed to close JMX reporter", e);
+            }
+        }
+        if (reporter != null) {
+            try {
+                reporter.close();
+            } catch (Exception e) {
+                log.warn("Failed to close metrics reporter", e);
+            }
+        }
+    }
+
+    @Test
+    void shouldRegisterExpectedMBeanForSingleMetric() throws Exception {
+        String nodeId = "aggregate_pipelines_main_via_step5_peek";
+        TopologyDescription td = buildTopologyDescription(nodeId);
+
+        reporter = new KsmlMetricsReporter(KsmlTagEnricher.from(td));
+        reporter.setRegistry(metricsRegistry);
+
+        MutableDoubleSupplier value = new MutableDoubleSupplier(302.0);
+        KafkaMetric metric = kafkaMetric("min", nodeId, value);
+
+        reporter.metricChange(metric);
+
+        ObjectName expectedName = new ObjectName(
+                JMX_DOMAIN +
+                        ":type=record_e2e_latency_min_ms," +
+                        "namespace=aggregate,operation_name=peek,pipeline=main," +
+                        "processor_node_id=" + nodeId + "," +
+                        "step=5,unit=ms");
+
+        assertThat(mBeanServer.isRegistered(expectedName)).isTrue();
+        assertThat(mBeanServer.getAttribute(expectedName, "Value"))
+                .isEqualTo(302.0);
+    }
+
+
+    @Test
+    void shouldRegisterMultipleBeans() throws Exception {
+        TopologyDescription topologyDescription = buildTopologyDescription(
+                "ns1_pipelines_pipe1_source",
+                "ns1_pipelines_pipe1_via_step1_filter",
+                "ns2_pipelines_pipe2_sink");
+
+        reporter = new KsmlMetricsReporter(KsmlTagEnricher.from(topologyDescription));
+        reporter.setRegistry(metricsRegistry);
+
+        record TestCase(String nodeId, String latType, double val,
+                        String ns, String pipe, String op, String step) {
+        }
+
+        List<TestCase> cases = List.of(
+                new TestCase("ns1_pipelines_pipe1_source", "avg", 100.0, "ns1", "pipe1", "source", null),
+                new TestCase("ns1_pipelines_pipe1_via_step1_filter", "max", 200.0, "ns1", "pipe1", "filter", "1"),
+                new TestCase("ns2_pipelines_pipe2_sink", "min", 50.0, "ns2", "pipe2", "sink", null)
+        );
+
+        cases.forEach(testCase -> {
+            MutableDoubleSupplier val = new MutableDoubleSupplier(testCase.val());
+            reporter.metricChange(kafkaMetric(testCase.latType(), testCase.nodeId(), val));
+        });
+
+        for (TestCase testCase : cases) {
+            String objectName =
+                    "%s:type=record_e2e_latency_%s_ms,namespace=%s,operation_name=%s,"
+                            + "pipeline=%s,processor_node_id=%s%s,unit=ms";
+            ObjectName name = new ObjectName(objectName.formatted(
+                    JMX_DOMAIN, testCase.latType(), testCase.ns(), testCase.op(),
+                    testCase.pipe(), testCase.nodeId(),
+                    testCase.step() != null ? ",step=" + testCase.step() : ""));
+
+            assertThat(mBeanServer.isRegistered(name)).isTrue();
+            assertThat(mBeanServer.getAttribute(name, "Value"))
+                    .isEqualTo(testCase.val());
+        }
+    }
+
+    @Test
+    void shouldReflectUpdatedValue() throws Exception {
+        String nodeId = "test_pipelines_main_forEach";
+        TopologyDescription td = buildTopologyDescription(nodeId);
+
+        reporter = new KsmlMetricsReporter(KsmlTagEnricher.from(td));
+        reporter.setRegistry(metricsRegistry);
+
+        MutableDoubleSupplier value = new MutableDoubleSupplier(100.0);
+        KafkaMetric metric = kafkaMetric("avg", nodeId, value);
+
+        reporter.metricChange(metric);
+
+        ObjectName on = new ObjectName(
+                JMX_DOMAIN + ":type=record_e2e_latency_avg_ms,namespace=test,operation_name=forEach,"
+                        + "pipeline=main,processor_node_id=" + nodeId + ",unit=ms");
+
+        assertThat(mBeanServer.getAttribute(on, "Value")).isEqualTo(100.0);
+
+        value.set(200.0);
+
+        assertThat(mBeanServer.getAttribute(on, "Value")).isEqualTo(200.0);
+    }
+
+
+    @Test
+    void shouldUnregisterBeanOnRemoval() throws Exception {
+        String nodeId = "test_pipelines_main_forEach";
+        TopologyDescription topologyDescription = buildTopologyDescription(nodeId);
+
+        reporter = new KsmlMetricsReporter(KsmlTagEnricher.from(topologyDescription));
+        reporter.setRegistry(metricsRegistry);
+
+        MutableDoubleSupplier value = new MutableDoubleSupplier(100.0);
+        KafkaMetric metric = kafkaMetric("avg", nodeId, value);
+
+        reporter.metricChange(metric);
+
+        ObjectName objectName = new ObjectName(
+                JMX_DOMAIN + ":type=record_e2e_latency_avg_ms,namespace=test,operation_name=forEach,"
+                        + "pipeline=main,processor_node_id=" + nodeId + ",unit=ms");
+
+        assertThat(mBeanServer.isRegistered(objectName)).isTrue();
+
+        reporter.metricRemoval(metric);
+
+        assertThat(mBeanServer.isRegistered(objectName)).isFalse();
+    }
+
+
+    @Test
+    void shouldIgnoreNonLatencyMetrics() throws Exception {
+        String nodeId = "test_pipelines_main_forEach";
+        TopologyDescription td = buildTopologyDescription(nodeId);
+
+        reporter = new KsmlMetricsReporter(KsmlTagEnricher.from(td));
+        reporter.setRegistry(metricsRegistry);
+
+        MutableDoubleSupplier supplier = new MutableDoubleSupplier(1_000.0);
+
+        MetricName metricName = new MetricName(
+                "process-rate",
+                "stream-processor-node-metrics",
+                "",
+                Map.of("processor-node-id", nodeId));
+
+        Measurable measurable = (cfg, now) -> supplier.getAsDouble();
+
+        KafkaMetric nonLatencyKafkaMetric = new KafkaMetric(
+                new Object(), metricName, measurable, new MetricConfig(), Time.SYSTEM);
+
+        reporter.metricChange(nonLatencyKafkaMetric);
+
+        assertThat(mBeanServer.queryNames(new ObjectName(JMX_DOMAIN + ":*"), null))
+                .isEmpty();
+    }
+
+
+    @Test
+    void closeShouldRemoveAllBeans() throws Exception {
+        TopologyDescription topologyDescription = buildTopologyDescription(
+                "test_pipelines_main_forEach",
+                "test_pipelines_main_map");
+
+        reporter = new KsmlMetricsReporter(KsmlTagEnricher.from(topologyDescription));
+        reporter.setRegistry(metricsRegistry);
+
+        reporter.metricChange(kafkaMetric(
+                "avg", "test_pipelines_main_forEach", new MutableDoubleSupplier(100.0)));
+        reporter.metricChange(kafkaMetric(
+                "max", "test_pipelines_main_map", new MutableDoubleSupplier(200.0)));
+
+        assertThat(mBeanServer.queryNames(new ObjectName(JMX_DOMAIN + ":*"), null))
+                .hasSize(2);
+
+        reporter.close();
+
+        assertThat(mBeanServer.queryNames(new ObjectName(JMX_DOMAIN + ":*"), null))
+                .isEmpty();
+    }
+
+    /**
+     * Builds a minimal {@link Topology} whose processor-node IDs match the supplied names,
+     * runs it through {@link TopologyTestDriver} (so we know it’s valid), and returns the
+     * resulting {@link TopologyDescription}.
+     */
+
+    private TopologyDescription buildTopologyDescription(String... processorNodeIds) {
+        Topology topology = new Topology();
+        topology.addSource("source", SOURCE_TOPIC);
+
+        for (String nodeId : processorNodeIds) {
+            topology.addProcessor(
+                    nodeId,
+                    () -> new Processor<Object, Object, Void, Void>() {
+                        @Override
+                        public void init(org.apache.kafka.streams.processor.api.ProcessorContext<Void, Void> context) {
+                            // No-op init
+                        }
+
+                        @Override
+                        public void process(org.apache.kafka.streams.processor.api.Record<Object, Object> record) {
+                            // No-op for test purposes
+                        }
+
+                        @Override
+                        public void close() {
+                            // No-op close
+                        }
+                    },
+                    "source"
+            );
+        }
+
+        topology.addSink("sink", SINK_TOPIC,
+                processorNodeIds.length == 0 ? "source"
+                        : processorNodeIds[processorNodeIds.length - 1]);
+
+        Properties props = new Properties();
+        props.put(StreamsConfig.APPLICATION_ID_CONFIG, "test-app");
+        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
+        props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+        props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+
+        drivers.add(new TopologyTestDriver(topology, props));
+
+        return topology.describe();
+    }
+
+
+    private static final class MutableDoubleSupplier implements DoubleSupplier {
+        private volatile double value;
+
+        MutableDoubleSupplier(double initial) {
+            this.value = initial;
+        }
+
+        void set(double v) {
+            this.value = v;
+        }
+
+        @Override
+        public double getAsDouble() {
+            return value;
+        }
+    }
+
+    /**
+     * Builds a genuine {@link KafkaMetric} that reports the latency value supplied
+     * by {@code valueSupplier}.  Because we keep a reference to that supplier, the
+     * test can change the metric’s value later simply by calling
+     * {@code supplier.set(newValue)} – no Mockito stubbing required.
+     */
+    private static KafkaMetric kafkaMetric(String latencySuffix,
+                                           String nodeId,
+                                           MutableDoubleSupplier valueSupplier) {
+
+        MetricName metricName = new MetricName(
+                "record-e2e-latency-" + latencySuffix,
+                "stream-processor-node-metrics",
+                "",
+                Map.of("processor-node-id", nodeId)
+        );
+
+        Measurable measurable = (cfg, now) -> valueSupplier.getAsDouble();
+
+        return new KafkaMetric(
+                new Object(),
+                metricName,
+                measurable,
+                new MetricConfig(),
+                Time.SYSTEM
+        );
+    }
+}

--- a/ksml/src/test/java/io/axual/ksml/metric/KsmlTagEnricherTest.java
+++ b/ksml/src/test/java/io/axual/ksml/metric/KsmlTagEnricherTest.java
@@ -1,0 +1,122 @@
+package io.axual.ksml.metric;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML
+ * %%
+ * Copyright (C) 2021 - 2025 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.stream.Stream;
+import java.util.regex.Matcher;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class KsmlTagEnricherPatternTest {
+
+    @ParameterizedTest(name = "{index}: {0}")
+    @MethodSource("examples")
+    void nodePatternParsesCorrectly(String nodeName,
+                                    String expectedNamespace,
+                                    String expectedPipelineName,
+                                    String expectedStepNumber,
+                                    String expectedOperationName) {
+
+        Matcher m = KsmlTagEnricher.NODE_PATTERN.matcher(nodeName);
+
+        assertThat(m.matches())
+                .as("Pattern should match: %s", nodeName)
+                .isTrue();
+
+        assertThat(m.group("ns"))
+                .as("namespace")
+                .isEqualTo(expectedNamespace);
+
+        assertThat(m.group("pipeline"))
+                .as("pipeline")
+                .isEqualTo(expectedPipelineName);
+
+        assertThat(m.group("step"))
+                .as("step")
+                .isEqualTo(expectedStepNumber);
+
+        assertThat(m.group("op"))
+                .as("operation")
+                .isEqualTo(expectedOperationName);
+    }
+
+    private static Stream<Arguments> examples() {
+        return Stream.of(
+                Arguments.of("inspect_pipelines_consume_avro_forEach",
+                        "inspect", "consume_avro",            null, "forEach"),
+                Arguments.of("copy_pipelines_main_copy_pipeline_via_step1_peek",
+                        "copy",    "main_copy_pipeline",      "1",  "peek"),
+                Arguments.of("copy_pipelines_main_copy_pipeline_to",
+                        "copy",    "main_copy_pipeline",      null, "to"),
+                Arguments.of("duplicate_pipelines_main_via_step1_transformKeyValueToKeyValueList",
+                        "duplicate","main",                   "1",  "transformKeyValueToKeyValueList"),
+                Arguments.of("convert_pipelines_main_to_xml_via_step2_peek",
+                        "convert", "main_to_xml",             "2",  "peek"),
+                Arguments.of("convert_pipelines_alternate_to_xml_to",
+                        "convert", "alternate_to_xml",        null, "to"),
+                Arguments.of("route_pipelines_main_toTopicNameExtractor",
+                        "route",   "main",                    null, "toTopicNameExtractor"),
+                Arguments.of("queryable_table_pipelines_main_via_step2_peek",
+                        "queryable_table","main",             "2",  "peek"),
+                Arguments.of("convert_pipelines_main_to_via_xml_via_step6_peek",
+                        "convert", "main_to_via_xml",         "6",  "peek"),
+                Arguments.of("via_convert_main_pipelines_main_to_via_xml_via_step6_peek",
+                        "via_convert_main","main_to_via_xml", "6",  "peek")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidNodeNames")
+    void shouldNotMatchInvalidNodeNames(String invalidNodeName) {
+        Matcher m = KsmlTagEnricher.NODE_PATTERN.matcher(invalidNodeName);
+        assertThat(m.matches())
+                .as("Pattern should not match: %s", invalidNodeName)
+                .isFalse();
+    }
+
+    private static Stream<String> invalidNodeNames() {
+        return Stream.of(
+                "invalid_format",
+                "missing_pipelines_part",
+                "namespace_pipeline_operation", // missing 'pipelines'
+                "_pipelines_pipeline_op", // empty namespace
+                "ns_pipelines__op", // empty pipeline
+                "ns_pipelines_pipe_" // empty operation
+        );
+    }
+
+    @Test
+    void shouldHandleSpecialCharactersInNodeNames() {
+        // Test with special characters that might break regex
+        String nodeWithSpecialChars = "ns-with-dash_pipelines_pipe.with.dots_op";
+        Matcher m = KsmlTagEnricher.NODE_PATTERN.matcher(nodeWithSpecialChars);
+
+        assertThat(m.matches()).isTrue();
+        assertThat(m.group("ns")).isEqualTo("ns-with-dash");
+        assertThat(m.group("pipeline")).isEqualTo("pipe.with.dots");
+        assertThat(m.group("op")).isEqualTo("op");
+    }
+}


### PR DESCRIPTION
- Add KsmlMetricsReporter to convert Kafka Streams latency metrics into KSML-compliant metrics
- Implement KsmlTagEnricher to parse processor node names and extract namespace/pipeline/operation metadata
- Filter and enrich only e2e latency metrics (avg/min/max) from stream-processor-node-metrics group
- Add integration tests validating JMX bean registration and metric value updates
- Include pattern matching tests for various node naming conventions

The changes enable monitoring of KSML pipeline performance by enriching Kafka Streams metrics with contextual tags, making it easier to track latency across specific namespaces, pipelines and operations.