### PR TITLE
fix: resolve metric registration conflicts in multi-partition environ…

### DIFF
--- a/ksml/src/main/java/io/axual/ksml/metric/MetricsRegistry.java
+++ b/ksml/src/main/java/io/axual/ksml/metric/MetricsRegistry.java
@@ -184,7 +184,7 @@ public class MetricsRegistry {
     public synchronized void remove(MetricName metricName) {
         registeredMetrics.remove(metricName);
         metricRegistry.remove(encodeName(metricName));
-        log.warn("Removed metric: {}", metricName);
+        log.debug("Removed metric: {}", metricName);
     }
 
     /**


### PR DESCRIPTION
**Problem Summary**
When running KSML against a cloud Kafka cluster with multi-partition topics, the application was experiencing metric registration conflicts. Multiple Kafka Streams tasks (e.g., task-id=1_0, 1_1, 1_2) were creating metrics that mapped to identical KSML metric names, causing `MetricRegistrationException` errors. This issue didn't occur in local Docker Compose environments because those used single-partition topics.
The root cause was that the `KsmlTagEnricher` was dropping the task-id information when enriching Kafka metrics, causing metrics from different partitions to collide on the same metric name.

Original Kafka metric: 	
```
kafka_streams_stream_processor_node_metrics_record_e2e_latency_avg{processor_node_id="aggregate_pipelines_main_via_step5_peek",task_id="7_0",thread_id="io.axual.ksml.example.processor-9b065f98-2742-452a-8d0c-fff369d56bea-StreamThread-1"} 3051157.6666666665
```
	
Enriched KSML metric(old):
```
ksml_record_e2e_latency_min_ms_value{namespace="aggregate",operation_name="peek",pipeline="main",processor_node_id="aggregate_pipelines_main_via_step5_peek",step="5",unit="ms"} 175.0	
```

Enhanced toKsmlMetricName() to include three new metric tags:
- task_id: Original task identifier (e.g., "3_17")
- subtopology: Subtopology number (e.g., "3")
- partition: Partition number (e.g., "17")

New KSML metric:
```
ksml_record_e2e_latency_avg_ms_number{namespace="filter",operation_name="to",partition="1",pipeline="filter_pipeline",processor_node_id="filter_pipelines_filter_pipeline_to",subtopology="0",task_id="0_1",unit="ms"} 42.0
```