### PR TITLE
dependabot.yaml ignore fixes

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -16,9 +16,11 @@ updates:
         dependency-type: "production"      
     ignore:
     - dependency-name: "com.google.protobuf:protobuf-java"
-      versions: [ ">=4.0.0" ]
-    - dependency-name: "org.apache.kafka:*"
-      versions: [ ">=4.0.0" ]
+      versions: [ ">=4.0.0" ]   # 4.x has breaking lite-runtime semantics; KSML on 3.25.9
+    - dependency-name: "com.github.victools:*"
+      versions: [ ">=5.0.0" ]   # 5.0 requires Jackson 3 + Java 17
+    - dependency-name: "com.squareup.wire:*"
+      versions: [ ">=6.0.0" ]   # 6.0 changed ProtoFileElement constructor
   - package-ecosystem: "pip"
     directory: "/"
     schedule:


### PR DESCRIPTION
- Add ignore for com.github.victools:* >=5.0.0. 5.0 requires Jackson 3 (different groupId, tools.jackson.core) and Java 17.
- Add ignore for com.squareup.wire:* >=6.0.0. 6.0 changed the ProtoFileElement constructor, breaking ksml-data-protobuf.
- Drop the org.apache.kafka:* rule. The threshold (>=4.0.0) became stale when KSML moved to kafka 4.2.0 in #517 and was silently blocking all kafka updates. 
- Add inline comments documenting the reason for each remaining rule.