### PR TITLE
Fix Sonar

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -29,11 +29,11 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'graalvm'
-          java-version: '23'
+          java-version: '25'
           cache: 'maven'
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -49,18 +49,18 @@ jobs:
         run: |
           SONAR_ARGS=""
 
-          if [[ "${{ github.ref_type }}" == "tag" ]]; then
-            SONAR_ARGS="-Dsonar.branch.name=${{ github.ref_name }}"
+          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+            SONAR_ARGS="-Dsonar.branch.name=$GITHUB_REF_NAME"
 
-          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            SONAR_ARGS="-Dsonar.pullrequest.key=${{ github.event.pull_request.number }} \
-              -Dsonar.pullrequest.branch=${{ github.head_ref }} \
-              -Dsonar.pullrequest.base=${{ github.base_ref }}"
+          elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            SONAR_ARGS="-Dsonar.pullrequest.key=$PR_NUMBER \
+              -Dsonar.pullrequest.branch=$GITHUB_HEAD_REF \
+              -Dsonar.pullrequest.base=$GITHUB_BASE_REF"
 
-          elif [[ "${{ github.ref_type }}" == "branch" ]]; then
-            SONAR_ARGS="-Dsonar.branch.name=${{ github.ref_name }}"
-            if [[ "${{ github.ref_name }}" != "${{ github.event.repository.default_branch }}" ]]; then
-              SONAR_ARGS="${SONAR_ARGS} -Dsonar.branch.target=${{ github.event.repository.default_branch }}"
+          elif [[ "$GITHUB_REF_TYPE" == "branch" ]]; then
+            SONAR_ARGS="-Dsonar.branch.name=$GITHUB_REF_NAME"
+            if [[ "$GITHUB_REF_NAME" != "$DEFAULT_BRANCH" ]]; then
+              SONAR_ARGS="${SONAR_ARGS} -Dsonar.branch.target=$DEFAULT_BRANCH"
             fi
           fi
 
@@ -68,6 +68,8 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
       - name: Publish test results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -32,48 +32,41 @@ jobs:
           java-version: '23'
           cache: 'maven'
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build and run all tests (unit + integration)
-        run: |
-          # Sonar disabled
-          # # Determine SonarQube arguments based on build type
-          # # Reference: https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/branches/branch-analysis/
-          # SONAR_ADDITION=""
-
-          # # Scenario 1: Tag builds - analyze as a branch with the tag name
-          # if [[ "${{ github.ref_type }}" == "tag" ]]; then
-          #   SONAR_ADDITION="-Dsonar.branch.name=${{ github.ref_name }}"
-          #   echo "SonarQube: Analyzing tag build '${{ github.ref_name }}'"
-
-          # # Scenario 2: Pull request builds - analyze as a pull request
-          # elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-          #   SONAR_ADDITION="-Dsonar.pullrequest.key=${{ github.event.pull_request.number }} \
-          #     -Dsonar.pullrequest.branch=${{ github.head_ref }} \
-          #     -Dsonar.pullrequest.base=${{ github.base_ref }}"
-          #   echo "SonarQube: Analyzing PR #${{ github.event.pull_request.number }} (${{ github.head_ref }} -> ${{ github.base_ref }})"
-
-          # # Scenario 3: Branch builds - analyze as a branch
-          # elif [[ "${{ github.ref_type }}" == "branch" ]]; then
-          #   SONAR_ADDITION="-Dsonar.branch.name=${{ github.ref_name }}"
-          #   echo "SonarQube: Analyzing branch '${{ github.ref_name }}'"
-
-          #   # If not the default branch, set target to default branch for comparison
-          #   if [[ "${{ github.ref_name }}" != "${{ github.event.repository.default_branch }}" ]]; then
-          #     SONAR_ADDITION="${SONAR_ADDITION} -Dsonar.branch.target=${{ github.event.repository.default_branch }}"
-          #     echo "SonarQube: Branch target set to '${{ github.event.repository.default_branch }}'"
-          #   fi
-          # fi
-
-          # Run Maven build with SonarQube arguments
-          # mvn clean verify -DskipITs=false --no-transfer-progress ${SONAR_ADDITION}
-
-          # Run Maven build without SonarQube
-          mvn clean verify -DskipITs=false --no-transfer-progress
+        timeout-minutes: 60
+        run: mvn clean verify -DskipITs=false --no-transfer-progress
         env:
