### PR TITLE
Mike `--allow-empty` flag

### DIFF
--- a/.github/workflows/build-release-docs.yml
+++ b/.github/workflows/build-release-docs.yml
@@ -36,6 +36,6 @@ jobs:
       - name: Build Docs Site
         id: deployment
         run: |
-          mike deploy --push --update-aliases ${{ github.event.release.tag_name || github.event.inputs.tag_name }}
-          mike set-default --push ${{ github.event.release.tag_name || github.event.inputs.tag_name }}
-          mike alias --push --update-aliases ${{ github.event.release.tag_name || github.event.inputs.tag_name }} latest
+          mike deploy --push --update-aliases --allow-empty ${{ github.event.release.tag_name || github.event.inputs.tag_name }}
+          mike set-default --push --allow-empty ${{ github.event.release.tag_name || github.event.inputs.tag_name }}
+          mike alias --push --update-aliases --allow-empty ${{ github.event.release.tag_name || github.event.inputs.tag_name }} latest


### PR DESCRIPTION
Added --allow-empty flag to all three mike commands in the workflow. This allows mike to create commits even when there are no changes to the documentation, which is useful for re-running deployments or when only metadata needs updating.