### PR TITLE
Fix SonarCloud fork PR analysis and coverage accuracy

### DIFF
--- a/.github/workflows/ci-pr-fork-sonar.yml
+++ b/.github/workflows/ci-pr-fork-sonar.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  actions: read
+  actions: write
   checks: write
   contents: read
   pull-requests: write
@@ -42,6 +42,12 @@ jobs:
           echo "HEAD_REF=$(cat pr-metadata/head-ref)"     >> $GITHUB_ENV
           echo "BASE_REF=$(cat pr-metadata/base-ref)"     >> $GITHUB_ENV
           echo "HEAD_SHA=$(cat pr-metadata/head-sha)"     >> $GITHUB_ENV
+          echo "FORK_REPO=$(cat pr-metadata/repo-name)"   >> $GITHUB_ENV
+
+      - name: Fetch fork commits for SCM context
+        run: |
+          git remote add fork https://github.com/${{ env.FORK_REPO }}
+          git fetch fork ${{ env.HEAD_REF }}
 
       - name: Discover build output paths
         run: |

--- a/ksml-reporting/pom.xml
+++ b/ksml-reporting/pom.xml
@@ -105,6 +105,11 @@
             <artifactId>ksml-kafka-clients</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.axual.ksml</groupId>
+            <artifactId>ksml-test-runner</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/lombok.config
+++ b/lombok.config
@@ -1,3 +1,4 @@
 lombok.accessors.fluent=true
 lombok.accessors.chain=false
 lombok.equalsAndHashCode.callSuper=call
+lombok.addLombokGeneratedAnnotation=true


### PR DESCRIPTION
This PR fixes three independent issues affecting SonarCloud analysis quality and accuracy.

Fork PR Sonar reporting zero new issues

- W2 (the Sonar workflow) checks out only the base repo, so the fork's commit SHA was absent from the local git history
- Sonar uses git blame to identify which lines are "new" in the PR - with an unknown SHA it finds nothing and reports zero issues
- Fixed by reading the fork repo name from the uploaded PR metadata and fetching the fork's branch before running Sonar, giving git blame the commits it needs
- Confirmed root cause via Sonar API: new_code_smells: ? (undefined, not 0) and documented in the SonarSource community forum

Artifact deletion failing after Sonar analysis

- The "Delete artifacts after analysis" step was failing every run with HttpError: Resource not accessible by integration
- Deleting an artifact requires write access but the workflow only had actions: read
- Fixed by changing the permission to actions: write

Coverage gap between Jacoco and SonarCloud

- SonarCloud reported ~2.5% lower coverage than the local Jacoco report because ksml-test-runner was missing from ksml-reporting/pom.xml
- Its 17 source files were invisible to the Jacoco aggregate report but SonarCloud scanned them anyway and counted all lines as uncovered
- Fixed by adding ksml-test-runner as a dependency in ksml-reporting/pom.xml
- Also added lombok.addLombokGeneratedAnnotation=true to lombok.config so Jacoco skips Lombok-generated methods (getters, builders, equals) that tests are not expected to cover