### PR TITLE
Fix Avro record-typed default round-trip (Unknown datum class regress…

### DIFF
--- a/ksml-data-avro/src/main/java/io/axual/ksml/data/notation/avro/AvroSchemaMapper.java
+++ b/ksml-data-avro/src/main/java/io/axual/ksml/data/notation/avro/AvroSchemaMapper.java
@@ -23,8 +23,12 @@ package io.axual.ksml.data.notation.avro;
 import io.axual.ksml.data.exception.SchemaException;
 import io.axual.ksml.data.mapper.DataSchemaMapper;
 import io.axual.ksml.data.mapper.DataTypeDataSchemaMapper;
+import io.axual.ksml.data.mapper.NativeDataObjectMapper;
+import io.axual.ksml.data.object.DataList;
+import io.axual.ksml.data.object.DataMap;
 import io.axual.ksml.data.object.DataNull;
 import io.axual.ksml.data.object.DataObject;
+import io.axual.ksml.data.object.DataStruct;
 import io.axual.ksml.data.schema.DataSchema;
 import io.axual.ksml.data.schema.DataSchemaConstants;
 import io.axual.ksml.data.schema.EnumSchema;
@@ -40,6 +44,7 @@ import org.apache.avro.Schema;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 import static io.axual.ksml.data.schema.DataSchemaConstants.NO_TAG;
@@ -56,6 +61,7 @@ import static io.axual.ksml.data.schema.DataSchemaConstants.NO_TAG;
 @Slf4j
 public class AvroSchemaMapper implements DataSchemaMapper<Schema> {
     private static final AvroDataObjectMapper avroMapper = new AvroDataObjectMapper();
+    private static final NativeDataObjectMapper NATIVE_MAPPER = new NativeDataObjectMapper();
     private static final Schema AVRO_NULL_TYPE = Schema.create(Schema.Type.NULL);
     private static final DataTypeDataSchemaMapper TYPE_SCHEMA_MAPPER = new DataTypeDataSchemaMapper();
 
@@ -360,7 +366,70 @@ public class AvroSchemaMapper implements DataSchemaMapper<Schema> {
     private Object convertDataObjectToAvroDefaultValue(DataObject defaultValue) {
         if (defaultValue == null) return null;
         if (defaultValue == DataNull.INSTANCE) return Schema.Field.NULL_DEFAULT_VALUE;
-        return avroMapper.fromDataObject(defaultValue);
+        return toJsonShapedDefault(defaultValue);
+    }
+
+    /**
+     * Turn a KSML default value into a plain Java value that Avro can write into the schema as JSON.
+     *
+     * <p>Why this exists: when we build an Avro {@code Schema.Field}, Avro asks us
+     * for the field's default value and then tries to write it into the schema as
+     * JSON. Avro can only do that for a small set of Java types — plain Maps, plain
+     * Lists, byte arrays, strings, numbers, booleans, and a special "null sentinel"
+     * for nulls inside containers. If we hand it anything else (for example one of
+     * Avro's own internal record objects), it crashes with
+     * {@code Unknown datum class: GenericData$Record} and the producer never sends
+     * a single message.</p>
+     *
+     * <p>So this method walks the KSML default value and rebuilds it using only
+     * those JSON-friendly Java types: KSML structs and maps become plain
+     * {@link LinkedHashMap}s, KSML lists become plain {@link ArrayList}s, scalars
+     * are unwrapped to their native Java values, and any null inside a container
+     * is replaced with Avro's null sentinel {@link JsonProperties#NULL_VALUE} (a
+     * raw Java {@code null} inside a Map or List would also crash Avro).</p>
+     */
+    private Object toJsonShapedDefault(DataObject value) {
+        // A null (either a Java null or KSML's DataNull) becomes Avro's null sentinel.
+        // We use this anywhere null shows up *inside* a default value — at the top
+        // level the caller (convertDataObjectToAvroDefaultValue) handles null first.
+        if (value == null || value instanceof DataNull) return JsonProperties.NULL_VALUE;
+
+        // KSML record (struct) -> plain Map. Recurse on each field value so that a
+        // record-inside-a-record default also turns into nested Maps, not Avro
+        // record objects.
+        if (value instanceof DataStruct struct) {
+            final var result = new LinkedHashMap<String, Object>();
+            for (var entry : struct.entrySet()) {
+                result.put(entry.getKey(), toJsonShapedDefault(entry.getValue()));
+            }
+            return result;
+        }
+
+        // KSML map -> plain Map. Same idea as struct.
+        if (value instanceof DataMap map) {
+            final var result = new LinkedHashMap<String, Object>();
+            for (var entry : map.entrySet()) {
+                result.put(entry.getKey(), toJsonShapedDefault(entry.getValue()));
+            }
+            return result;
+        }
+
+        // KSML list -> plain List. Recurse on each element so a list of records
+        // also becomes a list of Maps.
+        if (value instanceof DataList list) {
+            final var result = new ArrayList<>(list.size());
+            for (var item : list) {
+                result.add(toJsonShapedDefault(item));
+            }
+            return result;
+        }
+
+        // Anything else (string, int, long, boolean, bytes, enum, ...) — let the
+        // native mapper unwrap the KSML wrapper to its underlying Java value
+        // (DataString -> String, DataInteger -> Integer, etc.). If unwrapping
+        // produces a raw Java null, swap it for Avro's null sentinel.
+        final var native_ = NATIVE_MAPPER.fromDataObject(value);
+        return native_ == null ? JsonProperties.NULL_VALUE : native_;
     }
 
     private Schema.Field.Order convertStructFieldOrderToAvroFieldOrder(StructSchema.Field.Order order) {

--- a/ksml-data-avro/src/test/java/io/axual/ksml/data/notation/avro/AvroSchemaMapperTest.java
+++ b/ksml-data-avro/src/test/java/io/axual/ksml/data/notation/avro/AvroSchemaMapperTest.java
@@ -530,4 +530,263 @@ class AvroSchemaMapperTest {
                     .isEqualTo(DataNull.INSTANCE);
         });
     }
+
+    // ============================================================================
+    // Regression tests for an Avro default-value bug.
+    //
+    // Background:
+    // When KSML produces a message, it has to hand its internal schema back to
+    // Apache Avro. Avro then asks "what is the default value of this field?"
+    // and tries to write that default into the schema as JSON. Avro can only
+    // turn very specific Java types into JSON: plain Maps, Lists, byte arrays,
+    // strings, numbers, booleans, and a special sentinel for null. If we hand
+    // it anything else (for example, an Avro record object), it crashes with
+    //     "Unknown datum class: GenericData$Record"
+    // and the producer never sends a single message.
+    //
+    // KSML used to give Avro a record object for record-typed defaults, which
+    // is what caused the bug. The fix is in AvroSchemaMapper: instead of giving
+    // Avro a record object, we hand it a plain Map.
+    //
+    // Each test below sends a small Avro schema through KSML's converter twice
+    // (Avro -> KSML schema -> Avro) and checks that the conversion succeeds and
+    // produces the right shape of default value.
+    // ============================================================================
+
+    @Test
+    @DisplayName("Record field with empty default {} survives the round-trip (the original bug)")
+    void recordDefault_emptyObject_roundTrips() {
+        // This is the simplest reproduction of the original bug as reported
+        // The "inner" field is itself a record, and its default is {} (empty record).
+        // Before the fix, just running this test would crash with
+        // "Unknown datum class: GenericData$Record".
+        final var schemaJson = """
+                {
+                  "type": "record",
+                  "name": "Outer",
+                  "namespace": "io.axual.test",
+                  "fields": [
+                    {
+                      "name": "inner",
+                      "type": {
+                        "type": "record",
+                        "name": "Inner",
+                        "fields": [
+                          { "name": "content", "type": "string", "default": "" }
+                        ]
+                      },
+                      "default": {}
+                    }
+                  ]
+                }
+                """;
+        final var avroSchema = new Schema.Parser().parse(schemaJson);
+
+        // Avro -> KSML schema -> Avro again. The third line is the one that used
+        // to crash before the fix.
+        final var ksml = schemaMapper.toDataSchema(avroSchema);
+        final var back = schemaMapper.fromDataSchema(ksml);
+
+        // Going one more lap should give the same KSML schema back. If anything
+        // went wrong inside the conversion, the two won't match.
+        final var ksml2 = schemaMapper.toDataSchema(back.getNamespace(), back.getName(), back);
+        assertThat(ksml2).isEqualTo(ksml);
+
+        // The default for the inner record must be a plain Java Map (which Avro
+        // can JSON-encode). A Map is also what `{}` looks like when written as
+        // JSON. If the fix regresses, this would be an Avro record object instead
+        // and Avro's Schema.Field constructor would have already thrown above.
+        final var innerField = back.getField("inner");
+        assertThat(innerField.hasDefaultValue()).isTrue();
+        assertThat(innerField.defaultVal()).isInstanceOf(java.util.Map.class);
+    }
+
+    @Test
+    @DisplayName("Record default that has 'null' inside it must use Avro's null sentinel, not raw null")
+    void recordDefault_withExplicitNullInside_mapsToNullValue() {
+        // This is a case I uncovered while testing partial fixes. If a record
+        // default contains a literal null somewhere (here: typeCode is null),
+        // the converter must turn that null into Avro's special "null sentinel"
+        // (JsonProperties.NULL_VALUE). If we leave it as a plain Java null,
+        // Avro crashes with a NullPointerException when it tries to encode the
+        // default map. Easy to miss because most schemas don't hit this case.
+        final var schemaJson = """
+                {
+                  "type": "record",
+                  "name": "Outer",
+                  "namespace": "io.axual.test",
+                  "fields": [
+                    {
+                      "name": "id",
+                      "type": {
+                        "type": "record",
+                        "name": "OpenIDType",
+                        "fields": [
+                          { "name": "content", "type": "string", "default": "" },
+                          { "name": "typeCode", "type": ["null", "string"], "default": null }
+                        ]
+                      },
+                      "default": { "content": "x", "typeCode": null }
+                    }
+                  ]
+                }
+                """;
+        final var avroSchema = new Schema.Parser().parse(schemaJson);
+        final var ksml = schemaMapper.toDataSchema(avroSchema);
+        final var back = schemaMapper.fromDataSchema(ksml);
+
+        // Pull out the default map for the "id" field.
+        @SuppressWarnings("unchecked")
+        final var defaultMap = (java.util.Map<String, Object>) back.getField("id").defaultVal();
+
+        // Plain string default — should be the string "x".
+        assertThat(defaultMap.get("content")).isEqualTo("x");
+
+        // The important assertion: the null inside the default must be Avro's
+        // null sentinel, NOT a raw Java null. A raw null here is what makes
+        // Avro crash when it tries to JSON-encode the default.
+        assertThat(defaultMap.get("typeCode")).isEqualTo(JsonProperties.NULL_VALUE);
+    }
+
+    @Test
+    @DisplayName("Array of records as a default value (with nulls inside) survives the round-trip")
+    void arrayDefault_roundTrips() {
+        // Same idea as the previous test, but for arrays instead of plain records.
+        // The schema has two array fields:
+        //   - "tags" — empty list of strings as default. Easy case.
+        //   - "items" — a list of records, each with a null in it. This is the
+        //     hard case: KSML has to recurse into the list, into each record,
+        //     and turn the inner nulls into Avro's null sentinel — same rule as
+        //     the previous test, but going through a different code branch.
+        final var schemaJson = """
+                {
+                  "type": "record",
+                  "name": "Outer",
+                  "namespace": "io.axual.test",
+                  "fields": [
+                    {
+                      "name": "tags",
+                      "type": { "type": "array", "items": "string" },
+                      "default": []
+                    },
+                    {
+                      "name": "items",
+                      "type": {
+                        "type": "array",
+                        "items": {
+                          "type": "record",
+                          "name": "Item",
+                          "fields": [
+                            { "name": "k", "type": "string" },
+                            { "name": "v", "type": ["null", "string"], "default": null }
+                          ]
+                        }
+                      },
+                      "default": [{ "k": "a", "v": null }, { "k": "b", "v": null }]
+                    }
+                  ]
+                }
+                """;
+        final var avroSchema = new Schema.Parser().parse(schemaJson);
+        final var ksml = schemaMapper.toDataSchema(avroSchema);
+        final var back = schemaMapper.fromDataSchema(ksml);
+
+        // Empty array default should be a plain Java List.
+        assertThat(back.getField("tags").defaultVal()).isInstanceOf(java.util.List.class);
+
+        // The "items" default is a list with two records in it.
+        @SuppressWarnings("unchecked")
+        final var items = (java.util.List<Object>) back.getField("items").defaultVal();
+        assertThat(items).hasSize(2);
+
+        // Each item should have been turned into a plain Java Map.
+        assertThat(items.getFirst()).isInstanceOf(java.util.Map.class);
+
+        // And the null inside each record must be Avro's null sentinel — same
+        // rule as the previous test, but reached through the list branch.
+        @SuppressWarnings("unchecked")
+        final var first = (java.util.Map<String, Object>) items.getFirst();
+        assertThat(first.get("v")).isEqualTo(JsonProperties.NULL_VALUE);
+    }
+
+    @Test
+    @DisplayName("End-to-end: a deep schema like the original Enexis report survives the round-trip")
+    void recordDefault_roundTrips() {
+        // A trimmed copy of the schema from the original bug report. It combines
+        // everything the previous tests cover, in one realistic shape:
+        //   - top-level record field with default {}
+        //   - record inside that with its own default {}
+        //   - a named-type reference (OpenIDType) used twice, also with default {}
+        //   - a union field "typeCode" with default null
+        //   - an array-of-records field with default []
+        //
+        // If any one piece of the fix breaks, this test will fail too. Think of
+        // it as the "does the real-world case work end-to-end" check.
+        final var schemaJson = """
+                {
+                  "type": "record",
+                  "name": "AssetEventValue",
+                  "namespace": "io.axual.test.deep",
+                  "fields": [
+                    {
+                      "name": "AssetEvent",
+                      "type": {
+                        "type": "record",
+                        "name": "AssetEvent",
+                        "fields": [
+                          {
+                            "name": "MRID",
+                            "type": {
+                              "type": "record",
+                              "name": "OpenIDType",
+                              "fields": [
+                                { "name": "content", "type": "string", "default": "" },
+                                { "name": "typeCode", "type": ["null", "string"], "default": null }
+                              ]
+                            },
+                            "default": {}
+                          },
+                          {
+                            "name": "Asset",
+                            "type": {
+                              "type": "record",
+                              "name": "Asset",
+                              "fields": [
+                                { "name": "MRID", "type": "OpenIDType", "default": {} },
+                                {
+                                  "name": "Attributes",
+                                  "type": { "type": "array", "items": {
+                                    "type": "record",
+                                    "name": "Attribute",
+                                    "fields": [
+                                      { "name": "name", "type": "string" },
+                                      { "name": "value", "type": "string" }
+                                    ]
+                                  } },
+                                  "default": []
+                                }
+                              ]
+                            },
+                            "default": {}
+                          }
+                        ]
+                      },
+                      "default": {}
+                    }
+                  ]
+                }
+                """;
+        final var avroSchema = new Schema.Parser().parse(schemaJson);
+        final var ksml = schemaMapper.toDataSchema(avroSchema);
+
+        // First check: just don't throw. Before the fix, this line would crash
+        // with "Unknown datum class: GenericData$Record".
+        final var back = schemaMapper.fromDataSchema(ksml);
+        assertThat(back.getField("AssetEvent").hasDefaultValue()).isTrue();
+
+        // Second check: the round-trip is stable. Going through the conversion
+        // twice should give us the same KSML schema each time.
+        final var ksml2 = schemaMapper.toDataSchema(back.getNamespace(), back.getName(), back);
+        assertThat(ksml2).isEqualTo(ksml);
+    }
 }

--- a/ksml/src/test/java/io/axual/ksml/python/PythonFunctionTest.java
+++ b/ksml/src/test/java/io/axual/ksml/python/PythonFunctionTest.java
@@ -27,6 +27,7 @@ import io.axual.ksml.definition.FunctionDefinition;
 import io.axual.ksml.definition.ParameterDefinition;
 import io.axual.ksml.dsl.KSMLDSL;
 import io.axual.ksml.type.UserType;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -35,6 +36,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 class PythonFunctionTest {
+    @BeforeAll
+    static void warmupGraalVM() {
+        // The very first Python context creation in a JVM can fail with a libgraal cold-start
+        // error ("Error decoding exception: [B@..."). Build one throwaway context here so the
+        // field initializer below always runs against a warm libgraal isolate.
+        try {
+            new PythonContext(PythonContextConfig.builder().build());
+        } catch (Exception ignored) {
+            // Warmup only — the real assertions happen in the @Test methods.
+        }
+    }
+
     final PythonContext context = new PythonContext(PythonContextConfig.builder().build());
     final ParameterDefinition one = new ParameterDefinition("one", DataInteger.DATATYPE);
     final ParameterDefinition two = new ParameterDefinition("two", DataInteger.DATATYPE);


### PR DESCRIPTION
# The Avro default-value bug — what broke and what we did about it

KSML lets you describe a Kafka topic with an Avro schema (a `.avsc` file). When KSML produces a message, it has to translate that schema into something the Avro library understands. **For one specific kind of schema — one where a record has a default value — KSML was building the wrong type of Java object, and Avro crashed every time it tried to serialise.** The producer would fail on the very first message and the runner would exit.

The fix is small and lives in one method. The four new tests pin it down so this can't slip through again.

## What is "a record with a default value"?

An Avro schema is just a JSON description of a message. A *record* is the Avro word for an object with named fields, and any field can declare what value to use if the message doesn't supply one. A simple example:

```json
{
  "type": "record",
  "name": "Person",
  "fields": [
    { "name": "name",    "type": "string", "default": "Anonymous" },
    { "name": "address", "type": {
        "type": "record",
        "name": "Address",
        "fields": [{ "name": "city", "type": "string", "default": "" }]
      },
      "default": {}
    }
  ]
}
```

Two fields, both with defaults:

- `name`'s default is the string `"Anonymous"` — easy.
- `address`'s default is the empty object `{}` — and `address` is itself a *record*. **This is the case that crashed.**

It's a common pattern in business schemas (CIM, CDM, the Enexis schema we hit in the bug report). It says "if the producer doesn't fill this in, treat the address as an empty record".

## Why it crashed

Here's roughly what happens when KSML produces a message with that schema:

1. KSML reads the `.avsc` file and parses it into KSML's own internal schema model.
2. When it's time to actually send a message, KSML asks the Apache Avro library to do the serialisation.
3. To do that, KSML hands its internal schema *back* to Avro, which means re-creating an Avro `Schema` object from KSML's internal representation. For each field, Avro asks "what's the default value?".
4. Avro then writes that default value into the schema as JSON.

Step 4 is the trap. Avro can only turn a small set of Java types into JSON: plain `Map`s, plain `List`s, byte arrays, strings, numbers, booleans, and a special "null marker" used for nulls inside containers. **If we hand it anything else, Avro throws.**

KSML used to do exactly this. For a record-typed default like `{}`, it built one of Avro's own internal record objects (a `GenericData.Record`) and handed *that* to Avro. Avro's JSON encoder doesn't accept its own record objects there, so it crashed with the error message:

```
Unknown datum class: class org.apache.avro.generic.GenericData$Record
```

And the producer never sent a single message.

## Why it used to work in 1.1.0

The exact same `.avsc` file ran fine on KSML 1.1.0. So what changed?

KSML 1.1.0 had a simpler internal model for values. When it parsed `"default": {}` from the schema, it stored the default as a plain Java `Map` wrapped in a thin holder class. When it was time to hand the default back to Avro, the code just unwrapped the holder and gave Avro the raw `Map`. Avro accepts `Map`s. No crash.

## What PR #375 changed (and why it broke this)

[PR #375](https://github.com/Axual/ksml/pull/375) was a big refactor of KSML's internal type system. Instead of "raw Java values wrapped in a thin holder", KSML now uses a proper hierarchy of typed classes — `DataString` for strings, `DataInteger` for ints, `DataStruct` for records, and so on. It's a cleaner model overall, but it changed the *shape* of the data flowing through the converter.

In the new model, `"default": {}` is no longer a plain `Map` under the hood — it's a `DataStruct`. The line in `AvroSchemaMapper` that hands the default back to Avro got rewritten as part of the refactor. The new line was, roughly:

```java
return avroMapper.fromDataObject(defaultValue);
```

The trouble is what `avroMapper.fromDataObject(...)` does when you give it a `DataStruct`: it builds **Avro's own internal record object** (a `GenericData.Record`) — exactly the kind of thing Avro's JSON encoder doesn't accept. The refactor accidentally went from "give Avro a plain Map" to "give Avro one of Avro's own record objects", and the producer started crashing on the very first message.

The PR did add tests around default values, but those tests only covered defaults that were `null` or simple strings. None of the new tests used a record-typed default like `"default": {}`. So the regression slipped through review and shipped in 1.2.0.

## The fix

In `AvroSchemaMapper.java` we now do something very simple: instead of handing Avro one of its own record objects, we hand it a plain `Map`. The new method `toJsonShapedDefault` walks through whatever default value KSML has and rebuilds it using only those JSON-friendly Java types.

Roughly:

| KSML value      | becomes                       |
|-----------------|-------------------------------|
| record (struct) | plain `LinkedHashMap`         |
| map             | plain `LinkedHashMap`         |
| list            | plain `ArrayList`             |
| string          | plain `String`                |
| number          | plain `Integer` / `Long` / …  |
| boolean         | plain `Boolean`               |
| `null`          | Avro's null marker          |

Two subtle points worth understanding:

1. **It recurses.** A record default can contain another record (think `{"address": {}}`). So when we turn the outer record into a `Map`, we also have to turn the inner record into a `Map`. Same for lists of records, maps of records, etc.

2. **Nulls are special.** If a default contains a null somewhere inside it (e.g. `{ "typeCode": null }`), we can't leave that as a plain Java `null`. Avro chokes on raw nulls *inside* containers. We have to swap them for Avro's `JsonProperties.NULL_VALUE` marker. 

That second point is what made this bug particularly easy to half-fix. An obvious first attempt at the fix gets past the original "Unknown datum class" error but then crashes on a *different* error (a `NullPointerException`) the moment a null shows up inside a default. We hit that exact thing while iterating, which is why one of the tests is specifically about it.

## The tests

Four tests, each one nailing down a different way the fix could break. They live in `AvroSchemaMapperTest.java`.

Each test follows the same recipe:

1. Build a small Avro schema as a JSON string.
2. Convert it: Avro → KSML's internal schema → back to Avro.
3. Check that step 2 didn't crash, and that the resulting default value has the right *shape* (a `Map`, a `List`, the null marker — whatever's appropriate).

Because the bug crashes on step 2, just *running* a test that goes through that path is most of the value. The shape assertions are the second line of defence.

### Test 1 — `recordDefault_emptyObject_roundTrips`

The simplest possible reproduction of the original bug. A record field with `"default": {}`. If anyone reintroduces the bug, this test fails first — usually within milliseconds — with the exact `Unknown datum class: GenericData$Record` message. It's the canary.

### Test 2 — `recordDefault_withExplicitNullInside_mapsToNullValue`

A record default that explicitly contains a null inside it (e.g. `"default": { "typeCode": null }`). This catches the *secondary* error mentioned above: a fix that handles records-as-maps but doesn't translate inner nulls to Avro's marker will crash here with a `NullPointerException`. Without this test, an incomplete fix could pass review and then explode on real-world schemas that contain explicit nulls.

### Test 3 — `arrayDefault_roundTrips`

Same idea as Test 2, but the null is inside *records inside an array* (`"default": [{ "v": null }, …]`). Lists go through a different code branch from records, and the same null rule has to hold there too. If someone refactors only one of the two branches and forgets the other, this test catches it.

### Test 4 — `recordDefault_roundTrips`

A trimmed copy of the real schema from the bug report. Combines everything: nested records, named-type references, null-defaulted unions, an empty array default, and an array of records — all in one schema. Think of it as the "does the actual user scenario still work end-to-end" check. If any one of the smaller fixes silently breaks, this test fails too.
