### PR TITLE
Fix fork PR Sonar analysis

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,12 +12,14 @@ on:
 jobs:
   maven-build-test:
     name: Maven Build and Test (Unit + Integration)
+    if: github.event.pull_request.head.repo.fork == false || github.event_name != 'pull_request'
     uses: ./.github/workflows/maven-build.yml
     secrets: inherit
 
   docker-build-test:
     name: Docker build test on local registry
     needs: maven-build-test
+    if: github.event.pull_request.head.repo.fork == false || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     services:
       registry:

--- a/.github/workflows/ci-pr-fork-sonar.yml
+++ b/.github/workflows/ci-pr-fork-sonar.yml
@@ -55,12 +55,14 @@ jobs:
           echo "SONAR_TESTS=$TESTS"         >> $GITHUB_ENV
 
       - name: SonarCloud analysis
-        uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           args: >
+            -Dsonar.projectKey=ksml
+            -Dsonar.organization=axual-github
             -Dsonar.pullrequest.key=${{ env.PR_NUMBER }}
             -Dsonar.pullrequest.branch=${{ env.HEAD_REF }}
             -Dsonar.pullrequest.base=${{ env.BASE_REF }}


### PR DESCRIPTION
- Sonar analysis was failing because the standalone scanner needs sonar.projectKey and sonar.organization passed explicitly - unlike the Maven plugin, it does not read these from pom.xml
- Upgraded sonarqube-scan-action from v5 to v6 - v5 has a known security vulnerability
- Fixed build-and-test.yml to skip both jobs for fork PRs - previously it ran and failed on the Docker Hub login step because secrets are not available for fork pull requests