### PR TITLE
Some small improvements to data conversion and corresponding examples

### DIFF
--- a/examples/07-example-convert.yaml
+++ b/examples/07-example-convert.yaml
@@ -47,7 +47,7 @@ pipelines:
           code: log.info("STRING TO JSON - key={}, value={}", key, value)
       # Change notation from JSON to XML
       - type: convertValue
-        into: xml
+        into: xml:SensorData
         name: json_to_xml
       - type: peek
         forEach:
@@ -61,7 +61,7 @@ pipelines:
           code: log.info("XML TO STRING - key={}, value={}", key, value)
       # Convert back from String to XML
       - type: convertValue
-        into: xml
+        into: xml:SensorData
         name: string_to_xml
       - type: peek
         forEach:

--- a/examples/13-example-join.yaml
+++ b/examples/13-example-join.yaml
@@ -40,8 +40,6 @@ functions:
         for setting in value2["alertSettings"]:
           if setting["type"] == sensordata["type"] and setting["unit"] == sensordata["unit"] and ( (setting["alertBelow"] is not None and setting["alertBelow"] > sensordata["value"]) or (setting["alertAbove"] is not None and setting["alertAbove"] < sensordata["value"]) ):
             log.info('Triggered alert {}, type={}, unit={}, value={}, alertAbove={}, alertBelow={}', setting["name"], setting["type"], setting["unit"], sensordata["value"], setting["alertAbove"], setting["alertBelow"])