-          # TestContainers configuration for GitHub Actions
           TESTCONTAINERS_RYUK_DISABLED: false
-          # SonarQube token - Maven profile auto-activates when set
-          # SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          # GitHub token for SonarCloud PR decoration
+
+      - name: SonarCloud analysis
+        timeout-minutes: 15
+        run: |
+          SONAR_ARGS=""
+
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            SONAR_ARGS="-Dsonar.branch.name=${{ github.ref_name }}"
+
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            SONAR_ARGS="-Dsonar.pullrequest.key=${{ github.event.pull_request.number }} \
+              -Dsonar.pullrequest.branch=${{ github.head_ref }} \
+              -Dsonar.pullrequest.base=${{ github.base_ref }}"
+
+          elif [[ "${{ github.ref_type }}" == "branch" ]]; then
+            SONAR_ARGS="-Dsonar.branch.name=${{ github.ref_name }}"
+            if [[ "${{ github.ref_name }}" != "${{ github.event.repository.default_branch }}" ]]; then
+              SONAR_ARGS="${SONAR_ARGS} -Dsonar.branch.target=${{ github.event.repository.default_branch }}"
+            fi
+          fi
+
+          mvn sonar:sonar --no-transfer-progress ${SONAR_ARGS}
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish test results

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/backend/KafkaStreamsRunnerTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/backend/KafkaStreamsRunnerTest.java
@@ -706,7 +706,9 @@ class KafkaStreamsRunnerTest {
             // Start runner, is blocked so check with async
             var future = CompletableFuture.runAsync(runner, executor);
 
-            verify(mockStreams, Mockito.timeout(30_000).times(1)).start();
+            Awaitility.await("Wait for start() to be called")
+                    .atMost(Duration.ofSeconds(30))
+                    .untilAsserted(() -> verify(mockStreams, Mockito.times(1)).start());
             assertThat(future)
                     .as("Future should not have finished yet")
                     .isNotDone();

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/backend/KafkaStreamsRunnerTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/backend/KafkaStreamsRunnerTest.java
@@ -706,7 +706,7 @@ class KafkaStreamsRunnerTest {
             // Start runner, is blocked so check with async
             var future = CompletableFuture.runAsync(runner, executor);
 
-            verify(mockStreams, Mockito.timeout(1000).times(1)).start();
+            verify(mockStreams, Mockito.timeout(30_000).times(1)).start();
             assertThat(future)
                     .as("Future should not have finished yet")
                     .isNotDone();
@@ -718,7 +718,7 @@ class KafkaStreamsRunnerTest {
             runner.stop();
 
             Awaitility.await("Wait for runner to stop")
-                    .atMost(Duration.ofSeconds(1))
+                    .atMost(Duration.ofSeconds(30))
                     .until(future::isDone);
         } finally {
             executor.shutdownNow();

--- a/pom.xml
+++ b/pom.xml
@@ -152,8 +152,6 @@
         <sonar.version>5.7.0.6970</sonar.version>
 
         <!-- Sonar for JACOCO-->
-        <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
-        <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
         <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/ksml-reporting/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 


### PR DESCRIPTION
- Re-enable SonarCloud analysis in CI (was commented out), split into a separate step from the build
- Add timeout-minutes: 60 to the build step and timeout-minutes: 15 to the Sonar step
- Add Docker Hub login before the build to avoid TestContainers rate limit failures
- Remove two obsolete Sonar properties from pom.xml (sonar.java.coveragePlugin, sonar.dynamicAnalysis)
- Increase flaky test timeouts in KafkaStreamsRunnerTest from 1s to 30s