### PR TITLE
Fix crash when processing Avro schemas with composite default values (DataList, DataEnum, DataMap, DataBoolean)

### DIFF
--- a/ksml/src/main/java/io/axual/ksml/schema/NativeDataSchemaMapper.java
+++ b/ksml/src/main/java/io/axual/ksml/schema/NativeDataSchemaMapper.java
@@ -197,7 +197,8 @@ public class NativeDataSchemaMapper implements DataSchemaMapper<Object> {
             case DataBytes value -> node.put(fieldName, value.value());
             case DataString value -> node.put(fieldName, value.value());
             default ->
-                    throw new ExecutionException("Can not encode default value of type: " + defaultValue.getClass().getSimpleName());
+                    throw new ExecutionException(String.format(
+                        "Can not encode default value: type= %s, value= %s", defaultValue.getClass().getSimpleName(), defaultValue));
         }
     }
 }

--- a/ksml/src/main/java/io/axual/ksml/schema/NativeDataSchemaMapper.java
+++ b/ksml/src/main/java/io/axual/ksml/schema/NativeDataSchemaMapper.java
@@ -25,9 +25,12 @@ import io.axual.ksml.data.object.DataBoolean;
 import io.axual.ksml.data.object.DataByte;
 import io.axual.ksml.data.object.DataBytes;
 import io.axual.ksml.data.object.DataDouble;
+import io.axual.ksml.data.object.DataEnum;
 import io.axual.ksml.data.object.DataFloat;
 import io.axual.ksml.data.object.DataInteger;
+import io.axual.ksml.data.object.DataList;
 import io.axual.ksml.data.object.DataLong;
+import io.axual.ksml.data.object.DataMap;
 import io.axual.ksml.data.object.DataNull;
 import io.axual.ksml.data.object.DataObject;
 import io.axual.ksml.data.object.DataShort;
@@ -185,22 +188,35 @@ public class NativeDataSchemaMapper implements DataSchemaMapper<Object> {
     }
 
     private void encodeDefaultValue(Map<String, Object> node, DataObject defaultValue) {
-        final var fieldName = DataSchemaDSL.STRUCT_SCHEMA_FIELD_DEFAULT_VALUE_FIELD;
-        switch (defaultValue) {
-            case null -> node.put(fieldName, null);
-            case DataNull unused -> node.put(fieldName, null);
-            case DataBoolean value -> node.put(fieldName, value.value());
-            case DataByte value -> node.put(fieldName, value.value());
-            case DataShort value -> node.put(fieldName, value.value());
-            case DataInteger value -> node.put(fieldName, value.value());
-            case DataLong value -> node.put(fieldName, value.value());
-            case DataDouble value -> node.put(fieldName, value.value());
-            case DataFloat value -> node.put(fieldName, value.value());
-            case DataBytes value -> node.put(fieldName, value.value());
-            case DataString value -> node.put(fieldName, value.value());
-            default ->
-                    throw new ExecutionException(
-                        "Can not encode default value: type=%s, value=%s".formatted(defaultValue.getClass().getSimpleName(), defaultValue));
-        }
+        node.put(DataSchemaDSL.STRUCT_SCHEMA_FIELD_DEFAULT_VALUE_FIELD, encodeValue(defaultValue));
+    }
+
+    private Object encodeValue(DataObject value) {
+        return switch (value) {
+            case null -> null;
+            case DataNull unused -> null;
+            case DataBoolean v -> v.value();
+            case DataByte v -> v.value();
+            case DataShort v -> v.value();
+            case DataInteger v -> v.value();
+            case DataLong v -> v.value();
+            case DataDouble v -> v.value();
+            case DataFloat v -> v.value();
+            case DataBytes v -> v.value();
+            case DataString v -> v.value();
+            case DataEnum v -> v.value();
+            case DataList v -> {
+                var list = new ArrayList<>();
+                for (var element : v) list.add(encodeValue(element));
+                yield list;
+            }
+            case DataMap v -> {
+                var map = new LinkedHashMap<String, Object>();
+                v.forEach((k, val) -> map.put(k, encodeValue(val)));
+                yield map;
+            }
+            default -> throw new ExecutionException(
+                "Can not encode default value: type=%s, value=%s".formatted(value.getClass().getSimpleName(), value));
+        };
     }
 }

