### PR TITLE
Add support for templated KSML tests

### DIFF
--- a/ksml/src/test/java/io/axual/ksml/data/mapper/DataFlattenerTest.java
+++ b/ksml/src/test/java/io/axual/ksml/data/mapper/DataFlattenerTest.java
@@ -1,5 +1,25 @@
 package io.axual.ksml.data.mapper;
 
+/*-
+ * ========================LICENSE_START=================================
+ * KSML
+ * %%
+ * Copyright (C) 2021 - 2025 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
 import io.axual.ksml.data.object.DataString;
 import io.axual.ksml.data.object.DataStruct;
 import org.apache.kafka.streams.kstream.Windowed;

--- a/ksml/src/test/java/io/axual/ksml/operation/KSMLAggregatePipelinesTest.java
+++ b/ksml/src/test/java/io/axual/ksml/operation/KSMLAggregatePipelinesTest.java
@@ -1,0 +1,67 @@
+package io.axual.ksml.operation;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML
+ * %%
+ * Copyright (C) 2021 - 2025 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import io.axual.ksml.testutil.*;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.TestOutputTopic;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class KSMLAggregatePipelinesTest {
+
+    @KSMLDriver
+    TopologyTestDriver testDriver;
+
+    @KSMLTopic(topic = "input_topic", valueSerde = KSMLTopic.SerdeType.LONG)
+    TestInputTopic<String, Long> inputTopic;
+
+    @KSMLTopic(topic = "output_topic", valueSerde = KSMLTopic.SerdeType.LONG)
+    TestOutputTopic<String, Long> outputTopic;
+
+    @KSMLTopologyTest(topologies = {"pipelines/test-aggregate-store.yaml", "pipelines/test-aggregate-inline.yaml"})
+    @DisplayName("aggregate should work with a named or inline keyValue store")
+    void testAggregate() {
+        // given that we send some numbers with the same key
+        inputTopic.pipeInput("key1", 1L);
+        inputTopic.pipeInput("key1", 2L);
+        inputTopic.pipeInput("key1", 3L);
+
+        // the table as a topic should show the values aggregagting
+        List<KeyValue<String, Long>> keyValues = outputTopic.readKeyValuesToList();
+        assertThat(keyValues).contains(
+                new KeyValue<>("key1", 1L),
+                new KeyValue<>("key1", 3L),
+                new KeyValue<>("key1", 6L)
+        );
+
+        // and the named keyvalue store should have the final result
+        KeyValueStore<String, Long> aggregateStore = testDriver.getKeyValueStore("aggregate_store");
+        assertThat(aggregateStore.get("key1")).isEqualTo(6L);
+    }
+}

--- a/ksml/src/test/java/io/axual/ksml/operation/KSMLMapValueAndAliasesTest.java
+++ b/ksml/src/test/java/io/axual/ksml/operation/KSMLMapValueAndAliasesTest.java
@@ -1,0 +1,154 @@
+package io.axual.ksml.operation;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML
+ * %%
+ * Copyright (C) 2021 - 2025 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import io.axual.ksml.testutil.KSMLTopic;
+import io.axual.ksml.testutil.KSMLTopologyTest;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.TestOutputTopic;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+
+import java.util.List;
+
+import static io.axual.ksml.operation.SensorData.SensorType.HUMIDITY;
+import static io.axual.ksml.operation.SensorData.SensorType.TEMPERATURE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Slf4j
+/**
+ * Test for mapValues and its aliases mapValue and transformValue
+ */
+public class KSMLMapValueAndAliasesTest {
+
+    @KSMLTopic(topic = "input_topic", valueSerde = KSMLTopic.SerdeType.AVRO)
+    TestInputTopic<String, GenericRecord> inputTopic;
+
+    @KSMLTopic(topic = "output_topic")
+    TestOutputTopic<String, String> outputTopic;
+
+    List<GenericRecord> inputs = List.of(
+            SensorData.builder().city("AMS").type(HUMIDITY).unit("%").value("80").build().toRecord(),
+            SensorData.builder().city("UTR").type(HUMIDITY).unit("%").value("75").build().toRecord(),
+            SensorData.builder().city("AMS").type(TEMPERATURE).unit("C").value("25").build().toRecord(),
+            SensorData.builder().city("UTR").type(TEMPERATURE).unit("C").value("27").build().toRecord()
+    );
+
+    @KSMLTopologyTest(
+            topologies = {
+                    "pipelines/test-mapvalues-expression.yaml",
+                    "pipelines/test-transformvalue-expression.yaml"},
+            schemaDirectory = "schemas")
+    @DisplayName("Values can be mapped with mapValue")
+    @Disabled("Annotation processing not fully working yet")
+    void testMapValueByExpression() {
+        inputs.forEach(rec -> inputTopic.pipeInput("key", rec));
+
+        var keyValues = outputTopic.readKeyValuesToList();
+        assertEquals(4, keyValues.size(), "All records should be transformed");
+
+        // verify first and last value; the pipeline creates them from fields in the input value
+        assertEquals("HUMIDITY 80", keyValues.get(0).value);
+        assertEquals("HUMIDITY 75", keyValues.get(1).value);
+        assertEquals("TEMPERATURE 25", keyValues.get(2).value);
+        assertEquals("TEMPERATURE 27", keyValues.get(3).value);
+    }
+
+//    @KSMLTest(topology = "pipelines/test-mapvalues-expression.yaml", schemaDirectory = "schemas")
+//    @DisplayName("Values can be mapped with mapValues with an expression")
+    void testMapValuesByExpression() {
+        inputs.forEach(rec -> inputTopic.pipeInput("key", rec));
+
+        var keyValues = outputTopic.readKeyValuesToList();
+        assertEquals(4, keyValues.size(), "All records should be transformed");
+
+        // verify first and last value; the pipeline creates them from fields in the input value
+        assertEquals("HUMIDITY 80", keyValues.get(0).value);
+        assertEquals("HUMIDITY 75", keyValues.get(1).value);
+        assertEquals("TEMPERATURE 25", keyValues.get(2).value);
+        assertEquals("TEMPERATURE 27", keyValues.get(3).value);
+    }
+
+//    @KSMLTest(topology = "pipelines/test-transformvalue-expression.yaml", schemaDirectory = "schemas")
+//    @DisplayName("Values can be mapped with transformValue with an expression")
+    void testTransformValueByExpression() {
+        inputs.forEach(rec -> inputTopic.pipeInput("key", rec));
+
+        var keyValues = outputTopic.readKeyValuesToList();
+        assertEquals(4, keyValues.size(), "All records should be transformed");
+
+        // verify first and last value; the pipeline creates them from fields in the input value
+        assertEquals("HUMIDITY 80", keyValues.get(0).value);
+        assertEquals("HUMIDITY 75", keyValues.get(1).value);
+        assertEquals("TEMPERATURE 25", keyValues.get(2).value);
+        assertEquals("TEMPERATURE 27", keyValues.get(3).value);
+    }
+
+//    @KSMLTest(topology = "pipelines/test-mapvalue-code.yaml", schemaDirectory = "schemas")
+//    @DisplayName("Values can be mapped with mapValue with a code block")
+    void testMapValueByCode() {
+        inputs.forEach(rec -> inputTopic.pipeInput("key", rec));
+
+        var keyValues = outputTopic.readKeyValuesToList();
+        assertEquals(4, keyValues.size(), "All records should be transformed");
+
+        // verify first and last record key and value; the pipeline creates them from fields in the record value
+        assertEquals("HUMIDITY 80", keyValues.get(0).value);
+        assertEquals("HUMIDITY 75", keyValues.get(1).value);
+        assertEquals("TEMPERATURE 25", keyValues.get(2).value);
+        assertEquals("TEMPERATURE 27", keyValues.get(3).value);
+    }
+
+//    @KSMLTest(topology = "pipelines/test-mapvalues-code.yaml", schemaDirectory = "schemas")
+//    @DisplayName("Values can be mapped with mapValues with a code block")
+    void testMapValuesByCode() {
+        inputs.forEach(rec -> inputTopic.pipeInput("key", rec));
+
+        var keyValues = outputTopic.readKeyValuesToList();
+        assertEquals(4, keyValues.size(), "All records should be transformed");
+
+        // verify first and last record key and value; the pipeline creates them from fields in the record value
+        assertEquals("HUMIDITY 80", keyValues.get(0).value);
+        assertEquals("HUMIDITY 75", keyValues.get(1).value);
+        assertEquals("TEMPERATURE 25", keyValues.get(2).value);
+        assertEquals("TEMPERATURE 27", keyValues.get(3).value);
+    }
+
+//    @KSMLTest(topology = "pipelines/test-transformvalue-code.yaml", schemaDirectory = "schemas")
+//    @DisplayName("Values can be mapped with transformValue with a code block")
+    void testTransformValueByCode() {
+        inputs.forEach(rec -> inputTopic.pipeInput("key", rec));
+
+        var keyValues = outputTopic.readKeyValuesToList();
+        assertEquals(4, keyValues.size(), "All records should be transformed");
+
+        // verify first and last record key and value; the pipeline creates them from fields in the record value
+        assertEquals("HUMIDITY 80", keyValues.get(0).value);
+        assertEquals("HUMIDITY 75", keyValues.get(1).value);
+        assertEquals("TEMPERATURE 25", keyValues.get(2).value);
+        assertEquals("TEMPERATURE 27", keyValues.get(3).value);
+    }
+}
+
+

