### PR TITLE
Fix: Sonar reports zero new issues on fork PRs

### DIFF
--- a/.github/workflows/ci-pr-fork-sonar.yml
+++ b/.github/workflows/ci-pr-fork-sonar.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Fetch fork commits for SCM context
         run: |
           git remote add fork https://github.com/${{ env.FORK_REPO }}
-          git fetch fork ${{ env.HEAD_REF }}
+          git fetch fork ${{ env.HEAD_REF }}:${{ env.HEAD_REF }}
 
       - name: Discover build output paths
         run: |


### PR DESCRIPTION
Sonar needs to know which files changed in the PR. It finds this by looking up the PR branch by name in the local git repository.

The previous fetch command stored the branch under `fork/test-sonar-fork-pr` (a remote tracking ref), not under `test-sonar-fork-pr` (a local branch). Sonar looked for a local branch, found nothing, and concluded that
0 files changed - so it reported 0 new issues.

The fix changes one line:

**Before**
`git fetch fork ${{ env.HEAD_REF }}`

**After**
`git fetch fork ${{ env.HEAD_REF }}:${{ env.HEAD_REF }}`

The `:` syntax tells git to also create a local branch with that name. Sonar can now find it, see which files changed, and report new issues correctly.

No security impact - this only creates a git pointer, it does not run any code from the fork.