### PR TITLE
Regenerate ksml-language-spec.json from Maven (on demand)

### DIFF
--- a/ksml-runner/pom.xml
+++ b/ksml-runner/pom.xml
@@ -182,6 +182,43 @@
                     </execution>
                 </executions>
             </plugin>
+
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>regenerate-schema</id>
+            <activation>
+                <property>
+                    <name>regenerate-schema</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <id>generate-ksml-schema</id>
+                                <phase>process-classes</phase>
+                                <goals>
+                                    <goal>java</goal>
+                                </goals>
+                                <configuration>
+                                    <mainClass>io.axual.ksml.runner.KSMLRunner</mainClass>
+                                    <commandlineArgs>--schema ${ksml.schema.output.file}</commandlineArgs>
+                                    <classpathScope>compile</classpathScope>
+                                    <includeProjectDependencies>true</includeProjectDependencies>
+                                    <includePluginDependencies>false</includePluginDependencies>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/ksml-runner/pom.xml
+++ b/ksml-runner/pom.xml
@@ -199,7 +199,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
-                        <version>3.1.0</version>
+                        <version>${maven.exec.plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>generate-ksml-schema</id>

--- a/ksml-runner/pom.xml
+++ b/ksml-runner/pom.xml
@@ -183,42 +183,29 @@
                 </executions>
             </plugin>
 
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>${maven.exec.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate-ksml-schema</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>io.axual.ksml.runner.KSMLRunner</mainClass>
+                            <commandlineArgs>--schema ${ksml.schema.output.file}</commandlineArgs>
+                            <classpathScope>compile</classpathScope>
+                            <includeProjectDependencies>true</includeProjectDependencies>
+                            <includePluginDependencies>false</includePluginDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 
-    <profiles>
-        <profile>
-            <id>regenerate-schema</id>
-            <activation>
-                <property>
-                    <name>regenerate-schema</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <version>${maven.exec.plugin.version}</version>
-                        <executions>
-                            <execution>
-                                <id>generate-ksml-schema</id>
-                                <phase>process-classes</phase>
-                                <goals>
-                                    <goal>java</goal>
-                                </goals>
-                                <configuration>
-                                    <mainClass>io.axual.ksml.runner.KSMLRunner</mainClass>
-                                    <commandlineArgs>--schema ${ksml.schema.output.file}</commandlineArgs>
-                                    <classpathScope>compile</classpathScope>
-                                    <includeProjectDependencies>true</includeProjectDependencies>
-                                    <includePluginDependencies>false</includePluginDependencies>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,9 @@
         <slf4j.version>2.1.0-alpha1</slf4j.version>
         <wire.version>5.2.0</wire.version>
 
+        <!-- KSML schema generation -->
+        <ksml.schema.output.file>docs/ksml-language-spec.json</ksml.schema.output.file>
+
         <!-- Test dependency versions -->
         <assertj.version>3.27.4</assertj.version>
         <awaitility.version>4.3.0</awaitility.version>
@@ -768,6 +771,7 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
             </plugin>
+
         </plugins>
 
         <resources>


### PR DESCRIPTION
Added an invocation of the Maven exec plugin to call KSMLRunner to re-generate `docs/ksml-language-spec.json`.
The call is conditional, to regenerate the schema add a property to the Maven invocation:
```
mvn clean test -Dregenerate-schema
```
The schema location is configurable through a property in the root pom.