### PR TITLE
Draft: Clean up: simplify notation constructors

### DIFF
--- a/ksml-data-avro/src/main/java/io/axual/ksml/data/notation/avro/AvroNotation.java
+++ b/ksml-data-avro/src/main/java/io/axual/ksml/data/notation/avro/AvroNotation.java
@@ -36,12 +36,32 @@ public class AvroNotation extends VendorNotation {
     public static final DataType DEFAULT_TYPE = new StructType();
     private static final AvroSchemaParser AVRO_SCHEMA_PARSER = new AvroSchemaParser();
 
-    /**
-     * Construct an AvroNotation with the provided vendor context.
-     *
-     * @param context the vendor notation context providing serde supplier, native mapper, and configs
-     */
     public AvroNotation(VendorNotationContext context) {
-        super(AvroNotation.NOTATION_NAME, context, ".avsc", DEFAULT_TYPE, null, AVRO_SCHEMA_PARSER);
+        super(context);
+    }
+
+    @Override
+    public String notationName() {
+        return NOTATION_NAME;
+    }
+
+    @Override
+    public String filenameExtension() {
+        return ".avsc";
+    }
+
+    @Override
+    public DataType defaultType() {
+        return DEFAULT_TYPE;
+    }
+
+    @Override
+    public Converter converter() {
+        return null;
+    }
+
+    @Override
+    public SchemaParser schemaParser() {
+        return AVRO_SCHEMA_PARSER;
     }
 }

