### PR TITLE
Update example header references to ksml-language-spec.json

### DIFF
--- a/examples/00-example-dump-messages.yaml
+++ b/examples/00-example-dump-messages.yaml
@@ -1,4 +1,4 @@
-# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
+# $schema: https://axual.github.io/ksml/latest/ksml-language-spec.json
 
 # This example shows how to read from a binary stream, manipulate specific bytes and output
 # messages on a target stream. For validation purposes a second pipeline outputs the manipulated

--- a/examples/00-example-generate-alertsettings.yaml
+++ b/examples/00-example-generate-alertsettings.yaml
@@ -1,4 +1,4 @@
-# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
+# $schema: https://axual.github.io/ksml/latest/ksml-language-spec.json
 
 # This example shows how to generate data and have it sent to a target topic in a given format.
 

--- a/examples/00-example-generate-sensordata-avro-batch.yaml
+++ b/examples/00-example-generate-sensordata-avro-batch.yaml
@@ -1,4 +1,4 @@
-# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
+# $schema: https://axual.github.io/ksml/latest/ksml-language-spec.json
 
 # This example shows how to generate data and have it sent to a target topic in a given format.
 

--- a/examples/00-example-generate-sensordata-avro.yaml
+++ b/examples/00-example-generate-sensordata-avro.yaml
@@ -1,4 +1,4 @@
-# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
+# $schema: https://axual.github.io/ksml/latest/ksml-language-spec.json
 
 # This example shows how to generate data and have it sent to a target topic in a given format.
 

--- a/examples/00-example-generate-sensordata-binary.yaml
+++ b/examples/00-example-generate-sensordata-binary.yaml
@@ -1,4 +1,4 @@
-# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
+# $schema: https://axual.github.io/ksml/latest/ksml-language-spec.json
 
 # This example shows how to generate data and have it sent to a target topic in a given format.
 

--- a/examples/00-example-generate-sensordata-jsonschema.yaml
+++ b/examples/00-example-generate-sensordata-jsonschema.yaml
@@ -1,4 +1,4 @@
-# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
+# $schema: https://axual.github.io/ksml/latest/ksml-language-spec.json
 
 # This example shows how to generate data and have it sent to a target topic in a given format.
 

--- a/examples/00-example-generate-sensordata-protobuf.yaml
+++ b/examples/00-example-generate-sensordata-protobuf.yaml
@@ -1,4 +1,4 @@
-# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
+# $schema: https://axual.github.io/ksml/latest/ksml-language-spec.json
 
 # This example shows how to generate data and have it sent to a target topic in a given format.
 

--- a/examples/01-example-inspect.yaml
+++ b/examples/01-example-inspect.yaml
@@ -1,4 +1,4 @@
-# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
+# $schema: https://axual.github.io/ksml/latest/ksml-language-spec.json
 
 # This example shows how to read from different streams and log all messages
 

--- a/examples/02-example-copy.yaml
+++ b/examples/02-example-copy.yaml
@@ -1,4 +1,4 @@
-# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
+# $schema: https://axual.github.io/ksml/latest/ksml-language-spec.json
 
 # This example shows how to read from a simple stream and copy every message to a target topic.
 

--- a/examples/03-example-filter.yaml
+++ b/examples/03-example-filter.yaml
@@ -1,4 +1,4 @@
-# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
+# $schema: https://axual.github.io/ksml/latest/ksml-language-spec.json
 
 # This example shows how to filter messages from a simple stream. Here we
 # only let "blue sensors" pass and discard other messages.

--- a/examples/04-example-branch.yaml
+++ b/examples/04-example-branch.yaml
@@ -1,4 +1,4 @@
-# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
+# $schema: https://axual.github.io/ksml/latest/ksml-language-spec.json
 
 # This example shows how to branch processing of messages from a simple stream. Here we fork processing of "blue
 # sensors" and "red sensors" into a separate branch each. All other sensors will be processed in a default branch.

--- a/examples/05-example-route.yaml
+++ b/examples/05-example-route.yaml
@@ -1,4 +1,4 @@
-# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
+# $schema: https://axual.github.io/ksml/latest/ksml-language-spec.json
 
 # This example shows how to route messages to a dynamic topic. The target topic is the result of an executed function.
 

--- a/examples/06-example-duplicate.yaml
+++ b/examples/06-example-duplicate.yaml
@@ -1,4 +1,4 @@
-# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
+# $schema: https://axual.github.io/ksml/latest/ksml-language-spec.json
 
 streams:
   sensor_source:

--- a/examples/07-example-convert.yaml
+++ b/examples/07-example-convert.yaml
@@ -1,4 +1,4 @@
-# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
+# $schema: https://axual.github.io/ksml/latest/ksml-language-spec.json
 
 # This example shows how to read from a simple AVRO stream, then perform a series of conversions:
 #

