### PR TITLE
fix equality bug in DataStruct

### DIFF
--- a/ksml-data/src/main/java/io/axual/ksml/data/object/DataStruct.java
+++ b/ksml-data/src/main/java/io/axual/ksml/data/object/DataStruct.java
@@ -244,7 +244,7 @@ public class DataStruct implements DataObject {
     public <T> T getAs(String key, Class<T> clazz, T defaultValue) {
         final var value = get(key);
         if (value != null && clazz.isAssignableFrom(value.getClass())) {
-            return (T) value;
+            return clazz.cast(value);
         }
         return defaultValue;
     }
@@ -380,7 +380,7 @@ public class DataStruct implements DataObject {
         // Compare contents
         if (!flags.isSet(IGNORE_DATA_STRUCT_CONTENTS) && (contents != null || that.contents != null)) {
             if (contents == null || that.contents == null) return EqualUtil.objectNotEqual(this, that);
-            final var contentsEqual = equalContents(that, that, flags);
+            final var contentsEqual = equalContents(this, that, flags);
             if (contentsEqual.isNotEqual()) return objectNotEqual(this, that, contentsEqual);
         }
 

--- a/ksml-data/src/test/java/io/axual/ksml/data/object/DataListTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/object/DataListTest.java
@@ -20,6 +20,8 @@ package io.axual.ksml.data.object;
  * =========================LICENSE_END==================================
  */
 
+import io.axual.ksml.data.compare.Equality;
+import io.axual.ksml.data.compare.EqualityFlags;
 import io.axual.ksml.data.type.DataType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -98,5 +100,53 @@ class DataListTest {
         // Despite being null, DataList prints as empty list per current implementation
         assertThat(nul.toString(INTERNAL)).isEqualTo("[]");
         assertThat(nul.toString(EXTERNAL_TOP_SCHEMA)).isEqualTo("ListOfString: []");
+    }
+
+    @Test
+    @DisplayName("equals(Object, EqualityFlags) returns equal for lists with identical contents")
+    void flaggedEqualsSameContents() {
+        var a = new DataList(DataType.UNKNOWN);
+        a.add(new DataInteger(1));
+        a.add(new DataString("x"));
+
+        var b = new DataList(DataType.UNKNOWN);
+        b.add(new DataInteger(1));
+        b.add(new DataString("x"));
+
+        Equality result = a.equals(b, EqualityFlags.EMPTY);
+        assertThat(result.isEqual())
+                .as("Lists with identical contents should be equal")
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("equals(Object, EqualityFlags) returns not-equal for lists with different elements")
+    void flaggedEqualsDifferentElements() {
+        var a = new DataList(DataType.UNKNOWN);
+        a.add(new DataInteger(1));
+
+        var b = new DataList(DataType.UNKNOWN);
+        b.add(new DataInteger(2));
+
+        Equality result = a.equals(b, EqualityFlags.EMPTY);
+        assertThat(result.isNotEqual())
+                .as("Lists with different elements should NOT be equal")
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("equals(Object, EqualityFlags) returns not-equal for lists with different sizes")
+    void flaggedEqualsDifferentSizes() {
+        var a = new DataList(DataType.UNKNOWN);
+        a.add(new DataInteger(1));
+
+        var b = new DataList(DataType.UNKNOWN);
+        b.add(new DataInteger(1));
+        b.add(new DataInteger(2));
+
+        Equality result = a.equals(b, EqualityFlags.EMPTY);
+        assertThat(result.isNotEqual())
+                .as("Lists with different sizes should NOT be equal")
+                .isTrue();
     }
 }

--- a/ksml-data/src/test/java/io/axual/ksml/data/object/DataMapTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/object/DataMapTest.java
@@ -20,6 +20,8 @@ package io.axual.ksml.data.object;
  * =========================LICENSE_END==================================
  */
 
+import io.axual.ksml.data.compare.Equality;
+import io.axual.ksml.data.compare.EqualityFlags;
 import io.axual.ksml.data.type.DataType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -115,5 +117,50 @@ class DataMapTest {
         assertThat(map.toString(EXTERNAL_NO_SCHEMA)).isEqualTo("{\"a\": \"x\", \"b\": 2}");
         assertThat(map.toString(EXTERNAL_TOP_SCHEMA)).isEqualTo("MapOfUnknown: {\"a\": \"x\", \"b\": 2}");
         assertThat(map.toString(EXTERNAL_ALL_SCHEMA)).isEqualTo("MapOfUnknown: {\"a\": \"x\", \"b\": 2}");
+    }
+
+    @Test
+    @DisplayName("equals(Object, EqualityFlags) returns equal for maps with identical contents")
+    void flaggedEqualsSameContents() {
+        var a = new DataMap(DataType.UNKNOWN);
+        a.put("key", new DataString("value"));
+
+        var b = new DataMap(DataType.UNKNOWN);
+        b.put("key", new DataString("value"));
+
+        Equality result = a.equals(b, EqualityFlags.EMPTY);
+        assertThat(result.isEqual())
+                .as("Maps with identical contents should be equal")
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("equals(Object, EqualityFlags) returns not-equal for maps with different values")
+    void flaggedEqualsDifferentValues() {
+        var a = new DataMap(DataType.UNKNOWN);
+        a.put("key", new DataString("value1"));
+
+        var b = new DataMap(DataType.UNKNOWN);
+        b.put("key", new DataString("value2"));
+
+        Equality result = a.equals(b, EqualityFlags.EMPTY);
+        assertThat(result.isNotEqual())
+                .as("Maps with different values should NOT be equal")
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("equals(Object, EqualityFlags) returns not-equal for maps with different keys")
+    void flaggedEqualsDifferentKeys() {
+        var a = new DataMap(DataType.UNKNOWN);
+        a.put("key1", new DataString("value"));
+
+        var b = new DataMap(DataType.UNKNOWN);
+        b.put("key2", new DataString("value"));
+
+        Equality result = a.equals(b, EqualityFlags.EMPTY);
+        assertThat(result.isNotEqual())
+                .as("Maps with different keys should NOT be equal")
+                .isTrue();
     }
 }

--- a/ksml-data/src/test/java/io/axual/ksml/data/object/DataStructTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/object/DataStructTest.java
@@ -20,6 +20,8 @@ package io.axual.ksml.data.object;
  * =========================LICENSE_END==================================
  */
 
+import io.axual.ksml.data.compare.Equality;
+import io.axual.ksml.data.compare.EqualityFlags;
 import io.axual.ksml.data.schema.StructSchema;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -116,5 +118,50 @@ class DataStructTest {
         assertThat(a)
                 .isEqualTo(b)
                 .isNotEqualTo(c);
+    }
+
+    @Test
+    @DisplayName("equals(Object, EqualityFlags) returns equal for structs with identical contents")
+    void flaggedEqualsSameContents() {
+        var a = new DataStruct();
+        a.put("key", new DataString("value"));
+
+        var b = new DataStruct();
+        b.put("key", new DataString("value"));
+
+        Equality result = a.equals(b, EqualityFlags.EMPTY);
+        assertThat(result.isEqual())
+                .as("Structs with identical contents should be equal")
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("equals(Object, EqualityFlags) returns not-equal for structs with different contents")
+    void flaggedEqualsDifferentContents() {
+        var a = new DataStruct();
+        a.put("key", new DataString("value1"));
+
+        var b = new DataStruct();
+        b.put("key", new DataString("value2"));
+
+        Equality result = a.equals(b, EqualityFlags.EMPTY);
+        assertThat(result.isNotEqual())
+                .as("Structs with different contents should NOT be equal")
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("equals(Object, EqualityFlags) returns not-equal for structs with different keys")
+    void flaggedEqualsDifferentKeys() {
+        var a = new DataStruct();
+        a.put("key1", new DataString("value"));
+
+        var b = new DataStruct();
+        b.put("key2", new DataString("value"));
+
+        Equality result = a.equals(b, EqualityFlags.EMPTY);
+        assertThat(result.isNotEqual())
+                .as("Structs with different keys should NOT be equal")
+                .isTrue();
     }
 }

--- a/ksml-data/src/test/java/io/axual/ksml/data/object/DataTupleTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/object/DataTupleTest.java
@@ -20,6 +20,8 @@ package io.axual.ksml.data.object;
  * =========================LICENSE_END==================================
  */
 
+import io.axual.ksml.data.compare.Equality;
+import io.axual.ksml.data.compare.EqualityFlags;
 import io.axual.ksml.data.type.TupleType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -55,5 +57,41 @@ class DataTupleTest {
         assertThat(t.toString(EXTERNAL_NO_SCHEMA)).isEqualTo("(1, \"x\")");
         assertThat(t.toString(EXTERNAL_TOP_SCHEMA)).isEqualTo("TupleOfIntegerAndString: (1, \"x\")");
         assertThat(t.toString(EXTERNAL_ALL_SCHEMA)).isEqualTo("TupleOfIntegerAndString: (1, \"x\")");
+    }
+
+    @Test
+    @DisplayName("equals(Object, EqualityFlags) returns equal for tuples with identical elements")
+    void flaggedEqualsSameElements() {
+        var a = new DataTuple(new DataInteger(1), new DataString("x"));
+        var b = new DataTuple(new DataInteger(1), new DataString("x"));
+
+        Equality result = a.equals(b, EqualityFlags.EMPTY);
+        assertThat(result.isEqual())
+                .as("Tuples with identical elements should be equal")
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("equals(Object, EqualityFlags) returns not-equal for tuples with different elements")
+    void flaggedEqualsDifferentElements() {
+        var a = new DataTuple(new DataInteger(1), new DataString("x"));
+        var b = new DataTuple(new DataInteger(2), new DataString("x"));
+
+        Equality result = a.equals(b, EqualityFlags.EMPTY);
+        assertThat(result.isNotEqual())
+                .as("Tuples with different elements should NOT be equal")
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("equals(Object, EqualityFlags) returns not-equal for tuples with different sizes")
+    void flaggedEqualsDifferentSizes() {
+        var a = new DataTuple(new DataInteger(1));
+        var b = new DataTuple(new DataInteger(1), new DataString("x"));
+
+        Equality result = a.equals(b, EqualityFlags.EMPTY);
+        assertThat(result.isNotEqual())
+                .as("Tuples with different sizes should NOT be equal")
+                .isTrue();
     }
 }


### PR DESCRIPTION
Stumbled upon a bug in DataStruct where it passed the same argument to `contentEquals()` twice (so always content equals). 
This PR adds tests covering the equality check and fixes the bug.