--- a/ksml-data-binary/src/main/java/io/axual/ksml/data/notation/binary/BinaryNotation.java
+++ b/ksml-data-binary/src/main/java/io/axual/ksml/data/notation/binary/BinaryNotation.java
@@ -40,7 +40,7 @@ public class BinaryNotation extends BaseNotation {
     private final SerdeSupplier complexTypeSerdeSupplier;
 
     public BinaryNotation() {
-        this(null);
+        this(null, null);
     }
 
     public BinaryNotation(SerdeSupplier complexTypeSerdeSupplier) {
@@ -48,8 +48,38 @@ public class BinaryNotation extends BaseNotation {
     }
 
     public BinaryNotation(NotationContext context, SerdeSupplier complexTypeSerdeSupplier) {
-        super(NOTATION_NAME, context, null, SchemaUsage.SCHEMALESS_ONLY, DEFAULT_TYPE, null, null);
+        super(context);
         this.complexTypeSerdeSupplier = complexTypeSerdeSupplier;
+    }
+
+    @Override
+    public String notationName() {
+        return NOTATION_NAME;
+    }
+
+    @Override
+    public String filenameExtension() {
+        return null;
+    }
+
+    @Override
+    public SchemaUsage schemaUsage() {
+        return SchemaUsage.SCHEMALESS_ONLY;
+    }
+
+    @Override
+    public DataType defaultType() {
+        return DEFAULT_TYPE;
+    }
+
+    @Override
+    public Converter converter() {
+        return null;
+    }
+
+    @Override
+    public SchemaParser schemaParser() {
+        return null;
     }
 
     @Override

--- a/ksml-data-csv/src/main/java/io/axual/ksml/data/notation/csv/CsvNotation.java
+++ b/ksml-data-csv/src/main/java/io/axual/ksml/data/notation/csv/CsvNotation.java
@@ -20,33 +20,70 @@ package io.axual.ksml.data.notation.csv;
  * =========================LICENSE_END==================================
  */
 
+import io.axual.ksml.data.mapper.DataObjectMapper;
 import io.axual.ksml.data.notation.NotationContext;
 import io.axual.ksml.data.notation.string.StringNotation;
 import io.axual.ksml.data.type.DataType;
 import io.axual.ksml.data.type.ListType;
 import io.axual.ksml.data.type.StructType;
 import io.axual.ksml.data.type.UnionType;
-import lombok.Getter;
 import org.apache.kafka.common.serialization.Serde;
 
-@Getter
 public class CsvNotation extends StringNotation {
     public static final String NOTATION_NAME = "csv";
     public static final DataType DEFAULT_TYPE = new UnionType(
             new UnionType.Member(new StructType()),
             new UnionType.Member(new ListType()));
+    private static final CsvDataObjectConverter CONVERTER = new CsvDataObjectConverter();
+    private static final CsvSchemaParser SCHEMA_PARSER = new CsvSchemaParser();
+    private static final CsvDataObjectMapper STRING_MAPPER = new CsvDataObjectMapper();
 
     public CsvNotation() {
         this(null);
     }
 
     public CsvNotation(NotationContext context) {
-        super(NOTATION_NAME, context, ".csv", SchemaUsage.SCHEMA_REQUIRED, DEFAULT_TYPE, new CsvDataObjectConverter(), new CsvSchemaParser(), new CsvDataObjectMapper());
+        super(context);
+    }
+
+    @Override
+    public String notationName() {
+        return NOTATION_NAME;
+    }
+
+    @Override
+    public String filenameExtension() {
+        return ".csv";
+    }
+
+    @Override
+    public SchemaUsage schemaUsage() {
+        return SchemaUsage.SCHEMA_REQUIRED;
+    }
+
+    @Override
+    public DataType defaultType() {
+        return DEFAULT_TYPE;
+    }
+
+    @Override
+    public Converter converter() {
+        return CONVERTER;
+    }
+
+    @Override
+    public SchemaParser schemaParser() {
+        return SCHEMA_PARSER;
+    }
+
+    @Override
+    protected DataObjectMapper<String> stringMapper() {
+        return STRING_MAPPER;
     }
 
     @Override
     public Serde<Object> serde(DataType type, boolean isKey) {
-        // CSV types should ways be Lists, Structs or the union of them both
+        // CSV types should always be Lists, Structs or the union of them both
         if (type instanceof ListType || type instanceof StructType || DEFAULT_TYPE.equals(type))
             return super.serde(type, isKey);
         // Other types cannot be serialized as CSV

--- a/ksml-data-json/src/main/java/io/axual/ksml/data/notation/json/JsonNotation.java
+++ b/ksml-data-json/src/main/java/io/axual/ksml/data/notation/json/JsonNotation.java
@@ -58,6 +58,8 @@ public class JsonNotation extends BaseNotation {
     public static final DataType DEFAULT_TYPE = new UnionType(
             new UnionType.Member(new StructType()),
             new UnionType.Member(new ListType()));
+    private static final JsonDataObjectConverter CONVERTER = new JsonDataObjectConverter();
+    private static final JsonSchemaLoader SCHEMA_PARSER = new JsonSchemaLoader();
 
     /**
      * Creates a JsonNotation with a default {@link NotationContext}.
@@ -71,8 +73,37 @@ public class JsonNotation extends BaseNotation {
      * The filename extension is fixed to ".json".
      */
     public JsonNotation(NotationContext context) {
-        // Wire the BaseNotation with the JSON-specific converter and schema loader.
-        super(NOTATION_NAME, context, ".json", SchemaUsage.SCHEMALESS_ONLY, DEFAULT_TYPE, new JsonDataObjectConverter(), new JsonSchemaLoader());
+        super(context);
+    }
+
+    @Override
+    public String notationName() {
+        return NOTATION_NAME;
+    }
+
+    @Override
+    public String filenameExtension() {
+        return ".json";
+    }
+
+    @Override
+    public SchemaUsage schemaUsage() {
+        return SchemaUsage.SCHEMALESS_ONLY;
+    }
+
+    @Override
+    public DataType defaultType() {
+        return DEFAULT_TYPE;
+    }
+
+    @Override
+    public Converter converter() {
+        return CONVERTER;
+    }
+
+    @Override
+    public SchemaParser schemaParser() {
+        return SCHEMA_PARSER;
     }
 
     /**

--- a/ksml-data-jsonschema/src/main/java/io/axual/ksml/data/notation/jsonschema/JsonSchemaNotation.java
+++ b/ksml-data-jsonschema/src/main/java/io/axual/ksml/data/notation/jsonschema/JsonSchemaNotation.java
@@ -31,34 +31,41 @@ import io.axual.ksml.data.type.UnionType;
 
 /**
  * JSON Schema notation implementation for KSML using vendor-backed serdes.
- *
- * <p>Responsibilities:</p>
- * <ul>
- *   <li>Expose the notation name {@link #NOTATION_NAME} ("jsonschema").</li>
- *   <li>Define the default data type as a union of {@link StructType} and {@link ListType}
- *       to support both JSON objects and arrays.</li>
- *   <li>Wire a converter ({@link JsonDataObjectConverter}) and schema parser ({@link JsonSchemaLoader}).</li>
- *   <li>Create vendor-backed serdes via {@link VendorNotation} when types are assignable from the default type.</li>
- * </ul>
  */
 public class JsonSchemaNotation extends VendorNotation {
-    /**
-     * Canonical notation name for JSON Schema.
-     */
     public static final String NOTATION_NAME = "jsonschema";
-    /**
-     * Default supported data type: union of Struct and List.
-     */
     public static final DataType DEFAULT_TYPE = new UnionType(
             new UnionType.Member(new StructType()),
             new UnionType.Member(new ListType()));
+    private static final JsonDataObjectConverter CONVERTER = new JsonDataObjectConverter();
+    private static final JsonSchemaLoader SCHEMA_PARSER = new JsonSchemaLoader();
 
-    /**
-     * Creates a JsonSchemaNotation with the provided vendor context.
-     * The filename extension is ".json" to match JSON Schema files.
-     */
     public JsonSchemaNotation(VendorNotationContext context) {
-        // Wire the VendorNotation with JSON-specific converter and schema loader.
-        super(JsonSchemaNotation.NOTATION_NAME, context, ".json", DEFAULT_TYPE, new JsonDataObjectConverter(), new JsonSchemaLoader());
+        super(context);
+    }
+
+    @Override
+    public String notationName() {
+        return NOTATION_NAME;
+    }
+
+    @Override
+    public String filenameExtension() {
+        return ".json";
+    }
+
+    @Override
+    public DataType defaultType() {
+        return DEFAULT_TYPE;
+    }
+
+    @Override
+    public Converter converter() {
+        return CONVERTER;
+    }
+
+    @Override
+    public SchemaParser schemaParser() {
+        return SCHEMA_PARSER;
     }
 }

--- a/ksml-data-protobuf/src/main/java/io/axual/ksml/data/notation/protobuf/ProtobufNotation.java
+++ b/ksml-data-protobuf/src/main/java/io/axual/ksml/data/notation/protobuf/ProtobufNotation.java
@@ -28,8 +28,35 @@ import io.axual.ksml.data.type.StructType;
 public class ProtobufNotation extends VendorNotation {
     public static final String NOTATION_NAME = "protobuf";
     public static final DataType DEFAULT_TYPE = new StructType();
+    private final ProtobufSchemaParser protobufSchemaParser;
 
     public ProtobufNotation(VendorNotationContext context, ProtobufSchemaParser schemaParser) {
-        super(NOTATION_NAME, context, ".proto", DEFAULT_TYPE, null, schemaParser);
+        super(context);
+        this.protobufSchemaParser = schemaParser;
+    }
+
+    @Override
+    public String notationName() {
+        return NOTATION_NAME;
+    }
+
+    @Override
+    public String filenameExtension() {
+        return ".proto";
+    }
+
+    @Override
+    public DataType defaultType() {
+        return DEFAULT_TYPE;
+    }
+
+    @Override
+    public Converter converter() {
+        return null;
+    }
+
+    @Override
+    public SchemaParser schemaParser() {
+        return protobufSchemaParser;
     }
 }

--- a/ksml-data-soap/src/main/java/io/axual/ksml/data/notation/soap/SoapNotation.java
+++ b/ksml-data-soap/src/main/java/io/axual/ksml/data/notation/soap/SoapNotation.java
@@ -21,7 +21,6 @@ package io.axual.ksml.data.notation.soap;
  */
 
 import io.axual.ksml.data.mapper.DataObjectMapper;
-import io.axual.ksml.data.notation.Notation;
 import io.axual.ksml.data.notation.NotationContext;
 import io.axual.ksml.data.notation.string.StringNotation;
 import io.axual.ksml.data.object.DataObject;
@@ -29,37 +28,72 @@ import io.axual.ksml.data.schema.DataSchema;
 import io.axual.ksml.data.type.DataType;
 import io.axual.ksml.data.type.MapType;
 import io.axual.ksml.data.type.StructType;
-import lombok.Getter;
 import org.apache.kafka.common.serialization.Serde;
 
 import static io.axual.ksml.data.notation.soap.SoapSchema.generateSOAPSchema;
 
 @Deprecated(forRemoval = true, since = "1.3.0")
-@Getter
 public class SoapNotation extends StringNotation {
     public static final String NOTATION_NAME = "soap";
     public static final DataType DEFAULT_TYPE = new StructType(generateSOAPSchema(DataSchema.ANY_SCHEMA));
     private static final SoapDataObjectMapper DATA_OBJECT_MAPPER = new SoapDataObjectMapper();
     private static final SoapStringMapper STRING_MAPPER = new SoapStringMapper();
-    private final Notation.Converter converter = new SoapDataObjectConverter();
+    private static final SoapDataObjectConverter CONVERTER = new SoapDataObjectConverter();
+
+    private static final DataObjectMapper<String> SOAP_STRING_MAPPER = new DataObjectMapper<>() {
+        @Override
+        public DataObject toDataObject(DataType expected, String value) {
+            return DATA_OBJECT_MAPPER.toDataObject(expected, STRING_MAPPER.fromString(value));
+        }
+
+        @Override
+        public String fromDataObject(DataObject value) {
+            return STRING_MAPPER.toString(DATA_OBJECT_MAPPER.fromDataObject(value));
+        }
+    };
 
     public SoapNotation(NotationContext context) {
-        super(NOTATION_NAME, context, null, SchemaUsage.SCHEMALESS_ONLY, DEFAULT_TYPE, new SoapDataObjectConverter(), null, new DataObjectMapper<>() {
-            @Override
-            public DataObject toDataObject(DataType expected, String value) {
-                return DATA_OBJECT_MAPPER.toDataObject(expected, STRING_MAPPER.fromString(value));
-            }
+        super(context);
+    }
 
-            @Override
-            public String fromDataObject(DataObject value) {
-                return STRING_MAPPER.toString(DATA_OBJECT_MAPPER.fromDataObject(value));
-            }
-        });
+    @Override
+    public String notationName() {
+        return NOTATION_NAME;
+    }
+
+    @Override
+    public String filenameExtension() {
+        return null;
+    }
+
+    @Override
+    public SchemaUsage schemaUsage() {
+        return SchemaUsage.SCHEMALESS_ONLY;
+    }
+
+    @Override
+    public DataType defaultType() {
+        return DEFAULT_TYPE;
+    }
+
+    @Override
+    public Converter converter() {
+        return CONVERTER;
+    }
+
+    @Override
+    public SchemaParser schemaParser() {
+        return null;
+    }
+
+    @Override
+    protected DataObjectMapper<String> stringMapper() {
+        return SOAP_STRING_MAPPER;
     }
 
     @Override
     public Serde<Object> serde(DataType type, boolean isKey) {
-        // SOAP types should ways be Maps (or Structs)
+        // SOAP types should always be Maps (or Structs)
         if (type instanceof MapType) return super.serde(type, isKey);
         // Other types cannot be serialized as SOAP
         throw noSerdeFor(type);

--- a/ksml-data-xml/src/main/java/io/axual/ksml/data/notation/xml/XmlNotation.java
+++ b/ksml-data-xml/src/main/java/io/axual/ksml/data/notation/xml/XmlNotation.java
@@ -20,8 +20,7 @@ package io.axual.ksml.data.notation.xml;
  * =========================LICENSE_END==================================
  */
 
-import io.axual.ksml.data.mapper.DataTypeDataSchemaMapper;
-import io.axual.ksml.data.mapper.NativeDataObjectMapper;
+import io.axual.ksml.data.mapper.DataObjectMapper;
 import io.axual.ksml.data.notation.NotationContext;
 import io.axual.ksml.data.notation.string.StringNotation;
 import io.axual.ksml.data.type.DataType;
@@ -32,27 +31,62 @@ import org.apache.kafka.common.serialization.Serde;
 public class XmlNotation extends StringNotation {
     public static final String NOTATION_NAME = "xml";
     public static final DataType DEFAULT_TYPE = new StructType();
+    private static final XmlDataObjectConverter CONVERTER = new XmlDataObjectConverter();
+    private static final XmlDataObjectMapper STRING_MAPPER = new XmlDataObjectMapper(false);
+
+    private SchemaParser lazySchemaParser;
 
     public XmlNotation() {
         this(null);
     }
 
     public XmlNotation(NotationContext context) {
-        super(NOTATION_NAME,
-                context,
-                ".xsd",
-                SchemaUsage.SCHEMA_OPTIONAL,
-                DEFAULT_TYPE,
-                new XmlDataObjectConverter(),
-                new XmlSchemaParser(
-                        context != null ? context.nativeDataObjectMapper() : new NativeDataObjectMapper(),
-                        context != null ? context.typeSchemaMapper() : new DataTypeDataSchemaMapper()),
-                new XmlDataObjectMapper(false));
+        super(context);
+    }
+
+    @Override
+    public String notationName() {
+        return NOTATION_NAME;
+    }
+
+    @Override
+    public String filenameExtension() {
+        return ".xsd";
+    }
+
+    @Override
+    public SchemaUsage schemaUsage() {
+        return SchemaUsage.SCHEMA_OPTIONAL;
+    }
+
+    @Override
+    public DataType defaultType() {
+        return DEFAULT_TYPE;
+    }
+
+    @Override
+    public Converter converter() {
+        return CONVERTER;
+    }
+
+    @Override
+    public SchemaParser schemaParser() {
+        if (lazySchemaParser == null) {
+            lazySchemaParser = new XmlSchemaParser(
+                    context().nativeDataObjectMapper(),
+                    context().typeSchemaMapper());
+        }
+        return lazySchemaParser;
+    }
+
+    @Override
+    protected DataObjectMapper<String> stringMapper() {
+        return STRING_MAPPER;
     }
 
     @Override
     public Serde<Object> serde(DataType type, boolean isKey) {
-        // XML types should ways be Maps (or Structs)
+        // XML types should always be Maps (or Structs)
         if (type instanceof MapType || type instanceof StructType) return super.serde(type, isKey);
         // Other types cannot be serialized as XML
         throw noSerdeFor(type);

--- a/ksml-data/src/main/java/io/axual/ksml/data/notation/base/BaseNotation.java
+++ b/ksml-data/src/main/java/io/axual/ksml/data/notation/base/BaseNotation.java
@@ -29,25 +29,31 @@ import lombok.Getter;
 /**
  * Base implementation for Notation that stores common context and helpers.
  * Subclasses specialize in serialization, conversion, and schema parsing behavior.
+ * <p>
+ * Type-constant properties (notation name, filename extension, schema usage, default type,
+ * converter, schema parser) are provided by subclasses via method overrides rather than
+ * constructor arguments, since they are fixed per leaf type.
  */
 @Getter
 public abstract class BaseNotation implements Notation {
-    private final String name;
     private final NotationContext context;
-    private final String filenameExtension;
-    private final SchemaUsage schemaUsage;
-    private final DataType defaultType;
-    private final Converter converter;
-    private final SchemaParser schemaParser;
 
-    protected BaseNotation(String name, NotationContext context, String filenameExtension, SchemaUsage schemaUsage, DataType defaultType, Notation.Converter converter, Notation.SchemaParser schemaParser) {
-        this.name = name;
+    protected BaseNotation(NotationContext context) {
         this.context = context != null ? context : new NotationContext();
-        this.filenameExtension = filenameExtension;
-        this.schemaUsage = schemaUsage;
-        this.defaultType = defaultType;
-        this.converter = converter;
-        this.schemaParser = schemaParser;
+    }
+
+    /**
+     * Returns the base notation name (e.g. "avro", "json", "csv").
+     * This is used by the default {@link #name()} implementation and can be
+     * combined with a vendor prefix by subclasses like VendorNotation.
+     *
+     * @return the base notation name
+     */
+    public abstract String notationName();
+
+    @Override
+    public String name() {
+        return notationName();
     }
 
     protected RuntimeException noSerdeFor(DataType type) {

--- a/ksml-data/src/main/java/io/axual/ksml/data/notation/string/StringNotation.java
+++ b/ksml-data/src/main/java/io/axual/ksml/data/notation/string/StringNotation.java
@@ -21,7 +21,6 @@ package io.axual.ksml.data.notation.string;
  */
 
 import io.axual.ksml.data.mapper.DataObjectMapper;
-import io.axual.ksml.data.notation.Notation;
 import io.axual.ksml.data.notation.NotationContext;
 import io.axual.ksml.data.notation.base.BaseNotation;
 import io.axual.ksml.data.serde.StringSerde;
@@ -32,14 +31,17 @@ import org.apache.kafka.common.serialization.Serde;
  * Base notation implementation for notations that internally serialize to textual String form.
  */
 public abstract class StringNotation extends BaseNotation {
-    private final DataObjectMapper<String> stringMapper;
 
-    protected StringNotation(String name, NotationContext context, String filenameExtension, SchemaUsage schemaUsage,
-                             DataType defaultType, Notation.Converter converter,
-                             Notation.SchemaParser schemaParser, DataObjectMapper<String> stringMapper) {
-        super(name, context, filenameExtension, schemaUsage, defaultType, converter, schemaParser);
-        this.stringMapper = stringMapper;
+    protected StringNotation(NotationContext context) {
+        super(context);
     }
+
+    /**
+     * Returns the mapper used to convert DataObjects to/from their String representation.
+     *
+     * @return the string mapper for this notation
+     */
+    protected abstract DataObjectMapper<String> stringMapper();
 
     /**
      * Creates a StringSerde configured for the requested data type and key/value role.
@@ -50,7 +52,7 @@ public abstract class StringNotation extends BaseNotation {
      */
     @Override
     public Serde<Object> serde(DataType type, boolean isKey) {
-        final var result = new StringSerde(context().nativeDataObjectMapper(), stringMapper, type);
+        final var result = new StringSerde(context().nativeDataObjectMapper(), stringMapper(), type);
         result.configure(context().serdeConfigs(), isKey);
         return result;
     }

--- a/ksml-data/src/main/java/io/axual/ksml/data/notation/vendor/VendorNotation.java
+++ b/ksml-data/src/main/java/io/axual/ksml/data/notation/vendor/VendorNotation.java
@@ -38,16 +38,21 @@ public abstract class VendorNotation extends BaseNotation {
     private final DataObjectMapper<Object> serdeMapper;
     private final String vendorName;
 
-    protected VendorNotation(String name, VendorNotationContext context, String filenameExtension, DataType defaultType, Converter converter, SchemaParser schemaParser) {
-        super(name, context, filenameExtension, SchemaUsage.SCHEMA_REQUIRED, defaultType, converter, schemaParser);
+    protected VendorNotation(VendorNotationContext context) {
+        super(context);
         this.serdeSupplier = context.serdeSupplier();
         this.serdeMapper = context.serdeMapper();
-        vendorName = context.vendorName();
+        this.vendorName = context.vendorName();
     }
 
     @Override
     public String name() {
-        return (vendorName != null && !vendorName.isEmpty() ? vendorName + "_" : "") + super.name();
+        return (vendorName != null && !vendorName.isEmpty() ? vendorName + "_" : "") + notationName();
+    }
+
+    @Override
+    public SchemaUsage schemaUsage() {
+        return SchemaUsage.SCHEMA_REQUIRED;
     }
 
     /**

--- a/ksml-data/src/test/java/io/axual/ksml/data/notation/base/BaseNotationTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/notation/base/BaseNotationTest.java
@@ -32,33 +32,65 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class BaseNotationTest {
+
+    private static final SimpleType DEFAULT_TYPE = new SimpleType(String.class, "string");
+    private static final Notation.Converter CONVERTER = (value, targetType) -> value;
+    private static final Notation.SchemaParser PARSER = (ctx, name, schema) -> null;
+
     private static class DummyNotation extends BaseNotation {
-        DummyNotation(NotationContext context, String fileExt, SchemaUsage schemaUsage, DataType defaultType,
-                      Notation.Converter converter, Notation.SchemaParser parser) {
-            super("dummy", context, fileExt, schemaUsage, defaultType, converter, parser);
+        DummyNotation(NotationContext context) {
+            super(context);
+        }
+
+        @Override
+        public String notationName() {
+            return "dummy";
+        }
+
+        @Override
+        public String filenameExtension() {
+            return ".json";
+        }
+
+        @Override
+        public SchemaUsage schemaUsage() {
+            return SchemaUsage.SCHEMALESS_ONLY;
+        }
+
+        @Override
+        public DataType defaultType() {
+            return DEFAULT_TYPE;
+        }
+
+        @Override
+        public Converter converter() {
+            return CONVERTER;
+        }
+
+        @Override
+        public SchemaParser schemaParser() {
+            return PARSER;
         }
 
         @Override
         public Serde<Object> serde(DataType type, boolean isKey) {
-            // Always fail with the standard message to expose BaseNotation.noSerdeFor
             throw noSerdeFor(type);
         }
     }
 
     @Test
-    @DisplayName("name() delegates to context; getters expose provided constructor arguments; noSerdeFor message")
+    @DisplayName("name() delegates to notationName(); method overrides expose constants; noSerdeFor message")
     void baseBehaviourAndNoSerdeFor() {
         var context = new NotationContext();
-        var defaultType = new SimpleType(String.class, "string");
-        Notation.Converter converter = (value, targetType) -> value; // not used
-        Notation.SchemaParser parser = (ctx, name, schema) -> null; // not used
+        var notation = new DummyNotation(context);
 
-        var notation = new DummyNotation(context, ".json", Notation.SchemaUsage.SCHEMALESS_ONLY, defaultType, converter, parser);
-
+        assertThat(notation.name()).isEqualTo("dummy");
+        assertThat(notation.notationName()).isEqualTo("dummy");
         assertThat(notation.filenameExtension()).isEqualTo(".json");
-        assertThat(notation.defaultType()).isEqualTo(defaultType);
-        assertThat(notation.converter()).isSameAs(converter);
-        assertThat(notation.schemaParser()).isSameAs(parser);
+        assertThat(notation.defaultType()).isEqualTo(DEFAULT_TYPE);
+        assertThat(notation.converter()).isSameAs(CONVERTER);
+        assertThat(notation.schemaParser()).isSameAs(PARSER);
+        assertThat(notation.context()).isSameAs(context);
 
         var wrongType = new SimpleType(Integer.class, "int");
         assertThatThrownBy(() -> notation.serde(wrongType, true))

--- a/ksml-data/src/test/java/io/axual/ksml/data/notation/string/StringNotationTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/notation/string/StringNotationTest.java
@@ -22,7 +22,6 @@ package io.axual.ksml.data.notation.string;
 
 import io.axual.ksml.data.mapper.DataObjectMapper;
 import io.axual.ksml.data.mapper.StringDataObjectMapper;
-import io.axual.ksml.data.notation.Notation;
 import io.axual.ksml.data.notation.NotationContext;
 import io.axual.ksml.data.object.DataString;
 import io.axual.ksml.data.type.DataType;
@@ -33,15 +32,46 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class StringNotationTest {
+    private static final StringDataObjectMapper STRING_MAPPER = new StringDataObjectMapper();
+
     private static class ConcreteStringNotation extends StringNotation {
-        ConcreteStringNotation(String name,
-                               NotationContext context,
-                               String filenameExtension,
-                               DataType defaultType,
-                               Notation.Converter converter,
-                               Notation.SchemaParser schemaParser,
-                               DataObjectMapper<String> stringMapper) {
-            super(name, context, filenameExtension, SchemaUsage.SCHEMALESS_ONLY, defaultType, converter, schemaParser, stringMapper);
+        ConcreteStringNotation(NotationContext context) {
+            super(context);
+        }
+
+        @Override
+        public String notationName() {
+            return "string";
+        }
+
+        @Override
+        public String filenameExtension() {
+            return ".txt";
+        }
+
+        @Override
+        public SchemaUsage schemaUsage() {
+            return SchemaUsage.SCHEMALESS_ONLY;
+        }
+
+        @Override
+        public DataType defaultType() {
+            return DataString.DATATYPE;
+        }
+
+        @Override
+        public Converter converter() {
+            return (value, targetType) -> value;
+        }
+
+        @Override
+        public SchemaParser schemaParser() {
+            return (ctx, name, str) -> null;
+        }
+
+        @Override
+        protected DataObjectMapper<String> stringMapper() {
+            return STRING_MAPPER;
         }
     }
 
@@ -51,15 +81,7 @@ class StringNotationTest {
         final var context = new NotationContext();
         context.serdeConfigs().put("dummy", "config");
 
-        final var notation = new ConcreteStringNotation(
-                "string",
-                context,
-                ".txt",
-                DataString.DATATYPE,
-                (value, targetType) -> value,
-                (ctx, name, str) -> null,
-                new StringDataObjectMapper()
-        );
+        final var notation = new ConcreteStringNotation(context);
 
         try (final var serde = notation.serde(DataString.DATATYPE, true)) {
             final var serialized = serde.serializer().serialize("topic", new DataString("hello"));

--- a/ksml-data/src/test/java/io/axual/ksml/data/notation/vendor/VendorNotationTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/notation/vendor/VendorNotationTest.java
@@ -22,7 +22,6 @@ package io.axual.ksml.data.notation.vendor;
 
 import io.axual.ksml.data.mapper.DataObjectMapper;
 import io.axual.ksml.data.mapper.StringDataObjectMapper;
-import io.axual.ksml.data.notation.Notation;
 import io.axual.ksml.data.notation.NotationContext;
 import io.axual.ksml.data.object.DataString;
 import io.axual.ksml.data.serde.SerdeSupplier;
@@ -38,13 +37,33 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 class VendorNotationTest {
     private static class ConcreteVendorNotation extends VendorNotation {
-        ConcreteVendorNotation(String name,
-                               VendorNotationContext context,
-                               String filenameExtension,
-                               DataType defaultType,
-                               Notation.Converter converter,
-                               Notation.SchemaParser schemaParser) {
-            super(name, context, filenameExtension, defaultType, converter, schemaParser);
+        ConcreteVendorNotation(VendorNotationContext context) {
+            super(context);
+        }
+
+        @Override
+        public String notationName() {
+            return "avro";
+        }
+
+        @Override
+        public String filenameExtension() {
+            return ".avsc";
+        }
+
+        @Override
+        public DataType defaultType() {
+            return DataString.DATATYPE;
+        }
+
+        @Override
+        public Converter converter() {
+            return (v, t) -> v;
+        }
+
+        @Override
+        public SchemaParser schemaParser() {
+            return (c, n, s) -> null;
         }
     }
 
@@ -59,7 +78,7 @@ class VendorNotationTest {
     @DisplayName("serde() returns DataObjectSerde that round trips DataString via vendor String serde when type is supported")
     void serdeRoundTripsForSupportedType() {
         final var context = createContext();
-        final var notation = new ConcreteVendorNotation("avro", context, ".avsc", DataString.DATATYPE, (v, t) -> v, (c, n, s) -> null);
+        final var notation = new ConcreteVendorNotation(context);
 
         try (final var serde = notation.serde(DataString.DATATYPE, false)) {
             final var bytes = serde.serializer().serialize("t", new DataString("abc"));
@@ -74,7 +93,7 @@ class VendorNotationTest {
     @DisplayName("serde() throws DataException with helpful message when requested type not assignable from default type")
     void serdeThrowsForUnsupportedType() {
         final var context = createContext();
-        final var notation = new ConcreteVendorNotation("avro", context, ".avsc", DataString.DATATYPE, (v, t) -> v, (c, n, s) -> null);
+        final var notation = new ConcreteVendorNotation(context);
         final var wrongType = new SimpleType(Integer.class, "int");
 
         assertThatThrownBy(() -> notation.serde(wrongType, true))

--- a/openspec/changes/archive/2026-04-23-notation-constructor-cleanup/design.md
+++ b/openspec/changes/archive/2026-04-23-notation-constructor-cleanup/design.md
@@ -1,0 +1,123 @@
+## Context
+
+The `Notation` interface declares methods like `name()`, `defaultType()`, `schemaUsage()`, `converter()`, `schemaParser()`, `filenameExtension()`. Today `BaseNotation` implements all of them via `@Getter` on private final fields set in a 7-argument constructor. Every intermediate and leaf class passes these values up the chain, even though they're constants per leaf type.
+
+The `NotationProvider` interface already has the `notationName()` / `name()` split we need — `notationName()` returns the base name (e.g. `"avro"`), and `name()` composes it with an optional vendor prefix (e.g. `"confluent_avro"`). We align the `Notation` hierarchy to follow the same pattern.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Simplify constructor chains so only `context` flows through
+- One consistent pattern: leaf types define constants via method overrides
+- Keep the `Notation` interface unchanged
+- Align `name()` / `notationName()` with the existing `NotationProvider` pattern
+
+**Non-Goals:**
+- Changing the `Notation` interface
+- Changing `NotationProvider` or its implementations
+- Modifying `ConfluentAvroNotation`, `ApicurioAvroNotation`, or other classes that extend leaf notations
+
+## Decisions
+
+### Constants as method overrides, not constructor arguments
+
+Every value that is constant per leaf type becomes an abstract method in `BaseNotation` (or `StringNotation` for `stringMapper`) that the leaf overrides. This is consistent — all constants follow the same pattern regardless of where in the hierarchy they're defined.
+
+### `notationName()` / `name()` split
+
+`BaseNotation` declares an abstract `notationName()` method returning the base notation name. It provides a default `name()` implementation that simply delegates to `notationName()`. `VendorNotation` overrides `name()` to prepend the vendor name, using the same composition logic as `NotationProvider.name()`:
+
+```
+BaseNotation:
+  abstract String notationName();           // leaf overrides: "avro", "json", etc.
+  String name() { return notationName(); }  // default: just the notation name
+
+VendorNotation:
+  @Override
+  String name() {
+      return (vendorName != null && !vendorName.isEmpty()
+          ? vendorName + "_" : "") + notationName();
+  }
+```
+
+### Lazy schema parser for XmlNotation
+
+`XmlNotation`'s schema parser depends on `context()` (it needs `nativeDataObjectMapper()` and `typeSchemaMapper()`). Rather than constructing it eagerly with null checks, use a lazy holder:
+
+```java
+private SchemaParser lazySchemaParser;
+
+@Override
+public SchemaParser schemaParser() {
+    if (lazySchemaParser == null) {
+        lazySchemaParser = new XmlSchemaParser(
+            context().nativeDataObjectMapper(),
+            context().typeSchemaMapper());
+    }
+    return lazySchemaParser;
+}
+```
+
+This is safe because `context()` is guaranteed non-null (BaseNotation defaults it), and schema parsing is an I/O-bound operation where lazy init cost is negligible.
+
+### VendorNotation internal fields
+
+`VendorNotation` extracts `serdeSupplier`, `serdeMapper`, and `vendorName` from `VendorNotationContext`. These stay as fields — they vary per instance (via the context) and are used by `VendorNotation.serde()` and `VendorNotation.name()`.
+
+## Structure after refactoring
+
+```
+Notation (interface) — UNCHANGED
+  │ name(), filenameExtension(), schemaUsage(), defaultType(),
+  │ converter(), schemaParser(), serde()
+  │
+BaseNotation (abstract)
+  │ field: context
+  │ constructor: (NotationContext)
+  │ abstract: notationName(), filenameExtension(), schemaUsage(),
+  │           defaultType(), converter(), schemaParser()
+  │ default: name() → notationName()
+  │
+  ├── JsonNotation         ctx only → overrides all abstract methods
+  ├── BinaryNotation       ctx only → overrides all abstract methods
+  │
+  ├── StringNotation (abstract)
+  │   │ abstract: stringMapper()
+  │   │ implements: serde() using stringMapper()
+  │   │ constructor: (NotationContext)
+  │   │
+  │   ├── XmlNotation      ctx only → overrides all, lazy schemaParser()
+  │   ├── CsvNotation      ctx only → overrides all
+  │   └── SoapNotation     ctx only → overrides all (@Deprecated)
+  │
+  └── VendorNotation (abstract)
+      │ fields: serdeSupplier, serdeMapper, vendorName (from VendorNotationContext)
+      │ overrides: name() → vendorName + "_" + notationName()
+      │ implements: serde() using serdeSupplier/serdeMapper
+      │ constructor: (VendorNotationContext)
+      │
+      ├── AvroNotation         ctx only → overrides notationName(), defaultType(), etc.
+      │   └── ConfluentAvroNotation(ctx, registryClient, resolver) — UNCHANGED
+      │   └── ApicurioAvroNotation(ctx, registryClient, resolver) — UNCHANGED
+      ├── ProtobufNotation     ctx only → overrides all
+      └── JsonSchemaNotation   ctx only → overrides all
+```
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `BaseNotation.java` | Remove 6 fields, shrink constructor, add abstract `notationName()`, default `name()` |
+| `StringNotation.java` | Remove `stringMapper` field/param, add abstract `stringMapper()` |
+| `VendorNotation.java` | Shrink constructor, override `name()` using `notationName()` |
+| `JsonNotation.java` | Override abstract methods with constants |
+| `BinaryNotation.java` | Override abstract methods with constants |
+| `XmlNotation.java` | Override abstract methods, lazy `schemaParser()` |
+| `CsvNotation.java` | Override abstract methods with constants |
+| `SoapNotation.java` | Override abstract methods with constants |
+| `AvroNotation.java` | Override abstract methods with constants |
+| `ProtobufNotation.java` | Override abstract methods with constants |
+| `JsonSchemaNotation.java` | Override abstract methods with constants |
+| `BaseNotationTest.java` | Update dummy subclass to use overrides |
+| `StringNotationTest.java` | Update dummy subclass to use overrides |
+| `VendorNotationTest.java` | Update dummy subclass to use overrides |

--- a/openspec/changes/archive/2026-04-23-notation-constructor-cleanup/proposal.md
+++ b/openspec/changes/archive/2026-04-23-notation-constructor-cleanup/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+`BaseNotation` has a 7-argument constructor, and `StringNotation` extends that to 8. These arguments are all forwarded through intermediate classes, but in every leaf type they are constants — the only value that genuinely varies per instance is `context`. The long constructors obscure what's fixed and what's variable, making the hierarchy harder to read and extend.
+
+## What Changes
+
+Replace `BaseNotation`'s constructor parameters (except `context`) with abstract methods that leaf types override with constants. This keeps the `Notation` interface unchanged while simplifying the constructor chain.
+
+- `BaseNotation` constructor shrinks from 7 args to 1 (`context`)
+- `StringNotation` constructor shrinks from 8 args to 1 (`context`), with an abstract `stringMapper()` method for the mapper that `serde()` uses
+- `VendorNotation` constructor shrinks from 6 args to 1 (`VendorNotationContext`)
+- Leaf types override abstract methods with constant returns instead of passing values to `super()`
+- Introduce `notationName()` (matching the existing pattern on `NotationProvider`) so `VendorNotation.name()` can compose the vendor-prefixed name without relying on a stored field
+
+## Impact
+
+- **BaseNotation**: Remove 6 fields, keep `context`. Keep the `@Getter` on the class which now only creates a getter for `context()`. Add `notationName()` abstract method with a default `name()` that delegates to it.
+- **StringNotation**: Remove `stringMapper` field and constructor parameter. Add abstract `stringMapper()` method.
+- **VendorNotation**: Remove constructor parameters forwarded to `BaseNotation`. Override `name()` using `notationName()` + `vendorName` (same composition logic as `NotationProvider.name()`).
+- **All leaf notations** (JsonNotation, BinaryNotation, XmlNotation, CsvNotation, SoapNotation, AvroNotation, ProtobufNotation, JsonSchemaNotation): Override abstract methods with constant returns. Constructors shrink to just `context`.
+- **XmlNotation**: `schemaParser()` uses a lazy holder since it depends on `context()`, initialized on first call.
+- **ConfluentAvroNotation, ApicurioAvroNotation**: Unaffected — they extend `AvroNotation` and their extra constructor args (`registryClient`, `topicResolver`) are their own, not relayed through the chain.
+- **NotationProvider and its implementations**: Unaffected.
+- **Tests**: `BaseNotationTest`, `StringNotationTest`, `VendorNotationTest` need their dummy inner subclasses updated to use method overrides instead of constructor args. Leaf notation tests are unaffected (their constructor APIs don't change).

--- a/openspec/changes/archive/2026-04-23-notation-constructor-cleanup/tasks.md
+++ b/openspec/changes/archive/2026-04-23-notation-constructor-cleanup/tasks.md
@@ -1,0 +1,35 @@
+## 1. BaseNotation
+
+- [x] 1.1 Remove the 6 constant fields (`name`, `filenameExtension`, `schemaUsage`, `defaultType`, `converter`, `schemaParser`) from `BaseNotation`. Keep only `context`.
+- [x] 1.2 Shrink the constructor to `BaseNotation(NotationContext context)`.
+- [x] 1.3 Add abstract method `notationName()` and a default `name()` implementation that delegates to it.
+- [x] 1.4 Leave `filenameExtension()`, `schemaUsage()`, `defaultType()`, `converter()`, `schemaParser()` unimplemented (abstract by omission from the `Notation` interface).
+
+## 2. StringNotation
+
+- [x] 2.1 Remove `stringMapper` field and constructor parameter. Shrink constructor to `StringNotation(NotationContext context)`.
+- [x] 2.2 Add abstract method `stringMapper()` and update `serde()` to call it.
+
+## 3. VendorNotation
+
+- [x] 3.1 Shrink constructor to `VendorNotation(VendorNotationContext context)`. Extract `serdeSupplier`, `serdeMapper`, `vendorName` from context as before.
+- [x] 3.2 Override `name()` to use `notationName()` + vendor prefix composition (matching `NotationProvider.name()` logic).
+
+## 4. Leaf notations
+
+- [x] 4.1 `JsonNotation`: Override `notationName()`, `filenameExtension()`, `schemaUsage()`, `defaultType()`, `converter()`, `schemaParser()`. Constructor takes only `NotationContext`.
+- [x] 4.2 `BinaryNotation`: Same pattern. Constructor takes only `NotationContext` and optional `SerdeSupplier`.
+- [x] 4.3 `XmlNotation`: Same pattern, with lazy `schemaParser()` that constructs on first call using `context()`.
+- [x] 4.4 `CsvNotation`: Same pattern. Override `stringMapper()` from `StringNotation`.
+- [x] 4.5 `SoapNotation`: Same pattern (deprecated, minimal effort).
+- [x] 4.6 `AvroNotation`: Override `notationName()`, `filenameExtension()`, `defaultType()`, `converter()`, `schemaParser()`. Constructor takes only `VendorNotationContext`.
+- [x] 4.7 `ProtobufNotation`: Same pattern. `schemaParser()` override returns the parser (passed via constructor or created internally).
+- [x] 4.8 `JsonSchemaNotation`: Same pattern.
+
+## 5. Tests
+
+- [x] 5.1 Update `BaseNotationTest`: rewrite dummy inner subclass to use method overrides instead of constructor args.
+- [x] 5.2 Update `StringNotationTest`: rewrite dummy inner subclass.
+- [x] 5.3 Update `VendorNotationTest`: rewrite dummy inner subclass.
+- [x] 5.4 Verify all existing leaf notation tests pass unchanged.
+- [x] 5.5 Run full `mvn verify` to confirm no regressions.


### PR DESCRIPTION
`BaseNotation` has a 7 argument constructor (`StringNotation` extends this to 8). A high number of constructor arguments is generally seen as a code smell (too many collaborators) as it turns out most of the constructor arguments are not real instance variables but subclass specific constants.
Removed the `private final` instance fields in `BaseNotation` and replaced with getter implementations in the subclasses with a constant return value, constructor now only takes `context`.
No functional change, ran full build and integration tests.
