### PR TITLE
Fix JsonSchema type for Prometheus Config file, add bootstrap servers and documentation for JsonSchema

### DIFF
--- a/docs/ksml-runner-spec.json
+++ b/docs/ksml-runner-spec.json
@@ -134,10 +134,15 @@
       "type" : "object",
       "properties" : {
         "application.id" : {
-          "type" : "string"
+          "type" : "string",
+          "description" : "An identifier for the stream processing application. Must be unique within the Kafka cluster. It is used as 1) the default client-id prefix, 2) the group-id for membership management, 3) the changelog topic prefix."
+        },
+        "bootstrap.servers" : {
+          "type" : "string",
+          "description" : "A list of host/port pairs used to establish the initial connection to the Kafka cluster.\nClients use this list to bootstrap and discover the full set of Kafka brokers.\nWhile the order of servers in the list does not matter, we recommend including more than one server to ensure resilience if any servers are down.\nThis list does not need to contain the entire set of brokers, as Kafka clients automatically manage and update connections to the cluster efficiently.\nThis list must be in the form 'host1:port1,host2:port2,...'"
         }
       },
-      "required" : [ "application.id" ],
+      "required" : [ "application.id", "bootstrap.servers" ],
       "description" : "Contains the Kafka Streams configuration options, like bootstrap servers, application ids, etc",
       "additionalProperties" : {
         "type" : [ "string", "number", "integer", "boolean" ]
@@ -185,15 +190,12 @@
         "$ref" : "#/$defs/NotationConfig"
       }
     },
-    "Path" : {
-      "type" : "object",
-      "additionalProperties" : false
-    },
     "PrometheusConfig" : {
       "type" : "object",
       "properties" : {
         "configFile" : {
-          "$ref" : "#/$defs/Path"
+          "type" : "string",
+          "description" : "Path to a Prometheus JMX Exporter configuration file, containing metrics exposure and naming rules. If not set an internal definition is used."
         },
         "enabled" : {
           "type" : "boolean",

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/config/KSMLRunnerConfig.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/config/KSMLRunnerConfig.java
@@ -21,14 +21,16 @@ package io.axual.ksml.runner.config;
  */
 
 
-import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import org.apache.kafka.streams.StreamsConfig;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -90,14 +92,29 @@ public class KSMLRunnerConfig {
         }
 
         @Nonnull
-        @JsonProperty(value = "application.id", required = true)
+        @JsonProperty(value = StreamsConfig.APPLICATION_ID_CONFIG, required = true)
+        @JsonPropertyDescription("An identifier for the stream processing application. Must be unique within the Kafka cluster. It is used as 1) the default client-id prefix, 2) the group-id for membership management, 3) the changelog topic prefix.")
         private String applicationId;
+
+        @Nonnull
+        @JsonProperty(value = StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, required = true)
+        @JsonPropertyDescription("""
+                A list of host/port pairs used to establish the initial connection to the Kafka cluster. 
+                Clients use this list to bootstrap and discover the full set of Kafka brokers.
+                While the order of servers in the list does not matter, we recommend including more than one server to ensure resilience if any servers are down. 
+                This list does not need to contain the entire set of brokers, as Kafka clients automatically manage and update connections to the cluster efficiently.
+                This list must be in the form 'host1:port1,host2:port2,...' """)
+        private String bootstrapServers;
 
         @Override
         public String put(final String property, final String value) {
-            if ("application.id".equals(property)) {
+            if (StreamsConfig.APPLICATION_ID_CONFIG.equals(property)) {
                 this.applicationId = value;
             }
+            if (StreamsConfig.BOOTSTRAP_SERVERS_CONFIG.equals(property)) {
+                this.bootstrapServers = value;
+            }
+
             return super.put(property, value);
         }
 

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/config/PrometheusConfig.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/config/PrometheusConfig.java
@@ -31,7 +31,6 @@ import org.apache.commons.io.IOUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.Optional;
 
 import jakarta.annotation.Nonnull;
@@ -88,7 +87,8 @@ public class PrometheusConfig {
 
     /** Optional path to an explicit Prometheus exporter configuration file. */
     @JsonProperty(value = "configFile", required = false)
-    private Path configFile;
+    @JsonPropertyDescription("Path to a Prometheus JMX Exporter configuration file, containing metrics exposure and naming rules. If not set an internal definition is used.")
+    private String configFile;
 
     /**
      * Resolve the bind host. Returns null when the exporter is disabled so callers can interpret
@@ -143,6 +143,6 @@ public class PrometheusConfig {
         if (configFile == null) {
             return getDefaultConfigFile();
         }
-        return configFile.toFile();
+        return new File(configFile);
     }
 }


### PR DESCRIPTION
The generated JsonSchema uses an Object for PrometheusConfig configFile. Changed Java type to String to fix this, and added a small description for the JsonSchema.

Also added Bootstrap Servers as a required KafkaConfig and copied the Kafka (Streams) ApplicationId and Bootstrap Servers documentation as JsonSchema descriptions.