--- a/ksml/src/main/java/io/axual/ksml/schema/NativeDataSchemaMapper.java
+++ b/ksml/src/main/java/io/axual/ksml/schema/NativeDataSchemaMapper.java
@@ -21,6 +21,7 @@ package io.axual.ksml.schema;
  */
 
 import io.axual.ksml.data.mapper.DataSchemaMapper;
+import io.axual.ksml.data.object.DataBoolean;
 import io.axual.ksml.data.object.DataByte;
 import io.axual.ksml.data.object.DataBytes;
 import io.axual.ksml.data.object.DataDouble;
@@ -188,6 +189,7 @@ public class NativeDataSchemaMapper implements DataSchemaMapper<Object> {
         switch (defaultValue) {
             case null -> node.put(fieldName, null);
             case DataNull unused -> node.put(fieldName, null);
+            case DataBoolean value -> node.put(fieldName, value.value());
             case DataByte value -> node.put(fieldName, value.value());
             case DataShort value -> node.put(fieldName, value.value());
             case DataInteger value -> node.put(fieldName, value.value());
@@ -197,8 +199,8 @@ public class NativeDataSchemaMapper implements DataSchemaMapper<Object> {
             case DataBytes value -> node.put(fieldName, value.value());
             case DataString value -> node.put(fieldName, value.value());
             default ->
-                    throw new ExecutionException(String.format(
-                        "Can not encode default value: type= %s, value= %s", defaultValue.getClass().getSimpleName(), defaultValue));
+                    throw new ExecutionException(
+                        "Can not encode default value: type=%s, value=%s".formatted(defaultValue.getClass().getSimpleName(), defaultValue));
         }
     }
 }

--- a/ksml/src/test/java/io/axual/ksml/schema/NativeDataSchemaMapperTest.java
+++ b/ksml/src/test/java/io/axual/ksml/schema/NativeDataSchemaMapperTest.java
@@ -21,9 +21,16 @@ package io.axual.ksml.schema;
  */
 
 import io.axual.ksml.data.object.DataBoolean;
+import io.axual.ksml.data.object.DataEnum;
+import io.axual.ksml.data.object.DataList;
+import io.axual.ksml.data.object.DataMap;
+import io.axual.ksml.data.object.DataString;
 import io.axual.ksml.data.object.DataStruct;
 import io.axual.ksml.data.schema.DataSchema;
+import io.axual.ksml.data.schema.EnumSchema;
+import io.axual.ksml.data.schema.ListSchema;
 import io.axual.ksml.data.schema.StructSchema;
+import io.axual.ksml.data.type.EnumType;
 import io.axual.ksml.exception.ExecutionException;
 import org.junit.jupiter.api.Test;
 