--- a/examples/08-example-count.yaml
+++ b/examples/08-example-count.yaml
@@ -1,4 +1,4 @@
-# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
+# $schema: https://axual.github.io/ksml/latest/ksml-language-spec.json
 
 # This example shows how to read from a simple stream, group by owner, apply windows and count owners per window.
 

--- a/examples/09-example-aggregate.yaml
+++ b/examples/09-example-aggregate.yaml
@@ -1,4 +1,4 @@
-# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
+# $schema: https://axual.github.io/ksml/latest/ksml-language-spec.json
 
 # This example shows how to read from a simple stream, group by owner, apply windows and count owners per window.
 

--- a/examples/09-example-aggregate2.yaml
+++ b/examples/09-example-aggregate2.yaml
@@ -1,4 +1,4 @@
-# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
+# $schema: https://axual.github.io/ksml/latest/ksml-language-spec.json
 
 # This example shows how to read from a simple stream, group by owner, apply windows and count owners per window.
 

--- a/examples/10-example-queryable-table.yaml
+++ b/examples/10-example-queryable-table.yaml
@@ -1,4 +1,4 @@
-# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
+# $schema: https://axual.github.io/ksml/latest/ksml-language-spec.json
 
 # This example shows how to read from a simple stream, filter records and store the results in a queryable table.
 

--- a/examples/11-example-field-modification.yaml
+++ b/examples/11-example-field-modification.yaml
@@ -1,4 +1,4 @@
-# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
+# $schema: https://axual.github.io/ksml/latest/ksml-language-spec.json
 
 # This example shows how to read from an AVRO stream, modify a specific field and output to a target
 # stream. For validation purposes a second pipeline outputs the modified results.

--- a/examples/12-example-byte-manipulation.yaml
+++ b/examples/12-example-byte-manipulation.yaml
@@ -1,4 +1,4 @@
-# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
+# $schema: https://axual.github.io/ksml/latest/ksml-language-spec.json
 
 # This example shows how to read from a binary stream, manipulate specific bytes and output
 # messages on a target stream. For validation purposes a second pipeline outputs the manipulated

--- a/examples/13-example-join.yaml
+++ b/examples/13-example-join.yaml
@@ -1,4 +1,4 @@
-# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
+# $schema: https://axual.github.io/ksml/latest/ksml-language-spec.json
 
 # This example shows how to read sensor data from an Avro stream, join with the alert settings stored in a table and
 # produce alerts on a topic for the sensor data that should trigger alerts

--- a/examples/14-example-manual-state-store.yaml
+++ b/examples/14-example-manual-state-store.yaml
@@ -1,4 +1,4 @@
-# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
+# $schema: https://axual.github.io/ksml/latest/ksml-language-spec.json
 
 # This example shows how to use a manually defined state store
 

--- a/examples/15-example-pipeline-linking.yaml
+++ b/examples/15-example-pipeline-linking.yaml
@@ -1,4 +1,4 @@
-# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
+# $schema: https://axual.github.io/ksml/latest/ksml-language-spec.json
 
 # This example shows how to read from four simple streams and log all messages
 

--- a/examples/16-example-transform-metadata.yaml
+++ b/examples/16-example-transform-metadata.yaml
@@ -1,4 +1,4 @@
-# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
+# $schema: https://axual.github.io/ksml/latest/ksml-language-spec.json
 
 # This example shows how to transform timestamp and header information of messages
 

--- a/examples/17-example-inspect-with-metrics.yaml
+++ b/examples/17-example-inspect-with-metrics.yaml
@@ -1,4 +1,4 @@
-# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
+# $schema: https://axual.github.io/ksml/latest/ksml-language-spec.json
 
 # This example shows how to read from four simple streams and log all messages
 

--- a/examples/18-example-timestamp-extractor.yaml
+++ b/examples/18-example-timestamp-extractor.yaml
@@ -1,4 +1,4 @@
-# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
+# $schema: https://axual.github.io/ksml/latest/ksml-language-spec.json
 
 # This example shows how to apply a timestamp extractor and offset reset policy to an input stream
 

--- a/examples/19-example-performance-measurement.yaml
+++ b/examples/19-example-performance-measurement.yaml
@@ -1,4 +1,4 @@
-# $schema: https://raw.githubusercontent.com/Axual/ksml/refs/heads/release/1.0.x/docs/ksml-language-spec.json
+# $schema: https://axual.github.io/ksml/latest/ksml-language-spec.json
 
 # This example behaves similarly to example 2 (copy) but includes Python code to measure KSML's performance. It does
 # so by storing the message count and startup timestamp in global variables, and outputting log statements every 100


### PR DESCRIPTION
Update the references to ksml-language-spec.json in all example definitions. The new reference always points to the latest release version in the `docs` folder.