-            del setting["@type"]
-            del setting["@schema"]
             triggeredAlertSettings.append(setting)
 
       new_value={

--- a/examples/sensor_data.proto
+++ b/examples/sensor_data.proto
@@ -3,14 +3,21 @@ syntax = "proto3";
 package io.axual.ksml.example;
 
 message sensor_data {
-  string name = 1;                    // The name of the sensor
-  int64 timestamp = 2;                // The timestamp of the sensor reading
-  string value = 3;                   // The value of the sensor, represented as string
-  SensorType type = 4;                // The type of the sensor
-  string unit = 5;                    // The unit of the sensor
-  optional string color = 6;          // The color of the sensor
-  optional string city = 7;           // The city of the sensor
-  optional string owner = 8;          // The owner of the sensor
+  string name = 1;
+
+  int64 timestamp = 2;
+
+  string value = 3;
+
+  SensorType type = 4;
+
+  string unit = 5;
+
+  optional string color = 6;
+
+  optional string city = 7;
+
+  optional string owner = 8;
 
   enum SensorType {
     UNSPECIFIED = 0;

--- a/ksml-data-json/src/main/java/io/axual/ksml/data/notation/json/JsonDataObjectConverter.java
+++ b/ksml-data-json/src/main/java/io/axual/ksml/data/notation/json/JsonDataObjectConverter.java
@@ -47,7 +47,7 @@ public class JsonDataObjectConverter implements Notation.Converter {
         if (value instanceof DataString jsonString) {
             // Convert to structured JSON
             if (targetType instanceof ListType || targetType instanceof StructType || targetType instanceof UnionType) {
-                return DATA_OBJECT_MAPPER.toDataObject(jsonString.value());
+                return DATA_OBJECT_MAPPER.toDataObject(targetType, jsonString.value());
             }
         }
 

--- a/ksml-data-xml/src/main/java/io/axual/ksml/data/notation/xml/XmlDataObjectConverter.java
+++ b/ksml-data-xml/src/main/java/io/axual/ksml/data/notation/xml/XmlDataObjectConverter.java
@@ -39,7 +39,7 @@ public class XmlDataObjectConverter implements Notation.Converter {
 
         // Convert from String to Struct
         if (value instanceof DataString str && targetType instanceof StructType) {
-            return DATA_OBJECT_MAPPER.toDataObject(str.value());
+            return DATA_OBJECT_MAPPER.toDataObject(targetType, str.value());
         }
 
         // Return null if there is no conversion possible

--- a/ksml-data-xml/src/main/java/io/axual/ksml/data/notation/xml/XmlNotation.java
+++ b/ksml-data-xml/src/main/java/io/axual/ksml/data/notation/xml/XmlNotation.java
@@ -20,7 +20,6 @@ package io.axual.ksml.data.notation.xml;
  * =========================LICENSE_END==================================
  */
 
-import io.axual.ksml.data.mapper.DataObjectMapper;
 import io.axual.ksml.data.mapper.NativeDataObjectMapper;
 import io.axual.ksml.data.notation.string.StringNotation;
 import io.axual.ksml.data.type.DataType;
@@ -30,10 +29,15 @@ import org.apache.kafka.common.serialization.Serde;
 
 public class XmlNotation extends StringNotation {
     public static final DataType DEFAULT_TYPE = new StructType();
-    private static final DataObjectMapper<String> MAPPER = new XmlDataObjectMapper(true);
 
     public XmlNotation(String name, NativeDataObjectMapper nativeMapper) {
-        super(name, ".xsd", DEFAULT_TYPE, new XmlDataObjectConverter(), new XmlSchemaParser(), nativeMapper, MAPPER);
+        super(name,
+                ".xsd",
+                DEFAULT_TYPE,
+                new XmlDataObjectConverter(),
+                new XmlSchemaParser(),
+                nativeMapper,
+                new XmlDataObjectMapper(false));
     }
 
     @Override

--- a/ksml-data/src/main/java/io/axual/ksml/data/serde/StringSerde.java
+++ b/ksml-data/src/main/java/io/axual/ksml/data/serde/StringSerde.java
@@ -49,7 +49,7 @@ public class StringSerde implements Serde<Object> {
     @Override
     public Serializer<Object> serializer() {
         return (topic, data) -> {
-            final var dataObject = nativeMapper.toDataObject(data);
+            final var dataObject = nativeMapper.toDataObject(expectedType, data);
             if (!expectedType.isAssignableFrom(dataObject)) {
                 throw new DataException("Incorrect type passed in: expected=" + expectedType + ", got " + dataObject.type());
             }

--- a/ksml-data/src/main/java/io/axual/ksml/data/util/ConvertUtil.java
+++ b/ksml-data/src/main/java/io/axual/ksml/data/util/ConvertUtil.java
@@ -237,7 +237,7 @@ public class ConvertUtil {
         final var result = new DataStruct(structType.schema());
         for (final var entry : map.entrySet()) {
             final var targetType = structType.fieldType(entry.getKey(), DataType.UNKNOWN, DataType.UNKNOWN);
-            final var targetValue = dataObjectMapper.toDataObject(entry.getValue());
+            final var targetValue = dataObjectMapper.toDataObject(targetType, entry.getValue());
             if (!targetType.isAssignableFrom(targetValue))
                 throw convertError(targetValue != null ? targetValue.type() : null, targetType, targetValue);
             result.put(entry.getKey(), targetValue);
@@ -263,7 +263,7 @@ public class ConvertUtil {
         var index = 0;
         for (final var element : elements) {
             final var targetType = tupleType.subType(index);
-            final var targetValue = dataObjectMapper.toDataObject(tupleType.subType(index), element);
+            final var targetValue = dataObjectMapper.toDataObject(targetType, element);
             if (!targetType.isAssignableFrom(targetValue))
                 throw convertError(targetValue != null ? targetValue.type() : null, targetType, targetValue);
             tupleElements[index++] = targetValue;

--- a/ksml/src/main/java/io/axual/ksml/operation/ConvertKeyOperation.java
+++ b/ksml/src/main/java/io/axual/ksml/operation/ConvertKeyOperation.java
@@ -48,11 +48,11 @@ public class ConvertKeyOperation extends BaseOperation {
             return mapper.convert(k.userType().notation(), keyAsData, kr.userType());
         };
 
+        // Inject the mapper into the topology
         final var output = name != null
                 ? input.stream.selectKey(converter, Named.as(name))
                 : input.stream.selectKey(converter);
 
-        // Inject the mapper into the topology
         return new KStreamWrapper(output, kr, v);
     }
 }

--- a/ksml/src/main/java/io/axual/ksml/operation/ConvertKeyValueOperation.java
+++ b/ksml/src/main/java/io/axual/ksml/operation/ConvertKeyValueOperation.java
@@ -57,11 +57,11 @@ public class ConvertKeyValueOperation extends BaseOperation {
             return new KeyValue<>(convertedKey, convertedValue);
         };
 
+        // Inject the mapper into the topology
         final var output = name != null
                 ? input.stream.map(converter, Named.as(name))
                 : input.stream.map(converter);
 
-        // Inject the mapper into the topology
         return new KStreamWrapper(output, kr, vr);
     }
 }

--- a/ksml/src/main/java/io/axual/ksml/operation/ConvertValueOperation.java
+++ b/ksml/src/main/java/io/axual/ksml/operation/ConvertValueOperation.java
@@ -48,11 +48,11 @@ public class ConvertValueOperation extends BaseOperation {
             return mapper.convert(v.userType().notation(), valueAsData, vr.userType());
         };
 
+        // Inject the mapper into the topology
         final var output = name != null
                 ? input.stream.mapValues(converter, Named.as(name))
                 : input.stream.mapValues(converter);
 
-        // Inject the mapper into the topology
         return new KStreamWrapper(output, k, vr);
     }
 }


### PR DESCRIPTION
* Updates example 7 to convert to specific XML schema
* Fixes KeyError issue in example 13
* Update Protobuf schema since Apicurio only performs syntactical checks, not semantical (canonical)
* Makes expected type conversion explicit where possible for JSON, XML and StringSerde
* Don't pretty print XML output to Kafka (removes whitespaces in messages)
* Corrects some misplaced comment lines