--- a/ksml/src/test/java/io/axual/ksml/operation/KSMLMapValueAndAliasesTest.java
+++ b/ksml/src/test/java/io/axual/ksml/operation/KSMLMapValueAndAliasesTest.java
@@ -57,11 +57,14 @@ public class KSMLMapValueAndAliasesTest {
 
     @KSMLTopologyTest(
             topologies = {
+                    "pipelines/test-mapvalue-expression.yaml",
                     "pipelines/test-mapvalues-expression.yaml",
-                    "pipelines/test-transformvalue-expression.yaml"},
+                    "pipelines/test-transformvalue-expression.yaml",
+                    "pipelines/test-mapvalue-code.yaml",
+                    "pipelines/test-mapvalues-code.yaml",
+                    "pipelines/test-transformvalue-code.yaml"},
             schemaDirectory = "schemas")
-    @DisplayName("Values can be mapped with mapValue")
-    @Disabled("Annotation processing not fully working yet")
+    @DisplayName("Values can be mapped with mapValue and aliases")
     void testMapValueByExpression() {
         inputs.forEach(rec -> inputTopic.pipeInput("key", rec));
 
@@ -69,81 +72,6 @@ public class KSMLMapValueAndAliasesTest {
         assertEquals(4, keyValues.size(), "All records should be transformed");
 
         // verify first and last value; the pipeline creates them from fields in the input value
-        assertEquals("HUMIDITY 80", keyValues.get(0).value);
-        assertEquals("HUMIDITY 75", keyValues.get(1).value);
-        assertEquals("TEMPERATURE 25", keyValues.get(2).value);
-        assertEquals("TEMPERATURE 27", keyValues.get(3).value);
-    }
-
-//    @KSMLTest(topology = "pipelines/test-mapvalues-expression.yaml", schemaDirectory = "schemas")
-//    @DisplayName("Values can be mapped with mapValues with an expression")
-    void testMapValuesByExpression() {
-        inputs.forEach(rec -> inputTopic.pipeInput("key", rec));
-
-        var keyValues = outputTopic.readKeyValuesToList();
-        assertEquals(4, keyValues.size(), "All records should be transformed");
-
-        // verify first and last value; the pipeline creates them from fields in the input value
-        assertEquals("HUMIDITY 80", keyValues.get(0).value);
-        assertEquals("HUMIDITY 75", keyValues.get(1).value);
-        assertEquals("TEMPERATURE 25", keyValues.get(2).value);
-        assertEquals("TEMPERATURE 27", keyValues.get(3).value);
-    }
-
-//    @KSMLTest(topology = "pipelines/test-transformvalue-expression.yaml", schemaDirectory = "schemas")
-//    @DisplayName("Values can be mapped with transformValue with an expression")
-    void testTransformValueByExpression() {
-        inputs.forEach(rec -> inputTopic.pipeInput("key", rec));
-
-        var keyValues = outputTopic.readKeyValuesToList();
-        assertEquals(4, keyValues.size(), "All records should be transformed");
-
-        // verify first and last value; the pipeline creates them from fields in the input value
-        assertEquals("HUMIDITY 80", keyValues.get(0).value);
-        assertEquals("HUMIDITY 75", keyValues.get(1).value);
-        assertEquals("TEMPERATURE 25", keyValues.get(2).value);
-        assertEquals("TEMPERATURE 27", keyValues.get(3).value);
-    }
-
-//    @KSMLTest(topology = "pipelines/test-mapvalue-code.yaml", schemaDirectory = "schemas")
-//    @DisplayName("Values can be mapped with mapValue with a code block")
-    void testMapValueByCode() {
-        inputs.forEach(rec -> inputTopic.pipeInput("key", rec));
-
-        var keyValues = outputTopic.readKeyValuesToList();
-        assertEquals(4, keyValues.size(), "All records should be transformed");
-
-        // verify first and last record key and value; the pipeline creates them from fields in the record value
-        assertEquals("HUMIDITY 80", keyValues.get(0).value);
-        assertEquals("HUMIDITY 75", keyValues.get(1).value);
-        assertEquals("TEMPERATURE 25", keyValues.get(2).value);
-        assertEquals("TEMPERATURE 27", keyValues.get(3).value);
-    }
-
-//    @KSMLTest(topology = "pipelines/test-mapvalues-code.yaml", schemaDirectory = "schemas")
-//    @DisplayName("Values can be mapped with mapValues with a code block")
-    void testMapValuesByCode() {
-        inputs.forEach(rec -> inputTopic.pipeInput("key", rec));
-
-        var keyValues = outputTopic.readKeyValuesToList();
-        assertEquals(4, keyValues.size(), "All records should be transformed");
-
-        // verify first and last record key and value; the pipeline creates them from fields in the record value
-        assertEquals("HUMIDITY 80", keyValues.get(0).value);
-        assertEquals("HUMIDITY 75", keyValues.get(1).value);
-        assertEquals("TEMPERATURE 25", keyValues.get(2).value);
-        assertEquals("TEMPERATURE 27", keyValues.get(3).value);
-    }
-
-//    @KSMLTest(topology = "pipelines/test-transformvalue-code.yaml", schemaDirectory = "schemas")
-//    @DisplayName("Values can be mapped with transformValue with a code block")
-    void testTransformValueByCode() {
-        inputs.forEach(rec -> inputTopic.pipeInput("key", rec));
-
-        var keyValues = outputTopic.readKeyValuesToList();
-        assertEquals(4, keyValues.size(), "All records should be transformed");
-
-        // verify first and last record key and value; the pipeline creates them from fields in the record value
         assertEquals("HUMIDITY 80", keyValues.get(0).value);
         assertEquals("HUMIDITY 75", keyValues.get(1).value);
         assertEquals("TEMPERATURE 25", keyValues.get(2).value);

--- a/ksml/src/test/java/io/axual/ksml/testutil/KSMLTestExtension.java
+++ b/ksml/src/test/java/io/axual/ksml/testutil/KSMLTestExtension.java
@@ -192,10 +192,16 @@ public class KSMLTestExtension implements ExecutionCondition, BeforeAllCallback,
 
     @Override
     public void afterEach(ExtensionContext context) throws Exception {
-        if (context.getTestMethod().isEmpty()) return;         // not at method level
+        if (context.getTestMethod().isEmpty()) {
+            // not at method level
+            return;
+        }
         final var method = context.getTestMethod().get();
         final var annotation = method.getAnnotation(KSMLTest.class);
-        if (annotation == null) return;         // method was not annotated, nothing to do
+        if (annotation == null) {
+            // method was not annotated, nothing to do
+            return;
+        }
 
         // clean up
         log.debug("Clean up topology test driver");

--- a/ksml/src/test/java/io/axual/ksml/testutil/KSMLTopologyTest.java
+++ b/ksml/src/test/java/io/axual/ksml/testutil/KSMLTopologyTest.java
@@ -25,6 +25,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.lang.annotation.*;
 
+/**
+ * Method-level annotation to test multiple KSML topology definitions in one go.
+ */
 @Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @TestTemplate

--- a/ksml/src/test/java/io/axual/ksml/testutil/KSMLTopologyTest.java
+++ b/ksml/src/test/java/io/axual/ksml/testutil/KSMLTopologyTest.java
@@ -1,0 +1,47 @@
+package io.axual.ksml.testutil;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML
+ * %%
+ * Copyright (C) 2021 - 2025 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@TestTemplate
+@ExtendWith(KSMLTopologyTestContextProvider.class)
+public @interface KSMLTopologyTest {
+
+    String NO_SCHEMAS = "";
+
+    /**
+     * The topologies to test with the annotated method.
+     * @return
+     */
+    String[] topologies();
+
+    /**
+     * The directory where AVRO schema files for the tests can be found.
+     * @return
+     */
+    String schemaDirectory() default NO_SCHEMAS;
+}

--- a/ksml/src/test/java/io/axual/ksml/testutil/KSMLTopologyTestContextProvider.java
+++ b/ksml/src/test/java/io/axual/ksml/testutil/KSMLTopologyTestContextProvider.java
@@ -57,17 +57,25 @@ public class KSMLTopologyTestContextProvider implements TestTemplateInvocationCo
         return isAnnotated(context.getTestMethod(), KSMLTopologyTest.class);
     }
 
+    /**
+     * Set up test template invocation contexts for each listed pipeline definition.
+     * This method prepares test execution by scanning the test class for annotated fields ({@link KSMLTopic} and {@link KSMLDriver}
+     * annotated fields) which it will pass into each invocation context, to be handled by {@link KSMLTopologyTestExtension} when the test runs.
+     * @param context the extension context.
+     * @return a list containing one {@link KSMLTopologyTestInvocationContext} per configured KSML topology.
+     */
     @Override
     public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
         log.debug("provideTestTemplateInvocationContexts()");
 
-        Class<?> requiredTestClass = context.getRequiredTestClass();
         Map<String, KSMLTopic> inputTopics = new HashMap<>();
         Map<String, KSMLTopic> outputTopics = new HashMap<>();
         AtomicReference<String> testDriverRef = new AtomicReference<>();
-        Field[] declaredFields = requiredTestClass.getDeclaredFields();
 
+        Class<?> requiredTestClass = context.getRequiredTestClass();
+        Field[] declaredFields = requiredTestClass.getDeclaredFields();
         log.debug("Scanning class {} for annotated fields", requiredTestClass.getName());
+
         Arrays.stream(declaredFields).forEach(field -> {
             Class<?> type = field.getType();
             if (type.equals(TestInputTopic.class) && field.isAnnotationPresent(KSMLTopic.class)) {
@@ -89,7 +97,7 @@ public class KSMLTopologyTestContextProvider implements TestTemplateInvocationCo
         final String schemaDirectory = ksmlTopologyTest.schemaDirectory();
 
         // one-time preparation for the test runs: register notations
-        log.debug("Registering test notations");
+        log.debug("Registering notations in notationLibrary");
         final var mapper = new NativeDataObjectMapper();
         final var jsonNotation = new JsonNotation("json", mapper);
         ExecutionContext.INSTANCE.notationLibrary().register(new BinaryNotation(UserType.DEFAULT_NOTATION, mapper, jsonNotation::serde));

--- a/ksml/src/test/java/io/axual/ksml/testutil/KSMLTopologyTestContextProvider.java
+++ b/ksml/src/test/java/io/axual/ksml/testutil/KSMLTopologyTestContextProvider.java
@@ -1,0 +1,58 @@
+package io.axual.ksml.testutil;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML
+ * %%
+ * Copyright (C) 2021 - 2025 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+
+import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
+import static org.junit.platform.commons.support.AnnotationSupport.isAnnotated;
+
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+/**
+ * {@link TestTemplateInvocationContextProvider} that supports the {@link KSMLTopologyTest} annotation.
+ */
+@Slf4j
+public class KSMLTopologyTestContextProvider implements TestTemplateInvocationContextProvider {
+
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext context) {
+        log.debug("Checking for KSMLTopologyTest annotation");
+        return isAnnotated(context.getTestMethod(), KSMLTopologyTest.class);
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+        Method testMethod = context.getRequiredTestMethod();
+        String displayName = context.getDisplayName();
+        KSMLTopologyTest ksmlTopologyTest = findAnnotation(testMethod, KSMLTopologyTest.class).get();
+        final String schemaDirectory = ksmlTopologyTest.schemaDirectory();
+        return Arrays.stream(ksmlTopologyTest.topologies())
+                .map(topologyName -> new KSMLTopologyTestInvocationContext(topologyName, schemaDirectory, displayName)
+        );
+    }
+}

--- a/ksml/src/test/java/io/axual/ksml/testutil/KSMLTopologyTestExtension.java
+++ b/ksml/src/test/java/io/axual/ksml/testutil/KSMLTopologyTestExtension.java
@@ -56,21 +56,24 @@ public class KSMLTopologyTestExtension implements ExecutionCondition, BeforeAllC
     private TopologyTestDriver topologyTestDriver;
 
     /** Map of annotated {@link TestInputTopic} field names to their annotatopn. */
-    private final Map<String, KSMLTopic> inputTopics = new HashMap<>();
+    private final Map<String, KSMLTopic> inputTopics;
 
     /** Map of annotated {@link org.apache.kafka.streams.TestOutputTopic} to their annotations. */
-    private final Map<String, KSMLTopic> outputTopics = new HashMap<>();
+    private final Map<String, KSMLTopic> outputTopics;
 
     /** If present, name of a field of type {@link TopologyTestDriver} which should be linked by the extension.*/
-    private String testDriverRef;
+    private final String testDriverRef;
 
     private final String schemaDirectory;
 
     private final String topologyName;
 
-    public KSMLTopologyTestExtension(String schemaDirectory, String topologyName) {
+    public KSMLTopologyTestExtension(String schemaDirectory, String topologyName, Map<String, KSMLTopic> inputTopics, Map<String, KSMLTopic> outputTopics, String testDriverRef) {
+        this.inputTopics = inputTopics;
+        this.outputTopics = outputTopics;
         this.schemaDirectory = schemaDirectory;
         this.topologyName = topologyName;
+        this.testDriverRef = testDriverRef;
     }
 
     /**
@@ -100,29 +103,29 @@ public class KSMLTopologyTestExtension implements ExecutionCondition, BeforeAllC
     @Override
     public void beforeAll(ExtensionContext extensionContext) {
         log.debug("Registering test notations");
-        final var mapper = new NativeDataObjectMapper();
-        final var jsonNotation = new JsonNotation("json", mapper);
-        ExecutionContext.INSTANCE.notationLibrary().register(new BinaryNotation(UserType.DEFAULT_NOTATION, mapper, jsonNotation::serde));
-        ExecutionContext.INSTANCE.notationLibrary().register(jsonNotation);
+//        final var mapper = new NativeDataObjectMapper();
+//        final var jsonNotation = new JsonNotation("json", mapper);
+//        ExecutionContext.INSTANCE.notationLibrary().register(new BinaryNotation(UserType.DEFAULT_NOTATION, mapper, jsonNotation::serde));
+//        ExecutionContext.INSTANCE.notationLibrary().register(jsonNotation);
 
         log.debug("Registering annotated TestInputTopic, TestOutputTopic and TopologyTestDriver fields");
-        Class<?> requiredTestClass = extensionContext.getRequiredTestClass();
-        Field[] declaredFields = requiredTestClass.getDeclaredFields();
-        Arrays.stream(declaredFields).forEach(field -> {
-            Class<?> type = field.getType();
-            if (type.equals(TestInputTopic.class) && field.isAnnotationPresent(KSMLTopic.class)) {
-                KSMLTopic ksmlTopic = field.getAnnotation(KSMLTopic.class);
-                log.debug("Found annotated input topic field {}:{}", field.getName(), ksmlTopic);
-                inputTopics.put(field.getName(), ksmlTopic);
-            } else if (type.equals(org.apache.kafka.streams.TestOutputTopic.class) && field.isAnnotationPresent(KSMLTopic.class)) {
-                KSMLTopic ksmlTopic = field.getAnnotation(KSMLTopic.class);
-                log.debug("Found annotated output topic field {}:{}", field.getName(), ksmlTopic);
-                outputTopics.put(field.getName(), ksmlTopic);
-            } else if (type.equals(TopologyTestDriver.class) && field.isAnnotationPresent(KSMLDriver.class)) {
-                log.debug("Found annotated test driver field {}", field.getName());
-                testDriverRef = field.getName();
-            }
-        });
+//        Class<?> requiredTestClass = extensionContext.getRequiredTestClass();
+//        Field[] declaredFields = requiredTestClass.getDeclaredFields();
+//        Arrays.stream(declaredFields).forEach(field -> {
+//            Class<?> type = field.getType();
+//            if (type.equals(TestInputTopic.class) && field.isAnnotationPresent(KSMLTopic.class)) {
+//                KSMLTopic ksmlTopic = field.getAnnotation(KSMLTopic.class);
+//                log.debug("Found annotated input topic field {}:{}", field.getName(), ksmlTopic);
+//                inputTopics.put(field.getName(), ksmlTopic);
+//            } else if (type.equals(org.apache.kafka.streams.TestOutputTopic.class) && field.isAnnotationPresent(KSMLTopic.class)) {
+//                KSMLTopic ksmlTopic = field.getAnnotation(KSMLTopic.class);
+//                log.debug("Found annotated output topic field {}:{}", field.getName(), ksmlTopic);
+//                outputTopics.put(field.getName(), ksmlTopic);
+//            } else if (type.equals(TopologyTestDriver.class) && field.isAnnotationPresent(KSMLDriver.class)) {
+//                log.debug("Found annotated test driver field {}", field.getName());
+//                testDriverRef = field.getName();
+//            }
+//        });
     }
 
     @Override

--- a/ksml/src/test/java/io/axual/ksml/testutil/KSMLTopologyTestExtension.java
+++ b/ksml/src/test/java/io/axual/ksml/testutil/KSMLTopologyTestExtension.java
@@ -1,0 +1,267 @@
+package io.axual.ksml.testutil;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML
+ * %%
+ * Copyright (C) 2021 - 2024 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+import io.axual.ksml.TopologyGenerator;
+import io.axual.ksml.data.mapper.NativeDataObjectMapper;
+import io.axual.ksml.data.notation.avro.MockAvroNotation;
+import io.axual.ksml.data.notation.binary.BinaryNotation;
+import io.axual.ksml.data.notation.json.JsonNotation;
+import io.axual.ksml.definition.parser.TopologyDefinitionParser;
+import io.axual.ksml.execution.ExecutionContext;
+import io.axual.ksml.generator.YAMLObjectMapper;
+import io.axual.ksml.parser.ParseNode;
+import io.axual.ksml.type.UserType;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.serialization.*;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.TopologyDescription;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.graalvm.home.Version;
+import org.junit.jupiter.api.extension.*;
+
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.*;
+
+@Slf4j
+public class KSMLTopologyTestExtension implements ExecutionCondition, BeforeAllCallback, BeforeEachCallback, AfterEachCallback {
+
+    private final Set<Field> modifiedFields = new HashSet<>();
+
+    private TopologyTestDriver topologyTestDriver;
+
+    /** Map of annotated {@link TestInputTopic} field names to their annotatopn. */
+    private final Map<String, KSMLTopic> inputTopics = new HashMap<>();
+
+    /** Map of annotated {@link org.apache.kafka.streams.TestOutputTopic} to their annotations. */
+    private final Map<String, KSMLTopic> outputTopics = new HashMap<>();
+
+    /** If present, name of a field of type {@link TopologyTestDriver} which should be linked by the extension.*/
+    private String testDriverRef;
+
+    private final String schemaDirectory;
+
+    private final String topologyName;
+
+    public KSMLTopologyTestExtension(String schemaDirectory, String topologyName) {
+        this.schemaDirectory = schemaDirectory;
+        this.topologyName = topologyName;
+    }
+
+    /**
+     * Check if the test(s) are running on GraalVM.
+     *
+     * @param extensionContext the extension context
+     * @return enabled only if the test is running on GraalVM
+     */
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
+        if (extensionContext.getTestMethod().isEmpty()) {
+            // at class level verification
+            log.debug("Check for GraalVM");
+            if (Version.getCurrent().isRelease()) {
+                return ConditionEvaluationResult.enabled("running on GraalVM");
+            }
+            log.warn("KSML tests need GraalVM to run, test disabled");
+            extensionContext.publishReportEntry("KSML tests need GraalVM, test disabled");
+            return ConditionEvaluationResult.disabled("KSML tests need GraalVM to run");
+        }
+        return ConditionEvaluationResult.enabled("on method");
+    }
+
+    /**
+     * Register the required notations before executing the tests.
+     */
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) {
+        log.debug("Registering test notations");
+        final var mapper = new NativeDataObjectMapper();
+        final var jsonNotation = new JsonNotation("json", mapper);
+        ExecutionContext.INSTANCE.notationLibrary().register(new BinaryNotation(UserType.DEFAULT_NOTATION, mapper, jsonNotation::serde));
+        ExecutionContext.INSTANCE.notationLibrary().register(jsonNotation);
+
+        log.debug("Registering annotated TestInputTopic, TestOutputTopic and TopologyTestDriver fields");
+        Class<?> requiredTestClass = extensionContext.getRequiredTestClass();
+        Field[] declaredFields = requiredTestClass.getDeclaredFields();
+        Arrays.stream(declaredFields).forEach(field -> {
+            Class<?> type = field.getType();
+            if (type.equals(TestInputTopic.class) && field.isAnnotationPresent(KSMLTopic.class)) {
+                KSMLTopic ksmlTopic = field.getAnnotation(KSMLTopic.class);
+                log.debug("Found annotated input topic field {}:{}", field.getName(), ksmlTopic);
+                inputTopics.put(field.getName(), ksmlTopic);
+            } else if (type.equals(org.apache.kafka.streams.TestOutputTopic.class) && field.isAnnotationPresent(KSMLTopic.class)) {
+                KSMLTopic ksmlTopic = field.getAnnotation(KSMLTopic.class);
+                log.debug("Found annotated output topic field {}:{}", field.getName(), ksmlTopic);
+                outputTopics.put(field.getName(), ksmlTopic);
+            } else if (type.equals(TopologyTestDriver.class) && field.isAnnotationPresent(KSMLDriver.class)) {
+                log.debug("Found annotated test driver field {}", field.getName());
+                testDriverRef = field.getName();
+            }
+        });
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        StreamsBuilder streamsBuilder = new StreamsBuilder();
+        if (extensionContext.getTestMethod().isEmpty()) {
+            return;
+        }
+
+        // get the annotation on the method
+        log.debug("Setting up KSML test");
+        final var method = extensionContext.getTestMethod().get();
+        final var methodName = method.getName();
+
+        if (!KSMLTopologyTestInvocationContext.NO_SCHEMAS.equals(schemaDirectory)) {
+            log.debug("Configured schema directory: `{}`", schemaDirectory);
+            final var schemaDirectoryURI = ClassLoader.getSystemResource(schemaDirectory).toURI();
+            final var schemaDirectory = schemaDirectoryURI.getPath();
+            ExecutionContext.INSTANCE.schemaLibrary().schemaDirectory(schemaDirectory);
+            log.debug("Registered schema directory: {}", schemaDirectory);
+        } else {
+            ExecutionContext.INSTANCE.schemaLibrary().schemaDirectory(KSMLTest.NO_SCHEMAS);
+        }
+
+        ExecutionContext.INSTANCE.notationLibrary().register(new MockAvroNotation(new HashMap<>()));
+
+        // Get the KSML definition classpath relative path and load the topology into the test driver
+        log.debug("Loading topology {}", topologyName);
+        final var uri = ClassLoader.getSystemResource(topologyName).toURI();
+        final var path = Paths.get(uri);
+        final var definition = YAMLObjectMapper.INSTANCE.readValue(Files.readString(path), JsonNode.class);
+        final var definitions = ImmutableMap.of("definition",
+                new TopologyDefinitionParser("test").parse(ParseNode.fromRoot(definition, methodName)));
+        var topologyGenerator = new TopologyGenerator(methodName + ".app");
+        final var topology = topologyGenerator.create(streamsBuilder, definitions);
+        final TopologyDescription description = topology.describe();
+        System.out.println(description);
+        topologyTestDriver = new TopologyTestDriver(topology);
+
+        // create in- and output topics and assign them to variables in the test
+        Class<?> testClass = extensionContext.getRequiredTestClass();
+        Object testInstance = extensionContext.getRequiredTestInstance();
+
+        log.debug("Registering annotated fields");
+        for (Map.Entry<String, KSMLTopic> entry : inputTopics.entrySet()) {
+            String fieldName = entry.getKey();
+            KSMLTopic ksmlTopic = entry.getValue();
+            log.debug("Set variable {} to topic {}", fieldName, ksmlTopic.topic());
+            Field inputTopicField = testClass.getDeclaredField(fieldName);
+            inputTopicField.setAccessible(true);
+            inputTopicField.set(testInstance, topologyTestDriver.createInputTopic(ksmlTopic.topic(), getKeySerializer(ksmlTopic), getValueSerializer(ksmlTopic)));
+            modifiedFields.add(inputTopicField);
+        }
+        for (Map.Entry<String, KSMLTopic> entry : outputTopics.entrySet()) {
+            String fieldName = entry.getKey();
+            KSMLTopic ksmlTopic = entry.getValue();
+            log.debug("Set variable {} to topic {}", fieldName, ksmlTopic.topic());
+            Field outputTopicField = testClass.getDeclaredField(fieldName);
+            outputTopicField.setAccessible(true);
+            outputTopicField.set(testInstance, topologyTestDriver.createOutputTopic(ksmlTopic.topic(), getKeyDeserializer(ksmlTopic), getValueDeserializer(ksmlTopic)));
+            modifiedFields.add(outputTopicField);
+        }
+
+        // if a variable is configured for the test driver reference, set the reference
+        if (testDriverRef != null) {
+            log.debug("Set variable {} to test driver", testDriverRef);
+            Field testDriverField = testClass.getDeclaredField(testDriverRef);
+            testDriverField.setAccessible(true);
+            testDriverField.set(testInstance, topologyTestDriver);
+            modifiedFields.add(testDriverField);
+        }
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        if (context.getTestMethod().isEmpty()) return;         // not at method level
+        final var method = context.getTestMethod().get();
+        final var annotation = method.getAnnotation(KSMLTest.class);
+        if (annotation == null) return;         // method was not annotated, nothing to do
+
+        // clean up
+        log.debug("Clean up topology test driver");
+        if (topologyTestDriver != null) {
+            topologyTestDriver.close();
+            topologyTestDriver = null;
+        }
+
+        // clear any set fields
+        log.debug("clean up test instance variables");
+        final var testInstance = context.getRequiredTestInstance();
+        for (Field field : modifiedFields) {
+            log.debug("Clearing {}", field.getName());
+            field.setAccessible(true);
+            field.set(testInstance, null);
+        }
+        modifiedFields.clear();
+    }
+
+    private Serializer<?> getKeySerializer(KSMLTopic ksmlTopic) {
+        return getSerializer(ksmlTopic, true);
+    }
+
+    private Serializer<?> getValueSerializer(KSMLTopic ksmlTopic) {
+        return getSerializer(ksmlTopic, false);
+    }
+
+    private Serializer<?> getSerializer(KSMLTopic ksmlTopic, boolean isKey) {
+        return switch (isKey ? ksmlTopic.keySerde() : ksmlTopic.valueSerde()) {
+            case AVRO -> {
+                final var avroNotation = (MockAvroNotation) ExecutionContext.INSTANCE.notationLibrary().get(MockAvroNotation.NAME);
+                final var result = new KafkaAvroSerializer(avroNotation.mockSchemaRegistryClient());
+                result.configure(avroNotation.getSchemaRegistryConfigs(), isKey);
+                yield result;
+            }
+            case STRING -> new StringSerializer();
+            case LONG -> new LongSerializer();
+            case INTEGER -> new IntegerSerializer();
+        };
+    }
+
+    private Deserializer<?> getKeyDeserializer(KSMLTopic kamlTopic) {
+        return getDeserializer(kamlTopic, true);
+    }
+
+    private Deserializer<?> getValueDeserializer(KSMLTopic kamlTopic) {
+        return getDeserializer(kamlTopic, false);
+    }
+
+    private Deserializer<?> getDeserializer(KSMLTopic kamlTopic, boolean isKey) {
+        return switch (isKey ? kamlTopic.keySerde() : kamlTopic.valueSerde()) {
+            case AVRO -> {
+                final var avroNotation = (MockAvroNotation) ExecutionContext.INSTANCE.notationLibrary().get(MockAvroNotation.NAME);
+                final var result = new KafkaAvroDeserializer(avroNotation.mockSchemaRegistryClient());
+                result.configure(avroNotation.getSchemaRegistryConfigs(), isKey);
+                yield result;
+            }
+            case STRING -> new StringDeserializer();
+            case LONG -> new LongDeserializer();
+            case INTEGER -> new IntegerDeserializer();
+        };
+    }
+}

--- a/ksml/src/test/java/io/axual/ksml/testutil/KSMLTopologyTestInvocationContext.java
+++ b/ksml/src/test/java/io/axual/ksml/testutil/KSMLTopologyTestInvocationContext.java
@@ -1,0 +1,41 @@
+package io.axual.ksml.testutil;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML
+ * %%
+ * Copyright (C) 2021 - 2025 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+
+import java.util.List;
+
+public record KSMLTopologyTestInvocationContext(String topologyName, String schemaDirectory, String displayName) implements TestTemplateInvocationContext {
+
+    public static final String NO_SCHEMAS = "";
+
+    @Override
+    public String getDisplayName(int invocationIndex) {
+        return invocationIndex + ": " + topologyName;
+    }
+
+    @Override
+    public List<Extension> getAdditionalExtensions() {
+        return List.of(new KSMLTopologyTestExtension(schemaDirectory, topologyName));
+    }
+}

--- a/ksml/src/test/java/io/axual/ksml/testutil/KSMLTopologyTestInvocationContext.java
+++ b/ksml/src/test/java/io/axual/ksml/testutil/KSMLTopologyTestInvocationContext.java
@@ -24,8 +24,13 @@ import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 
 import java.util.List;
+import java.util.Map;
 
-public record KSMLTopologyTestInvocationContext(String topologyName, String schemaDirectory, String displayName) implements TestTemplateInvocationContext {
+public record KSMLTopologyTestInvocationContext(String topologyName,
+                                                String schemaDirectory,
+                                                Map<String, KSMLTopic> inputTopics,
+                                                Map<String, KSMLTopic> outputTopics,
+                                                String testDriverRef) implements TestTemplateInvocationContext {
 
     public static final String NO_SCHEMAS = "";
 
@@ -36,6 +41,6 @@ public record KSMLTopologyTestInvocationContext(String topologyName, String sche
 
     @Override
     public List<Extension> getAdditionalExtensions() {
-        return List.of(new KSMLTopologyTestExtension(schemaDirectory, topologyName));
+        return List.of(new KSMLTopologyTestExtension(schemaDirectory, topologyName, inputTopics, outputTopics, testDriverRef));
     }
 }

--- a/ksml/src/test/resources/pipelines/test-aggregate-inline.yaml
+++ b/ksml/src/test/resources/pipelines/test-aggregate-inline.yaml
@@ -1,3 +1,4 @@
+# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
 streams:
   input_stream:
     topic: input_topic
@@ -16,6 +17,7 @@ pipelines:
       - type: groupByKey
       - type: aggregate
         store:
+          name: aggregate_store
           type: keyValue
           keyType: string
           valueType: long


### PR DESCRIPTION
Since some KSML operations have multiple aliases and/or can be configured in different ways, the current tests have some duplication where the same code is just annotated with a different pipeline definition.

This PR adds a new annotation `@KSMLTopologyTest` which can be provided with a list of KSML topologies; it will then run the test for each topology. `@KSMLTopic` and `@KSMLDriver` annotations are supported as before, as well as the `schemaDirectory` parameter for AVRO support.
The test class no longer needs an `@ExtendsWith` anntation, this is handled with the code that manages the new annotation.

Usage example: 
```java
    @KSMLTopologyTest(
            topologies = {
                    "pipelines/test-mapvalue-expression.yaml",
                    "pipelines/test-mapvalues-expression.yaml",
                    "pipelines/test-transformvalue-expression.yaml",
                    "pipelines/test-mapvalue-code.yaml",
                    "pipelines/test-mapvalues-code.yaml",
                    "pipelines/test-transformvalue-code.yaml"},
            schemaDirectory = "schemas")
    @DisplayName("Values can be mapped with mapValue and aliases")
    void testMapValueByExpression() {

```
