### PR TITLE
Backported PR #224 changes for KSML 1.0.x

### DIFF
--- a/examples/ksml-runner.yaml
+++ b/examples/ksml-runner.yaml
@@ -8,15 +8,15 @@ ksml:
   enablePipelines: true
   definitions:
     # Format is <namespace>: <ksml_definition_filename>
-#    inspect: 01-example-inspect.yaml
-#    copy: 02-example-copy.yaml
+    inspect: 01-example-inspect.yaml
+    copy: 02-example-copy.yaml
 #    filter: 03-example-filter.yaml
 #    branch: 04-example-branch.yaml
 #    route: 05-example-route.yaml
 #    duplicate: 06-example-duplicate.yaml
 #    convert: 07-example-convert.yaml
 #    count: 08-example-count.yaml
-    aggregate: 09-example-aggregate.yaml
+#    aggregate: 09-example-aggregate.yaml
 #    queryable_table: 10-example-queryable-table.yaml
 #    field_modification: 11-example-field-modification.yaml
 #    byte_manipulation: 12-example-byte-manipulation.yaml

--- a/ksml-runner/NOTICE.txt
+++ b/ksml-runner/NOTICE.txt
@@ -1,5 +1,5 @@
 
-Lists of 123 third-party dependencies.
+Lists of 124 third-party dependencies.
      (Eclipse Public License - v 1.0) (GNU Lesser General Public License) Logback Classic Module (ch.qos.logback:logback-classic:1.5.18 - http://logback.qos.ch/logback-classic)
      (Eclipse Public License - v 1.0) (GNU Lesser General Public License) Logback Core Module (ch.qos.logback:logback-core:1.5.18 - http://logback.qos.ch/logback-core)
      (MIT License) minimal-json (com.eclipsesource.minimal-json:minimal-json:0.9.5 - https://github.com/ralfstx/minimal-json)
@@ -32,6 +32,7 @@ Lists of 123 third-party dependencies.
      (Apache 2.0) KSML Data Library - XML (io.axual.ksml:ksml-data-xml:1.0.8-SNAPSHOT - https://github.com/Axual/ksml/ksml-data-xml)
      (Apache 2.0) KSML Kafka clients (io.axual.ksml:ksml-kafka-clients:1.0.8-SNAPSHOT - https://github.com/Axual/ksml/ksml-kafka-clients)
      (Apache 2.0) KSML Queryable State Store (io.axual.ksml:ksml-query:1.0.8-SNAPSHOT - https://github.com/Axual/ksml/ksml-query)
+     (Apache 2.0) Axual Header Cleaning (io.axual.utils:axual-header-cleaning:1.0.0 - https://gitlab.com/axual/public/axual-utils/axual-header-cleaning)
      (Apache License 2.0) utils (io.confluent:common-utils:7.6.1 - https://confluent.io/common-utils)
      (Apache License 2.0) kafka-avro-serializer (io.confluent:kafka-avro-serializer:7.6.1 - http://confluent.io/kafka-avro-serializer)
      (Apache License 2.0) kafka-schema-registry-client (io.confluent:kafka-schema-registry-client:7.6.1 - http://confluent.io/kafka-schema-registry-client)

--- a/ksml-runner/pom.xml
+++ b/ksml-runner/pom.xml
@@ -72,6 +72,10 @@
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.axual.utils</groupId>
+            <artifactId>axual-header-cleaning</artifactId>
+        </dependency>
 
         <!-- TEST dependencies -->
         <dependency>

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/backend/KafkaStreamsRunner.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/backend/KafkaStreamsRunner.java
@@ -21,6 +21,8 @@ package io.axual.ksml.runner.backend;
  */
 
 
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -29,6 +31,8 @@ import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyConfig;
 
 import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -42,22 +46,54 @@ import io.axual.ksml.generator.TopologyDefinition;
 import io.axual.ksml.runner.config.ApplicationServerConfig;
 import io.axual.ksml.runner.exception.RunnerException;
 import io.axual.ksml.runner.streams.KSMLClientSupplier;
+import io.axual.utils.headers.cleaning.AxualHeaderCleaningInterceptor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * Implementation of the Runner interface that manages Kafka Streams applications.
+ *
+ * <p>This class is responsible for:</p>
+ * <ul>
+ *     <li>Creating and configuring Kafka Streams applications</li>
+ *     <li>Managing the lifecycle (start, run, stop) of Kafka Streams applications</li>
+ *     <li>Handling state transitions and error scenarios</li>
+ *     <li>Adding cleanup interceptors to consumer configurations</li>
+ *     <li>Providing metrics reporting</li>
+ * </ul>
+ *
+ * <p>The runner creates a Kafka Streams instance based on the provided configuration,
+ * sets up appropriate error handlers and state listeners, and manages the application's
+ * lifecycle through the Runner interface methods.</p>
+ */
 @Slf4j
 public class KafkaStreamsRunner implements Runner {
     @Getter
     private final KafkaStreams kafkaStreams;
     private final AtomicBoolean stopRunning = new AtomicBoolean(false);
+    // Default sleep durations that can be overridden in tests
+    private long startupSleepMs = 1000;
+    private long pollingSleepMs = 200;
 
+    /**
+     * Configuration record for the KafkaStreamsRunner.
+     *
+     * @param definitions Map of topology definitions to be used in the Kafka Streams application
+     * @param storageDirectory Directory where Kafka Streams will store its state
+     * @param appServer Configuration for the application server (used for interactive queries)
+     * @param kafkaConfig Kafka configuration properties
+     */
     @Builder
     public record Config(Map<String, TopologyDefinition> definitions,
                          String storageDirectory,
                          ApplicationServerConfig appServer,
                          Map<String, String> kafkaConfig) {
-        public Config(final Map<String, TopologyDefinition> definitions, final String storageDirectory, final ApplicationServerConfig appServer, final Map<String, String> kafkaConfig) {
+        public Config(
+                final Map<String, TopologyDefinition> definitions,
+                final String storageDirectory,
+                final ApplicationServerConfig appServer,
+                final Map<String, String> kafkaConfig) {
             this.definitions = definitions;
             this.storageDirectory = storageDirectory;
             this.appServer = appServer;
@@ -71,15 +107,24 @@ public class KafkaStreamsRunner implements Runner {
                 processedKafkaConfig.put(StreamsConfig.DEFAULT_CLIENT_SUPPLIER_CONFIG, KSMLClientSupplier.class.getCanonicalName());
             }
             this.kafkaConfig = processedKafkaConfig;
-
         }
     }
 
+    /**
+     * Creates a new KafkaStreamsRunner with the provided configuration.
+     *
+     * @param config The configuration for the Kafka Streams application
+     */
     public KafkaStreamsRunner(Config config) {
         this(config, KafkaStreams::new);
     }
 
-    // Package private so tests can inject a factory
+    /**
+     * Package private constructor that allows tests to inject a factory for creating KafkaStreams instances.
+     *
+     * @param config The configuration for the Kafka Streams application
+     * @param kafkaStreamsFactory Factory function for creating KafkaStreams instances
+     */
     KafkaStreamsRunner(Config config, BiFunction<Topology, Properties, KafkaStreams> kafkaStreamsFactory) {
         log.info("Constructing Kafka Backend");
 
@@ -101,11 +146,87 @@ public class KafkaStreamsRunner implements Runner {
         kafkaStreams.setUncaughtExceptionHandler(ExecutionContext.INSTANCE::uncaughtException);
     }
 
+    /**
+     * Logs state changes in the Kafka Streams application.
+     * This method is used as a state listener for the Kafka Streams instance.
+     *
+     * @param newState The new state of the Kafka Streams application
+     * @param oldState The previous state of the Kafka Streams application
+     */
     private void logStreamsStateChange(KafkaStreams.State newState, KafkaStreams.State oldState) {
         log.info("Pipeline processing state change. Moving from old state '{}' to new state '{}'", oldState, newState);
     }
 
-    private Map<String, Object> getStreamsConfig(Map<String, String> initialConfigs, String storageDirectory, ApplicationServerConfig appServer) {
+    private static final String CLEANUP_INTERCEPTOR_CLASS_NAME = AxualHeaderCleaningInterceptor.class.getCanonicalName();
+
+    /**
+     * Adds the AxualHeaderCleaningInterceptor to the consumer interceptor configuration.
+     * This method is package-private for testability.
+     *
+     * <p>The cleanup interceptor is added as the first interceptor in the chain if it's not already present.</p>
+     * <ul>
+     *     <li>For the plain consumer ({@code CONSUMER_PREFIX}), the interceptor is always added if {@code addConfigIfMissing} is true.</li>
+     *     <li>For other consumers ({@code MAIN_CONSUMER_PREFIX}, {@code RESTORE_CONSUMER_PREFIX}, {@code GLOBAL_CONSUMER_PREFIX}),
+     *     the interceptor is only added if the configuration already exists.</li>
+     * </ul>
+     *
+     * @param configPrefix The configuration prefix for the consumer (e.g., {@code consumer.}, {@code main.consumer.}, etc.)
+     * @param configs The configuration map to modify
+     * @param addConfigIfMissing Whether to add the interceptor configuration if it doesn't exist
+     */
+    void addCleanupInterceptor(String configPrefix, Map<String, Object> configs, boolean addConfigIfMissing) {
+        final var configName = configPrefix + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG;
+        if (!configs.containsKey(configName) && !addConfigIfMissing) {
+            return;
+        }
+
+        var interceptorClasses = new LinkedList<String>();
+
+        // Get existing interceptors if any
+        final var configValue = configs.get(configName);
+        if (configValue != null) {
+            var parsedValue = ConfigDef.parseType(configName, configValue, ConfigDef.Type.LIST);
+            if (parsedValue instanceof List<?> rawInterceptors) {
+                // add list items
+                for (Object rawInterceptor : rawInterceptors) {
+                    if (rawInterceptor instanceof String interceptorClassName) {
+                        interceptorClasses.add(interceptorClassName);
+                    } else if (rawInterceptor instanceof Class<?> clazz) {
+                        interceptorClasses.add(clazz.getCanonicalName());
+                    }
+                }
+            }
+        }
+
+        // Add the cleanup interceptor if not already present
+        if (!interceptorClasses.contains(CLEANUP_INTERCEPTOR_CLASS_NAME)) {
+            // Add the cleanup interceptor as first interceptor
+            interceptorClasses.addFirst(CLEANUP_INTERCEPTOR_CLASS_NAME);
+        }
+
+        configs.put(configName, String.join(",", interceptorClasses));
+    }
+
+    /**
+     * Creates a configuration map for Kafka Streams with appropriate settings.
+     * This method is package-private for testability.
+     *
+     * <p>The method:</p>
+     * <ul>
+     *     <li>Copies the initial configuration if provided</li>
+     *     <li>Sets default values for optimization if not explicitly configured</li>
+     *     <li>Sets exception handlers for production and deserialization errors</li>
+     *     <li>Adds cleanup interceptors to all consumer configurations</li>
+     *     <li>Sets the state directory for Kafka Streams</li>
+     *     <li>Configures the application server if enabled</li>
+     * </ul>
+     *
+     * @param initialConfigs Initial configuration map (can be {@code null})
+     * @param storageDirectory Directory where Kafka Streams will store its state
+     * @param appServer Configuration for the application server (used for interactive queries)
+     * @return A map with the complete Kafka Streams configuration
+     */
+    Map<String, Object> getStreamsConfig(Map<String, String> initialConfigs, String storageDirectory, ApplicationServerConfig appServer) {
         final Map<String, Object> result = initialConfigs != null ? new HashMap<>(initialConfigs) : new HashMap<>();
         // Set default value if not explicitly configured
         result.putIfAbsent(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
@@ -113,6 +234,12 @@ public class KafkaStreamsRunner implements Runner {
         // Explicit configs can overwrite those from the map
         result.put(StreamsConfig.DEFAULT_PRODUCTION_EXCEPTION_HANDLER_CLASS_CONFIG, ExecutionErrorHandler.class);
         result.put(StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG, ExecutionErrorHandler.class);
+
+        // Make sure that all consumers have an interceptor configuration
+        addCleanupInterceptor(StreamsConfig.CONSUMER_PREFIX, result, true);
+        addCleanupInterceptor(StreamsConfig.MAIN_CONSUMER_PREFIX, result, false);
+        addCleanupInterceptor(StreamsConfig.RESTORE_CONSUMER_PREFIX, result, false);
+        addCleanupInterceptor(StreamsConfig.GLOBAL_CONSUMER_PREFIX, result, false);
 
         result.put(StreamsConfig.STATE_DIR_CONFIG, storageDirectory);
         if (appServer != null && appServer.isEnabled()) {
@@ -122,12 +249,23 @@ public class KafkaStreamsRunner implements Runner {
         return result;
     }
 
+    /**
+     * Converts a Map to a Properties object.
+     *
+     * @param configs The map to convert
+     * @return A Properties object containing all entries from the map
+     */
     private Properties mapToProperties(Map<String, Object> configs) {
         final var result = new Properties();
         result.putAll(configs);
         return result;
     }
 
+    /**
+     * Maps the Kafka Streams state to the Runner state.
+     *
+     * @return The current state of the runner
+     */
     @Override
     public State getState() {
         return switch (kafkaStreams.state()) {
@@ -140,17 +278,30 @@ public class KafkaStreamsRunner implements Runner {
         };
     }
 
+    /**
+     * Starts the Kafka Streams application and monitors its state.
+     * This method blocks until the application is stopped or fails.
+     *
+     * <p>The method:</p>
+     * <ul>
+     *     <li>Starts the Kafka Streams application</li>
+     *     <li>Waits for a short period to allow asynchronous startup</li>
+     *     <li>Continuously monitors the application state</li>
+     *     <li>Closes the application when stopped</li>
+     *     <li>Throws an exception if the application fails</li>
+     * </ul>
+     */
     @Override
     public void run() {
         log.info("Starting Kafka Streams backend");
         try {
             kafkaStreams.start();
             // Allow Kafka Streams to start up asynchronously
-            Utils.sleep(1000);
+            Utils.sleep(startupSleepMs);
 
             // While we need to keep running, wait and check for failure state
             while (isRunning() && !stopRunning.get()) {
-                Utils.sleep(200);
+                Utils.sleep(pollingSleepMs);
             }
         } finally {
             if (isRunning()) {
@@ -165,6 +316,22 @@ public class KafkaStreamsRunner implements Runner {
         }
     }
 
+    /**
+     * Sets the sleep durations used in the run method.
+     * This method is package-private and intended for testing to reduce wait times.
+     *
+     * @param startupSleepMs Time to sleep after starting Kafka Streams to allow asynchronous startup
+     * @param pollingSleepMs Time to sleep between state checks while running
+     */
+    void setSleepDurations(long startupSleepMs, long pollingSleepMs) {
+        this.startupSleepMs = startupSleepMs;
+        this.pollingSleepMs = pollingSleepMs;
+    }
+
+    /**
+     * Signals the runner to stop.
+     * This method sets a flag that will cause the run method to exit its monitoring loop.
+     */
     @Override
     public void stop() {
         stopRunning.set(true);

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/backend/KafkaStreamsRunnerTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/backend/KafkaStreamsRunnerTest.java
@@ -20,12 +20,12 @@ package io.axual.ksml.runner.backend;
  * =========================LICENSE_END==================================
  */
 
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,6 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
@@ -51,17 +52,31 @@ import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
 import io.axual.ksml.client.resolving.ResolvingClientConfig;
+import io.axual.ksml.execution.ExecutionErrorHandler;
 import io.axual.ksml.runner.config.ApplicationServerConfig;
+import io.axual.ksml.runner.exception.RunnerException;
 import lombok.extern.slf4j.Slf4j;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Named.named;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
+/**
+ * Test class for {@link KafkaStreamsRunner}.
+ *
+ * <p>This class tests various aspects of the KafkaStreamsRunner:</p>
+ * <ul>
+ *     <li>Configuration handling in the Config record</li>
+ *     <li>Streams configuration with various scenarios</li>
+ *     <li>Cleanup interceptor addition for different consumer prefixes</li>
+ *     <li>Error handling and state transitions</li>
+ *     <li>Kafka Streams lifecycle management</li>
+ * </ul>
+ *
+ * <p>The tests use parameterized tests with named arguments for better readability
+ * and mock Kafka Streams instances to avoid actual Kafka connections.</p>
+ */
 @Slf4j
 @ExtendWith(MockitoExtension.class)
 class KafkaStreamsRunnerTest {
@@ -110,6 +125,18 @@ class KafkaStreamsRunnerTest {
     };
 
 
+    /**
+     * Provides test data for testing the Config record's pattern handling.
+     *
+     * <p>Test cases:</p>
+     * <ol>
+     *     <li>Configuration without patterns should remain unchanged</li>
+     *     <li>Configuration with current pattern format should remain unchanged</li>
+     *     <li>Configuration with deprecated (compat) pattern format should be converted to current format</li>
+     * </ol>
+     *
+     * @return Stream of test arguments with input and expected configurations
+     */
     static Stream<Arguments> testConfigData() {
         return Stream.of(
                 Arguments.of(named("No pattern should remain the same", INPUT_CONFIG_WITHOUT_PATTERNS), EXPECTED_CONFIG_WITHOUT_PATTERNS),
@@ -118,6 +145,20 @@ class KafkaStreamsRunnerTest {
         );
     }
 
+    /**
+     * Tests that the Config record correctly handles pattern configurations.
+     *
+     * <p>This test verifies that:</p>
+     * <ul>
+     *     <li>Configurations without patterns remain unchanged</li>
+     *     <li>Current pattern formats are preserved</li>
+     *     <li>Deprecated pattern formats are converted to current format</li>
+     *     <li>Restricted (deprecated) config keys are removed</li>
+     * </ul>
+     *
+     * @param inputConfig The input configuration to test
+     * @param expectedConfig The expected configuration after processing
+     */
     @ParameterizedTest
     @DisplayName("Check pattern handling")
     @MethodSource(value = "testConfigData")
@@ -130,7 +171,496 @@ class KafkaStreamsRunnerTest {
                 .doesNotContainKeys(RESTRICTED_CONFIGS);
     }
 
-    @Disabled("Somehow Kafka Streams mock gets stuck during these tests, needs further investigation")
+    /**
+     * Provides test data for testing the getStreamsConfig method.
+     *
+     * <p>Test cases include:</p>
+     * <ol>
+     *     <li>Basic configuration with initial configs</li>
+     *     <li>Configuration with application server</li>
+     *     <li>Configuration with {@code null} initial configs</li>
+     *     <li>Configuration with existing interceptor configs</li>
+     * </ol>
+     *
+     * @return Stream of test arguments with different configuration scenarios
+     */
+    static Stream<Arguments> streamsConfigTestData() {
+        var appServer = ApplicationServerConfig.builder()
+                .enabled(true)
+                .host("localhost")
+                .port("8080")
+                .build();
+
+        return Stream.of(
+                // Basic configuration
+                Arguments.of(
+                        named("Basic configuration with initial configs",
+                                new StreamsConfigTestCase(
+                                        INPUT_CONFIG_WITHOUT_PATTERNS,
+                                        "test-dir",
+                                        null,
+                                        Map.of(
+                                                StreamsConfig.APPLICATION_ID_CONFIG, "test-id",
+                                                StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "mock:9092",
+                                                "AnotherKey", "value",
+                                                StreamsConfig.STATE_DIR_CONFIG, "test-dir",
+                                                StreamsConfig.DEFAULT_PRODUCTION_EXCEPTION_HANDLER_CLASS_CONFIG, ExecutionErrorHandler.class,
+                                                StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG, ExecutionErrorHandler.class,
+                                                StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE
+                                        ),
+                                        Set.of(
+                                                StreamsConfig.CONSUMER_PREFIX + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG
+                                        )
+                                ))),
+
+                // With application server
+                Arguments.of(
+                        named("Configuration with application server",
+                                new StreamsConfigTestCase(
+                                        INPUT_CONFIG_WITHOUT_PATTERNS,
+                                        "test-dir",
+                                        appServer,
+                                        Map.of(
+                                                StreamsConfig.APPLICATION_ID_CONFIG, "test-id",
+                                                StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "mock:9092",
+                                                "AnotherKey", "value",
+                                                StreamsConfig.STATE_DIR_CONFIG, "test-dir",
+                                                StreamsConfig.DEFAULT_PRODUCTION_EXCEPTION_HANDLER_CLASS_CONFIG, ExecutionErrorHandler.class,
+                                                StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG, ExecutionErrorHandler.class,
+                                                StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE,
+                                                StreamsConfig.APPLICATION_SERVER_CONFIG, "localhost:8080"
+                                        ),
+                                        Set.of(
+                                                StreamsConfig.CONSUMER_PREFIX + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG
+                                        )
+                                ))),
+
+                // With null initial configs
+                Arguments.of(
+                        named("Configuration with null initial configs",
+                                new StreamsConfigTestCase(
+                                        null,
+                                        "test-dir",
+                                        null,
+                                        Map.of(
+                                                StreamsConfig.STATE_DIR_CONFIG, "test-dir",
+                                                StreamsConfig.DEFAULT_PRODUCTION_EXCEPTION_HANDLER_CLASS_CONFIG, ExecutionErrorHandler.class,
+                                                StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG, ExecutionErrorHandler.class,
+                                                StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE
+                                        ),
+                                        Set.of(
+                                                StreamsConfig.CONSUMER_PREFIX + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG
+                                        )
+                                ))),
+
+                // With existing interceptor configs
+                Arguments.of(
+                        named("Configuration with existing interceptor configs",
+                                new StreamsConfigTestCase(
+                                        Map.of(
+                                                StreamsConfig.APPLICATION_ID_CONFIG, "test-id",
+                                                StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "mock:9092",
+                                                StreamsConfig.MAIN_CONSUMER_PREFIX + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, "some.other.Interceptor",
+                                                StreamsConfig.RESTORE_CONSUMER_PREFIX + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, "some.other.Interceptor",
+                                                StreamsConfig.GLOBAL_CONSUMER_PREFIX + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, "some.other.Interceptor"
+                                        ),
+                                        "test-dir",
+                                        null,
+                                        Map.of(
+                                                StreamsConfig.APPLICATION_ID_CONFIG, "test-id",
+                                                StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "mock:9092",
+                                                StreamsConfig.STATE_DIR_CONFIG, "test-dir",
+                                                StreamsConfig.DEFAULT_PRODUCTION_EXCEPTION_HANDLER_CLASS_CONFIG, ExecutionErrorHandler.class,
+                                                StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG, ExecutionErrorHandler.class,
+                                                StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE
+                                        ),
+                                        Set.of(
+                                                StreamsConfig.CONSUMER_PREFIX + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG,
+                                                StreamsConfig.MAIN_CONSUMER_PREFIX + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG,
+                                                StreamsConfig.RESTORE_CONSUMER_PREFIX + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG,
+                                                StreamsConfig.GLOBAL_CONSUMER_PREFIX + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG
+                                        )
+                                )))
+        );
+    }
+
+    /**
+     * Test case class for testing the getStreamsConfig method.
+     * Contains input parameters and expected results for each test scenario.
+     */
+    static class StreamsConfigTestCase {
+        final Map<String, String> initialConfigs;
+        final String storageDirectory;
+        final ApplicationServerConfig appServer;
+        final Map<String, Object> expectedEntries;
+        final Set<String> expectedKeys;
+
+        /**
+         * Creates a new test case for the getStreamsConfig method.
+         *
+         * @param initialConfigs The initial configuration map to pass to getStreamsConfig
+         * @param storageDirectory The storage directory to pass to getStreamsConfig
+         * @param appServer The application server configuration to pass to getStreamsConfig
+         * @param expectedEntries Map of key-value pairs expected in the result
+         * @param expectedKeys Set of keys expected to be present in the result
+         */
+        StreamsConfigTestCase(Map<String, String> initialConfigs, String storageDirectory,
+                             ApplicationServerConfig appServer, Map<String, Object> expectedEntries,
+                             Set<String> expectedKeys) {
+            this.initialConfigs = initialConfigs;
+            this.storageDirectory = storageDirectory;
+            this.appServer = appServer;
+            this.expectedEntries = expectedEntries;
+            this.expectedKeys = expectedKeys;
+        }
+    }
+
+    /**
+     * Tests the getStreamsConfig method with various scenarios.
+     *
+     * <p>This test verifies that the getStreamsConfig method:</p>
+     * <ul>
+     *     <li>Correctly handles different initial configurations</li>
+     *     <li>Sets appropriate default values</li>
+     *     <li>Adds exception handlers</li>
+     *     <li>Configures interceptors correctly</li>
+     *     <li>Sets the state directory</li>
+     *     <li>Configures the application server when enabled</li>
+     * </ul>
+     *
+     * @param testCase The test case containing input parameters and expected results
+     */
+    @ParameterizedTest
+    @DisplayName("Test getStreamsConfig method with various scenarios")
+    @MethodSource("streamsConfigTestData")
+    void testGetStreamsConfig(StreamsConfigTestCase testCase) {
+        // Create a runner to test the method
+        final var config = KafkaStreamsRunner.Config.builder()
+                .definitions(Map.of())
+                .kafkaConfig(INPUT_CONFIG_WITHOUT_PATTERNS)
+                .storageDirectory("tmp")
+                .build();
+
+        var runner = new KafkaStreamsRunner(config, (topology, properties) -> mock(KafkaStreams.class));
+
+        // Get the streams config
+        var result = runner.getStreamsConfig(testCase.initialConfigs, testCase.storageDirectory, testCase.appServer);
+
+        // Verify expected entries
+        assertThat(result).containsAllEntriesOf(testCase.expectedEntries);
+
+        // Verify expected keys
+        for (String key : testCase.expectedKeys) {
+            assertThat(result).containsKey(key);
+        }
+
+        // Verify interceptor configurations
+        if (result.containsKey(StreamsConfig.CONSUMER_PREFIX + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG)) {
+            String interceptors = (String) result.get(StreamsConfig.CONSUMER_PREFIX + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG);
+            assertThat(interceptors).contains("io.axual.utils.headers.cleaning.AxualHeaderCleaningInterceptor");
+        }
+    }
+
+    /**
+     * Provides test data for testing the addCleanupInterceptor method.
+     *
+     * <p>Test cases include:</p>
+     * <ul>
+     *     <li>Plain consumer ({@code CONSUMER_PREFIX}) scenarios with different configurations</li>
+     *     <li>Main consumer ({@code MAIN_CONSUMER_PREFIX}) scenarios</li>
+     *     <li>Restore consumer ({@code RESTORE_CONSUMER_PREFIX}) scenarios</li>
+     *     <li>Global consumer ({@code GLOBAL_CONSUMER_PREFIX}) scenarios</li>
+     * </ul>
+     *
+     * <p>Each scenario tests different combinations of:</p>
+     * <ul>
+     *     <li>Empty or existing interceptor configurations</li>
+     *     <li>Whether to add the interceptor if missing</li>
+     *     <li>Different formats of interceptor configuration ({@code String} or {@code List})</li>
+     * </ul>
+     *
+     * @return Stream of test arguments with different interceptor scenarios
+     */
+    static Stream<Arguments> interceptorTestData() {
+        return Stream.of(
+                // Plain consumer (CONSUMER_PREFIX) scenarios
+                Arguments.of(
+                        named("Plain consumer - Empty config, add if missing = true",
+                                new InterceptorTestCase(StreamsConfig.CONSUMER_PREFIX, new HashMap<>(), true,
+                                        Map.of(StreamsConfig.CONSUMER_PREFIX + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG,
+                                                "io.axual.utils.headers.cleaning.AxualHeaderCleaningInterceptor")))),
+                Arguments.of(
+                        named("Plain consumer - Empty config, add if missing = false",
+                                new InterceptorTestCase(StreamsConfig.CONSUMER_PREFIX, new HashMap<>(), false,
+                                        Map.of()))),
+                Arguments.of(
+                        named("Plain consumer - Existing interceptor config as String",
+                                new InterceptorTestCase(StreamsConfig.CONSUMER_PREFIX,
+                                        Map.of(StreamsConfig.CONSUMER_PREFIX + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, "some.other.Interceptor"),
+                                        false,
+                                        Map.of(StreamsConfig.CONSUMER_PREFIX + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG,
+                                                "io.axual.utils.headers.cleaning.AxualHeaderCleaningInterceptor,some.other.Interceptor")))),
+                Arguments.of(
+                        named("Plain consumer - Existing interceptor config as List",
+                                new InterceptorTestCase(StreamsConfig.CONSUMER_PREFIX,
+                                        Map.of(StreamsConfig.CONSUMER_PREFIX + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, List.of("some.other.Interceptor")),
+                                        false,
+                                        Map.of(StreamsConfig.CONSUMER_PREFIX + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG,
+                                                "io.axual.utils.headers.cleaning.AxualHeaderCleaningInterceptor,some.other.Interceptor")))),
+                Arguments.of(
+                        named("Plain consumer - Cleanup interceptor already present",
+                                new InterceptorTestCase(StreamsConfig.CONSUMER_PREFIX,
+                                        Map.of(StreamsConfig.CONSUMER_PREFIX + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG,
+                                                "io.axual.utils.headers.cleaning.AxualHeaderCleaningInterceptor,some.other.Interceptor"),
+                                        false,
+                                        Map.of(StreamsConfig.CONSUMER_PREFIX + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG,
+                                                "io.axual.utils.headers.cleaning.AxualHeaderCleaningInterceptor,some.other.Interceptor")))),
+
+                // Main consumer (MAIN_CONSUMER_PREFIX) scenarios
+                Arguments.of(
+                        named("Main consumer - Empty config, add if missing = false",
+                                new InterceptorTestCase(StreamsConfig.MAIN_CONSUMER_PREFIX, new HashMap<>(), false,
+                                        Map.of()))),
+                Arguments.of(
+                        named("Main consumer - Existing interceptor config",
+                                new InterceptorTestCase(StreamsConfig.MAIN_CONSUMER_PREFIX,
+                                        Map.of(StreamsConfig.MAIN_CONSUMER_PREFIX + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, "some.other.Interceptor"),
+                                        false,
+                                        Map.of(StreamsConfig.MAIN_CONSUMER_PREFIX + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG,
+                                                "io.axual.utils.headers.cleaning.AxualHeaderCleaningInterceptor,some.other.Interceptor")))),
+
+                // Restore consumer (RESTORE_CONSUMER_PREFIX) scenarios
+                Arguments.of(
+                        named("Restore consumer - Empty config, add if missing = false",
+                                new InterceptorTestCase(StreamsConfig.RESTORE_CONSUMER_PREFIX, new HashMap<>(), false,
+                                        Map.of()))),
+                Arguments.of(
+                        named("Restore consumer - Existing interceptor config",
+                                new InterceptorTestCase(StreamsConfig.RESTORE_CONSUMER_PREFIX,
+                                        Map.of(StreamsConfig.RESTORE_CONSUMER_PREFIX + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, "some.other.Interceptor"),
+                                        false,
+                                        Map.of(StreamsConfig.RESTORE_CONSUMER_PREFIX + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG,
+                                                "io.axual.utils.headers.cleaning.AxualHeaderCleaningInterceptor,some.other.Interceptor")))),
+
+                // Global consumer (GLOBAL_CONSUMER_PREFIX) scenarios
+                Arguments.of(
+                        named("Global consumer - Empty config, add if missing = false",
+                                new InterceptorTestCase(StreamsConfig.GLOBAL_CONSUMER_PREFIX, new HashMap<>(), false,
+                                        Map.of()))),
+                Arguments.of(
+                        named("Global consumer - Existing interceptor config",
+                                new InterceptorTestCase(StreamsConfig.GLOBAL_CONSUMER_PREFIX,
+                                        Map.of(StreamsConfig.GLOBAL_CONSUMER_PREFIX + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, "some.other.Interceptor"),
+                                        false,
+                                        Map.of(StreamsConfig.GLOBAL_CONSUMER_PREFIX + ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG,
+                                                "io.axual.utils.headers.cleaning.AxualHeaderCleaningInterceptor,some.other.Interceptor"))))
+        );
+    }
+
+    /**
+     * Test case class for testing the addCleanupInterceptor method.
+     * Contains input parameters and expected results for each test scenario.
+     */
+    static class InterceptorTestCase {
+        final String configPrefix;
+        final Map<String, Object> inputConfig;
+        final boolean addConfigIfMissing;
+        final Map<String, Object> expectedConfig;
+
+        /**
+         * Creates a new test case for the addCleanupInterceptor method.
+         *
+         * @param configPrefix The configuration prefix to pass to addCleanupInterceptor
+         * @param inputConfig The input configuration map to pass to addCleanupInterceptor
+         * @param addConfigIfMissing Whether to add the interceptor if the config is missing
+         * @param expectedConfig Map of key-value pairs expected in the result
+         */
+        InterceptorTestCase(String configPrefix, Map<String, Object> inputConfig, boolean addConfigIfMissing,
+                           Map<String, Object> expectedConfig) {
+            this.configPrefix = configPrefix;
+            this.inputConfig = new HashMap<>(inputConfig);
+            this.addConfigIfMissing = addConfigIfMissing;
+            this.expectedConfig = expectedConfig;
+        }
+    }
+
+    /**
+     * Tests the addCleanupInterceptor method with various scenarios.
+     *
+     * <p>This test verifies that the addCleanupInterceptor method:</p>
+     * <ul>
+     *     <li>Correctly handles different consumer prefixes</li>
+     *     <li>Adds the cleanup interceptor as the first interceptor when appropriate</li>
+     *     <li>Respects the {@code addConfigIfMissing} flag</li>
+     *     <li>Handles different formats of interceptor configuration</li>
+     *     <li>Preserves existing interceptors</li>
+     * </ul>
+     *
+     * @param testCase The test case containing input parameters and expected results
+     */
+    @ParameterizedTest
+    @DisplayName("Test addCleanupInterceptor method with various scenarios")
+    @MethodSource("interceptorTestData")
+    void testAddCleanupInterceptor(InterceptorTestCase testCase) {
+        // Create a runner to test the method
+        final var config = KafkaStreamsRunner.Config.builder()
+                .definitions(Map.of())
+                .kafkaConfig(INPUT_CONFIG_WITHOUT_PATTERNS)
+                .storageDirectory("tmp")
+                .build();
+
+        var runner = new KafkaStreamsRunner(config, (topology, properties) -> mock(KafkaStreams.class));
+
+        // Apply the interceptor logic
+        runner.addCleanupInterceptor(testCase.configPrefix, testCase.inputConfig, testCase.addConfigIfMissing);
+
+        // Verify the result
+        assertThat(testCase.inputConfig).containsAllEntriesOf(testCase.expectedConfig);
+        if (testCase.expectedConfig.isEmpty()) {
+            assertThat(testCase.inputConfig).isEmpty();
+        }
+    }
+
+    /**
+     * Tests error handling in the KafkaStreamsRunner.
+     *
+     * <p>This test verifies that:</p>
+     * <ul>
+     *     <li>When Kafka Streams is in an {@code ERROR} state, the runner reports a {@code FAILED} state</li>
+     *     <li>The runner throws a {@code RunnerException} when in a failed state</li>
+     *     <li>The runner properly starts and stops the Kafka Streams instance</li>
+     * </ul>
+     */
+    @Test
+    @DisplayName("Test error handling")
+    void testErrorHandling() throws Exception {
+        final var mockStreams = mock(KafkaStreams.class);
+        AtomicReference<KafkaStreams.State> streamState = new AtomicReference<>(KafkaStreams.State.CREATED);
+
+        // Mock the state method to return the current state from the AtomicReference
+        when(mockStreams.state()).thenAnswer(inv -> streamState.get());
+
+        // Create a runner with the mock
+        final var config = KafkaStreamsRunner.Config.builder()
+                .definitions(Map.of())
+                .kafkaConfig(INPUT_CONFIG_WITHOUT_PATTERNS)
+                .storageDirectory("tmp")
+                .build();
+
+        var runner = new KafkaStreamsRunner(config, (topology, properties) -> mockStreams);
+        runner.setSleepDurations(10, 10);
+
+        // Set up a thread to run the runner
+        final var thread = new Thread(runner);
+
+        try {
+            // Start in ERROR state
+            streamState.set(KafkaStreams.State.ERROR);
+
+            // Start the runner
+            thread.start();
+
+            // Wait for the thread to complete or timeout
+            thread.join(1000);
+
+            // Verify that the runner is not running
+            assertThat(runner.isRunning()).isFalse();
+            assertThat(runner.getState()).isEqualTo(Runner.State.FAILED);
+
+            // Verify that start was called
+            verify(mockStreams).start();
+
+            // We don't verify close() because the runner throws an exception before close() is called
+            // This is expected behavior when the streams are in ERROR state
+        } catch (Exception e) {
+            // If the thread throws an exception, make sure it's a RunnerException
+            assertThat(e).isInstanceOf(RunnerException.class)
+                    .hasMessage("Kafka Streams is in a failed state");
+        } finally {
+            // Make sure the thread is stopped
+            if (thread.isAlive()) {
+                runner.stop();
+                thread.join(1000);
+            }
+        }
+    }
+
+    /**
+     * Tests state transitions in the KafkaStreamsRunner.
+     *
+     * <p>This test verifies that:</p>
+     * <ul>
+     *     <li>The runner correctly maps Kafka Streams states to Runner states</li>
+     *     <li>The {@code isRunning} method correctly reports the running state based on the Kafka Streams state</li>
+     * </ul>
+     */
+    @Test
+    @DisplayName("Test state transitions")
+    void testStateTransitions() {
+        final var mockStreams = mock(KafkaStreams.class);
+
+        // Create a runner with the mock
+        final var config = KafkaStreamsRunner.Config.builder()
+                .definitions(Map.of())
+                .kafkaConfig(INPUT_CONFIG_WITHOUT_PATTERNS)
+                .storageDirectory("tmp")
+                .build();
+
+        var runner = new KafkaStreamsRunner(config, (topology, properties) -> mockStreams);
+
+        // Test all state mappings
+        when(mockStreams.state()).thenReturn(KafkaStreams.State.CREATED);
+        assertThat(runner.getState()).isEqualTo(Runner.State.CREATED);
+
+        when(mockStreams.state()).thenReturn(KafkaStreams.State.REBALANCING);
+        assertThat(runner.getState()).isEqualTo(Runner.State.STARTING);
+
+        when(mockStreams.state()).thenReturn(KafkaStreams.State.RUNNING);
+        assertThat(runner.getState()).isEqualTo(Runner.State.STARTED);
+
+        when(mockStreams.state()).thenReturn(KafkaStreams.State.PENDING_SHUTDOWN);
+        assertThat(runner.getState()).isEqualTo(Runner.State.STOPPING);
+
+        when(mockStreams.state()).thenReturn(KafkaStreams.State.NOT_RUNNING);
+        assertThat(runner.getState()).isEqualTo(Runner.State.STOPPED);
+
+        when(mockStreams.state()).thenReturn(KafkaStreams.State.PENDING_ERROR);
+        assertThat(runner.getState()).isEqualTo(Runner.State.FAILED);
+
+        when(mockStreams.state()).thenReturn(KafkaStreams.State.ERROR);
+        assertThat(runner.getState()).isEqualTo(Runner.State.FAILED);
+
+        // Test isRunning method
+        when(mockStreams.state()).thenReturn(KafkaStreams.State.CREATED);
+        assertThat(runner.isRunning()).isFalse();
+
+        when(mockStreams.state()).thenReturn(KafkaStreams.State.REBALANCING);
+        assertThat(runner.isRunning()).isTrue();
+
+        when(mockStreams.state()).thenReturn(KafkaStreams.State.RUNNING);
+        assertThat(runner.isRunning()).isTrue();
+
+        when(mockStreams.state()).thenReturn(KafkaStreams.State.PENDING_SHUTDOWN);
+        assertThat(runner.isRunning()).isTrue();
+
+        when(mockStreams.state()).thenReturn(KafkaStreams.State.NOT_RUNNING);
+        assertThat(runner.isRunning()).isFalse();
+
+        when(mockStreams.state()).thenReturn(KafkaStreams.State.ERROR);
+        assertThat(runner.isRunning()).isFalse();
+    }
+
+    /**
+     * Tests the lifecycle of the KafkaStreamsRunner.
+     *
+     * <p>This test verifies that:</p>
+     * <ul>
+     *     <li>The runner is correctly initialized with the provided configuration</li>
+     *     <li>The runner starts the Kafka Streams instance</li>
+     *     <li>The runner reports the correct state during execution</li>
+     *     <li>The runner can be stopped and properly closes the Kafka Streams instance</li>
+     * </ul>
+     */
     @Test
     @DisplayName("Check Kafka Streams lifecycle")
     void testStreamsRunner() throws Exception {
@@ -162,6 +692,8 @@ class KafkaStreamsRunnerTest {
                 .build();
 
         var runner = new KafkaStreamsRunner(config, mockStreamsSupplier);
+        // Set small sleep durations for faster test execution
+        runner.setSleepDurations(10, 10);
 
         // Check initial runner state
         assertThat(runner)
@@ -188,7 +720,7 @@ class KafkaStreamsRunnerTest {
             // Start runner, is blocked so check with async
             var future = CompletableFuture.runAsync(runner, executor);
 
-            verify(mockStreams, Mockito.timeout(60000).times(1)).start();
+            verify(mockStreams, Mockito.timeout(1000).times(1)).start();
             assertThat(future)
                     .as("Future should not have finished yet")
                     .isNotDone();
@@ -199,16 +731,19 @@ class KafkaStreamsRunnerTest {
             // Stop the runner
             runner.stop();
 
-
             Awaitility.await("Wait for runner to stop")
-                    .atMost(Duration.ofSeconds(10))
+                    .atMost(Duration.ofSeconds(1))
                     .until(future::isDone);
         }
     }
 
 
     /**
-     * Supplier for mock Kafka Streams
+     * A test helper class that implements {@code BiFunction} to supply mock KafkaStreams instances.
+     *
+     * <p>This class captures the topology and properties passed to it when creating
+     * KafkaStreams instances, allowing tests to verify that the correct configuration
+     * is being used.</p>
      */
     static class MockStreamsSupplier implements BiFunction<Topology, Properties, KafkaStreams> {
         final KafkaStreams mockKafkaStreams;

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
         <apache.commons.compress.version>1.27.1</apache.commons.compress.version>
         <apache.kafka.version>3.8.0</apache.kafka.version>
         <apicurio.version>2.6.8.Final</apicurio.version>
+        <axual.utils.version>1.0.0</axual.utils.version>
         <confluent.version>7.6.1</confluent.version>
         <findbugs.jsr305.version>3.0.2</findbugs.jsr305.version>
         <graalvm.version>23.1.2</graalvm.version>
@@ -339,6 +340,11 @@
                 <groupId>com.google.code.findbugs</groupId>
                 <artifactId>jsr305</artifactId>
                 <version>${findbugs.jsr305.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.axual.utils</groupId>
+                <artifactId>axual-header-cleaning</artifactId>
+                <version>${axual.utils.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Backport changes of  #224 to KSML 1.0
### Issue description

When using KSML on the Axual platform it can happen that the source topics contain records distributed from other Kafka Clusters.

These records are marked with special Kafka Header indicating that the record is already distributed, and should not be distributed again.

Kafka Streams copies record headers from the source records to all records produced in the defined streams.

These new records will not be distributed, as they are marked as already distributed.

This PR adds the Axual header cleaning interceptor to KSML

### Changes

- Added Axual Header Cleaning library to the KSML Runner module
- Updated the KafkaStreamsRunner module to add the interceptor to `consumer.interceptor.classes` if it does not defined there. The configuration property is added if none were defined
- Updated the KafkaStreamsRunner module to add the interceptor to `main.consumer.interceptor.classes`, `global.consumer.interceptor.classes` and `restore.consumer.interceptor.classes` if the property was already set
- Added tests for the KafkaStreamsRunner module
- Refactored the classes for easier testing
- Added documentation to the classes

### Tests

- Added unit tests
- Ran tests with local deployment, and copy example. Explicit Axual headers are not replicated anymore
- 