### PR TITLE
Sonar fork PR support

### DIFF
--- a/.github/workflows/ci-pr-fork-build.yml
+++ b/.github/workflows/ci-pr-fork-build.yml
@@ -17,12 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Set up GraalVM
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/ci-pr-fork-build.yml
+++ b/.github/workflows/ci-pr-fork-build.yml
@@ -62,3 +62,5 @@ jobs:
             **/target/classes/
             **/target/generated-sources/
             **/target/failsafe-reports/
+            **/src/main/java/
+            **/src/test/java/

--- a/.github/workflows/ci-pr-fork-build.yml
+++ b/.github/workflows/ci-pr-fork-build.yml
@@ -1,0 +1,64 @@
+name: CI - Fork PR Build
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: fork-build-${{ github.event.pull_request.head.repo.full_name }}-${{ github.event.pull_request.head.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.fork == true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up GraalVM
+        uses: actions/setup-java@v5
+        with:
+          distribution: graalvm
+          java-version: '25'
+          cache: maven
+
+      - name: Build and test
+        timeout-minutes: 60
+        run: mvn clean verify -DskipITs=false --no-transfer-progress
+        env:
+          TESTCONTAINERS_RYUK_DISABLED: false
+
+      - name: Save PR metadata
+        env:
+          REPO_NAME: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          mkdir -p pr-metadata
+          printf '%s' "$REPO_NAME" > pr-metadata/repo-name
+          printf '%s' "$HEAD_REF"  > pr-metadata/head-ref
+          printf '%s' "$HEAD_SHA"  > pr-metadata/head-sha
+          printf '%s' "$PR_NUMBER" > pr-metadata/pr-number
+          printf '%s' "$BASE_REF"  > pr-metadata/base-ref
+
+      - name: Upload Sonar inputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: sonar-inputs-${{ github.event.pull_request.head.sha }}
+          retention-days: 1
+          path: |
+            pr-metadata/
+            ksml-reporting/target/site/jacoco-aggregate/jacoco.xml
+            **/target/classes/
+            **/target/generated-sources/
+            **/target/failsafe-reports/

--- a/.github/workflows/ci-pr-fork-sonar.yml
+++ b/.github/workflows/ci-pr-fork-sonar.yml
@@ -1,0 +1,98 @@
+name: CI - Fork PR Sonar Analysis
+
+on:
+  workflow_run:
+    workflows: ["CI - Fork PR Build"]
+    types: [completed]
+
+concurrency:
+  group: fork-sonar-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  checks: write
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  sonar:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download Sonar inputs
+        uses: actions/download-artifact@v4
+        with:
+          name: sonar-inputs-${{ github.event.workflow_run.head_sha }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Read PR metadata
+        run: |
+          echo "PR_NUMBER=$(cat pr-metadata/pr-number)"   >> $GITHUB_ENV
+          echo "HEAD_REF=$(cat pr-metadata/head-ref)"     >> $GITHUB_ENV
+          echo "BASE_REF=$(cat pr-metadata/base-ref)"     >> $GITHUB_ENV
+          echo "HEAD_SHA=$(cat pr-metadata/head-sha)"     >> $GITHUB_ENV
+          echo "REPO_NAME=$(cat pr-metadata/repo-name)"   >> $GITHUB_ENV
+
+      - name: Checkout fork source (for Sonar line mapping only)
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.REPO_NAME }}
+          ref: ${{ env.HEAD_SHA }}
+          fetch-depth: 0
+
+      - name: Discover build output paths
+        run: |
+          BINARIES=$(find . -type d -name classes -path '*/target/classes' | sort -u | paste -sd ',' -)
+          GENERATED=$(find . -type d -name generated-sources -path '*/target/generated-sources' | sort -u | paste -sd ',' -)
+          SOURCES=$(find . -type d -name java -path '*/main/java' | sort -u | paste -sd ',' -)
+          TESTS=$(find . -type d -name java -path '*/test/java' | sort -u | paste -sd ',' -)
+          echo "SONAR_BINARIES=$BINARIES"   >> $GITHUB_ENV
+          echo "SONAR_GENERATED=$GENERATED" >> $GITHUB_ENV
+          echo "SONAR_SOURCES=$SOURCES"     >> $GITHUB_ENV
+          echo "SONAR_TESTS=$TESTS"         >> $GITHUB_ENV
+
+      - name: SonarCloud analysis
+        uses: SonarSource/sonarqube-scan-action@v5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: >
+            -Dsonar.pullrequest.key=${{ env.PR_NUMBER }}
+            -Dsonar.pullrequest.branch=${{ env.HEAD_REF }}
+            -Dsonar.pullrequest.base=${{ env.BASE_REF }}
+            -Dsonar.pullrequest.provider=github
+            -Dsonar.pullrequest.github.repository=${{ github.repository }}
+            -Dsonar.scm.revision=${{ env.HEAD_SHA }}
+            -Dsonar.sources=${{ env.SONAR_SOURCES }}
+            -Dsonar.tests=${{ env.SONAR_TESTS }}
+            -Dsonar.java.binaries=${{ env.SONAR_BINARIES }}
+            -Dsonar.generatedSources=${{ env.SONAR_GENERATED }}
+            -Dsonar.coverage.jacoco.xmlReportPaths=ksml-reporting/target/site/jacoco-aggregate/jacoco.xml
+            -Dsonar.qualitygate.wait=true
+
+      - name: Delete artifacts after analysis
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+            for (const artifact of artifacts.data.artifacts) {
+              if (artifact.name.startsWith('sonar-inputs-')) {
+                await github.rest.actions.deleteArtifact({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  artifact_id: artifact.id,
+                });
+              }
+            }

--- a/.github/workflows/ci-pr-fork-sonar.yml
+++ b/.github/workflows/ci-pr-fork-sonar.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Checkout base repo
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.repository }}
           fetch-depth: 0
 
       - name: Download Sonar inputs