@@ -31,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class NativeDataSchemaMapperTest {
@@ -59,6 +67,88 @@ class NativeDataSchemaMapperTest {
         var fields = (List<?>) result.get("fields");
         var fieldMap = (Map<?, ?>) fields.get(0);
         assertThat(fieldMap.get("defaultValue")).isEqualTo(false);
+    }
+
+    @Test
+    void emptyListDefaultValue_isEncodedAsEmptyList() {
+        var field = new StructSchema.Field("tags", new ListSchema(DataSchema.STRING_SCHEMA), null, 0, false, false, new DataList());
+        var schema = new StructSchema(null, "TestRecord", null, List.of(field));
+
+        var result = (Map<?, ?>) mapper.fromDataSchema(schema);
+
+        var fields = (List<?>) result.get("fields");
+        var fieldMap = (Map<?, ?>) fields.get(0);
+        assertThat(fieldMap.get("defaultValue")).isEqualTo(List.of());
+    }
+
+    @Test
+    void listDefaultValue_withStringElements_isEncodedCorrectly() {
+        var list = new DataList();
+        list.add(new DataString("a"));
+        list.add(new DataString("b"));
+        var field = new StructSchema.Field("tags", new ListSchema(DataSchema.STRING_SCHEMA), null, 0, false, false, list);
+        var schema = new StructSchema(null, "TestRecord", null, List.of(field));
+
+        var result = (Map<?, ?>) mapper.fromDataSchema(schema);
+
+        var fields = (List<?>) result.get("fields");
+        var fieldMap = (Map<?, ?>) fields.get(0);
+        assertThat(fieldMap.get("defaultValue")).isEqualTo(List.of("a", "b"));
+    }
+
+    @Test
+    void enumDefaultValue_isEncodedAsString() {
+        var enumSchema = new EnumSchema(null, "SensorType", null,
+                List.of(EnumSchema.Symbol.of("AREA"), EnumSchema.Symbol.of("TEMPERATURE")));
+        var enumType = new EnumType(enumSchema);
+        var field = new StructSchema.Field("kind", enumSchema, null, 0, false, false, new DataEnum(enumType, "AREA"));
+        var schema = new StructSchema(null, "TestRecord", null, List.of(field));
+
+        var result = (Map<?, ?>) mapper.fromDataSchema(schema);
+
+        var fields = (List<?>) result.get("fields");
+        var fieldMap = (Map<?, ?>) fields.get(0);
+        assertThat(fieldMap.get("defaultValue")).isEqualTo("AREA");
+    }
+
+    @Test
+    void emptyMapDefaultValue_isEncodedAsEmptyMap() {
+        var field = new StructSchema.Field("props", DataSchema.STRING_SCHEMA, null, 0, false, false, new DataMap());
+        var schema = new StructSchema(null, "TestRecord", null, List.of(field));
+
+        var result = (Map<?, ?>) mapper.fromDataSchema(schema);
+
+        var fields = (List<?>) result.get("fields");
+        var fieldMap = (Map<?, ?>) fields.get(0);
+        assertThat(fieldMap.get("defaultValue")).isEqualTo(Map.of());
+    }
+
+    @Test
+    void mapDefaultValue_withStringValues_isEncodedCorrectly() {
+        var map = new DataMap();
+        map.put("key1", new DataString("val1"));
+        map.put("key2", new DataString("val2"));
+        var field = new StructSchema.Field("props", DataSchema.STRING_SCHEMA, null, 0, false, false, map);
+        var schema = new StructSchema(null, "TestRecord", null, List.of(field));
+
+        var result = (Map<?, ?>) mapper.fromDataSchema(schema);
+
+        var fields = (List<?>) result.get("fields");
+        var fieldMap = (Map<?, ?>) fields.get(0);
+        assertThat(fieldMap.get("defaultValue")).isEqualTo(Map.of("key1", "val1", "key2", "val2"));
+    }
+
+    @Test
+    void attributesField_withEmptyArrayDefault_doesNotThrow() {
+        // Regression test: Avro schema with "Attributes": { "type": "array", "default": [] } crashed with DataList
+        var attributeSchema = new StructSchema(null, "Attribute", null, List.of(
+                new StructSchema.Field("AttributeName", DataSchema.STRING_SCHEMA, null, 0, false, false, null),
+                new StructSchema.Field("AttributeValue", DataSchema.STRING_SCHEMA, null, 0, false, false, null)));
+        var attributesField = new StructSchema.Field("Attributes", new ListSchema(attributeSchema),
+                null, 0, false, false, new DataList());
+        var schema = new StructSchema(null, "Asset", null, List.of(attributesField));
+
+        assertThatNoException().isThrownBy(() -> mapper.fromDataSchema(schema));
     }
 
     @Test

--- a/ksml/src/test/java/io/axual/ksml/schema/NativeDataSchemaMapperTest.java
+++ b/ksml/src/test/java/io/axual/ksml/schema/NativeDataSchemaMapperTest.java
@@ -1,0 +1,75 @@
+package io.axual.ksml.schema;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML
+ * %%
+ * Copyright (C) 2021 - 2025 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import io.axual.ksml.data.object.DataBoolean;
+import io.axual.ksml.data.object.DataStruct;
+import io.axual.ksml.data.schema.DataSchema;
+import io.axual.ksml.data.schema.StructSchema;
+import io.axual.ksml.exception.ExecutionException;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class NativeDataSchemaMapperTest {
+
+    private final NativeDataSchemaMapper mapper = new NativeDataSchemaMapper();
+
+    @Test
+    void booleanDefaultValue_isEncodedCorrectly() {
+        var field = new StructSchema.Field("active", DataSchema.BOOLEAN_SCHEMA, null, 0, false, false, new DataBoolean(true));
+        var schema = new StructSchema(null, "TestRecord", null, List.of(field));
+
+        var result = (Map<?, ?>) mapper.fromDataSchema(schema);
+
+        var fields = (List<?>) result.get("fields");
+        var fieldMap = (Map<?, ?>) fields.get(0);
+        assertThat(fieldMap.get("defaultValue")).isEqualTo(true);
+    }
+
+    @Test
+    void booleanFalseDefaultValue_isEncodedCorrectly() {
+        var field = new StructSchema.Field("deleted", DataSchema.BOOLEAN_SCHEMA, null, 0, false, false, new DataBoolean(false));
+        var schema = new StructSchema(null, "TestRecord", null, List.of(field));
+
+        var result = (Map<?, ?>) mapper.fromDataSchema(schema);
+
+        var fields = (List<?>) result.get("fields");
+        var fieldMap = (Map<?, ?>) fields.get(0);
+        assertThat(fieldMap.get("defaultValue")).isEqualTo(false);
+    }
+
+    @Test
+    void unknownDefaultValueType_throwsWithTypeAndValueInMessage() {
+        var unhandledDefault = new DataStruct();
+        var field = new StructSchema.Field("broken", DataSchema.STRING_SCHEMA, null, 0, false, false, unhandledDefault);
+        var schema = new StructSchema(null, "TestRecord", null, List.of(field));
+
+        assertThatThrownBy(() -> mapper.fromDataSchema(schema))
+                .isInstanceOf(ExecutionException.class)
+                .hasMessageContaining("DataStruct")
+                .hasMessageContaining(unhandledDefault.toString());
+    }
+}


### PR DESCRIPTION
## Problem

KSML crashed on the first message processed through any Python function (filter, transform, peek, etc.) when the source Avro schema contained a field with a composite or boolean default value.

The most common trigger was an array field with an empty-array default:

```json
{
  "name": "Attributes",
  "type": { "type": "array", "items": { ... } },
  "default": []
}
```

Error seen in production (KSML 1.2.1):

```
io.axual.ksml.exception.ExecutionException: KSML execution error: Can not encode default value of type: DataList
  at NativeDataSchemaMapper.encodeDefaultValue(NativeDataSchemaMapper.java:200)
  at NativeDataSchemaMapper.convertField
  ...
  at UserPredicate.test
  at FilterOperation
```

The same crash occurred for `DataEnum` and `DataMap` defaults. `DataBoolean` was also missing from the switch and would throw for any schema field with a boolean default.

## Root Cause

`NativeDataSchemaMapper.encodeDefaultValue` converts a field's default value into a native Java value before passing the schema as a Python dict to user functions. Its switch statement was incomplete — it handled most numeric primitives and strings, but was missing:

| Type | Example Avro default |
|---|---|
| `DataBoolean` | `"default": true` |
| `DataEnum` | `"default": "SYMBOL"` |
| `DataList` | `"default": []` |
| `DataMap` | `"default": {}` |


## Changes

Refactored `encodeDefaultValue` by extracting a private `encodeValue(DataObject) → Object` helper. This allows the switch to return a value directly and enables natural recursion for `DataList` and `DataMap` elements. The four missing types are now handled:

- `DataBoolean` → `v.value()` (boolean)
- `DataEnum` → `v.value()` (symbol string)
- `DataList` → recursively encodes each element into an `ArrayList`
- `DataMap` → recursively encodes each entry into a `LinkedHashMap<String, Object>`

The error message in the fallback `default` case is also improved to include both the type name and the value, making future unhandled types easier to diagnose.