### PR TITLE
Fix Docker build for Intel mac

### DIFF
--- a/ksml/src/test/java/io/axual/ksml/BasicStreamRunTest.java
+++ b/ksml/src/test/java/io/axual/ksml/BasicStreamRunTest.java
@@ -68,7 +68,7 @@ class BasicStreamRunTest {
         ExecutionContext.INSTANCE.notationLibrary().register(jsonNotation);
 
         try {
-            final var schemaDirectoryURI = ClassLoader.getSystemResource("pipelines").toURI();
+            final var schemaDirectoryURI = ClassLoader.getSystemResource("schemas").toURI();
             final var schemaDirectory = schemaDirectoryURI.getPath();
             System.out.println("schemaDirectory = " + schemaDirectory);
             ExecutionContext.INSTANCE.schemaLibrary().schemaDirectory(schemaDirectory);


### PR DESCRIPTION
Fixes #248 (but may need further discussion and code change, see below). 

The Docker build on Intel Mac fails due to a failing test (`BasicStreamRunTest`). 
The cause of the error is in line 71 and following where a schema directory is set up. The schemas were moved to a separate directory `schemas` in an earlier PR but this class was overlooked  and still referred to `pipelines`.

The build works on other systems, this is most probably because of timing. `ExecutionContext` is a singleton instance which holds an instance of `SchemaLibrary`, since there are multiple tests that refer the `sensorData` schema, if a test runs earlier which loads the schema from the correct location, this test will work. If it is run first, it will fail.

For production runs the ExecutionContext is set up only once and the problem does not surface.

This PR fixes the location issue.