@@ -69,7 +70,7 @@ jobs:
             -Dsonar.sources=${{ env.SONAR_SOURCES }}
             -Dsonar.tests=${{ env.SONAR_TESTS }}
             -Dsonar.java.binaries=${{ env.SONAR_BINARIES }}
-            -Dsonar.generatedSources=${{ env.SONAR_GENERATED }}
+            -Dsonar.java.generatedSources=${{ env.SONAR_GENERATED }}
             -Dsonar.coverage.jacoco.xmlReportPaths=ksml-reporting/target/site/jacoco-aggregate/jacoco.xml
             -Dsonar.qualitygate.wait=true
 

--- a/.github/workflows/ci-pr-fork-sonar.yml
+++ b/.github/workflows/ci-pr-fork-sonar.yml
@@ -23,6 +23,11 @@ jobs:
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
     steps:
+      - name: Checkout base repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Download Sonar inputs
         uses: actions/download-artifact@v4
         with:
@@ -36,14 +41,6 @@ jobs:
           echo "HEAD_REF=$(cat pr-metadata/head-ref)"     >> $GITHUB_ENV
           echo "BASE_REF=$(cat pr-metadata/base-ref)"     >> $GITHUB_ENV
           echo "HEAD_SHA=$(cat pr-metadata/head-sha)"     >> $GITHUB_ENV
-          echo "REPO_NAME=$(cat pr-metadata/repo-name)"   >> $GITHUB_ENV
-
-      - name: Checkout fork source (for Sonar line mapping only)
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ env.REPO_NAME }}
-          ref: ${{ env.HEAD_SHA }}
-          fetch-depth: 0
 
       - name: Discover build output paths
         run: |


### PR DESCRIPTION
- Fork PRs from outside contributors had no Sonar checks because GitHub blocks secrets from untrusted code
- Adds two new workflows that work together: one builds the fork PR and saves the results, the other picks up those results and runs Sonar safely
- The build runs without secrets; Sonar runs separately in a trusted context where secrets are available
- No changes to existing workflows - everything for internal PRs stays the same
- Both files need to be on main before this works