### PR TITLE
Fix Dependabot ignore rules and adopt Testcontainers 2.x

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -20,7 +20,7 @@ updates:
     - dependency-name: "com.github.victools:*"
       versions: [ ">=5.0.0" ]   # 5.0 requires Jackson 3 + Java 17
     - dependency-name: "com.squareup.wire:*"
-      versions: [ ">=6.0.0" ]   # 6.0 changed ProtoFileElement constructor
+      versions: [ ">=5.3.0" ]   # 5.3 changed ProtoFileElement constructor (added a param)
   - package-ecosystem: "pip"
     directory: "/"
     schedule:

--- a/ksml-integration-tests/pom.xml
+++ b/ksml-integration-tests/pom.xml
@@ -23,17 +23,17 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>kafka</artifactId>
+            <artifactId>testcontainers-kafka</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>toxiproxy</artifactId>
+            <artifactId>testcontainers-toxiproxy</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <junit.version>6.0.3</junit.version>
         <mockito-core.version>5.23.0</mockito-core.version>
         <mockito-junit-jupiter.version>5.23.0</mockito-junit-jupiter.version>
-        <testcontainers.version>1.21.4</testcontainers.version>
+        <testcontainers.version>2.0.5</testcontainers.version>
 
         <!-- Project and java version settings -->
         <java.source.version>23</java.source.version>


### PR DESCRIPTION
  - Tighten com.squareup.wire ignore from >=6.0.0 to >=5.3.0 — the ProtoFileElement constructor arity changed in 5.3, not 6.0
  - Migrate ksml-integration-tests to Testcontainers 2.x artifact names (kafka → testcontainers-kafka, junit-jupiter → testcontainers-junit-jupiter, toxiproxy → testcontainers-toxiproxy) and bump version to 2.0.5 —
  all 9 integration tests pass