### PR TITLE
Fix Sonar PR analysis: checkout fork branch so diff is non-empty

### DIFF
--- a/.github/workflows/ci-pr-fork-sonar.yml
+++ b/.github/workflows/ci-pr-fork-sonar.yml
@@ -48,6 +48,7 @@ jobs:
         run: |
           git remote add fork https://github.com/${{ env.FORK_REPO }}
           git fetch fork ${{ env.HEAD_REF }}:${{ env.HEAD_REF }}
+          git checkout ${{ env.HEAD_REF }}
 
       - name: Discover build output paths
         run: |


### PR DESCRIPTION
**Problem**

Sonar reports "Analyzing 0 new or changed file(s)" on every fork PR, so no new issues are ever detected.

The root cause: W2 checks out `Axual/ksml:main` at the start, and the workspace git HEAD stays there even after the fork branch is fetched. Sonar computes changed files by diffing workspace HEAD against the last-analyzed main commit on the Sonar server - both point to the same SHA, so the diff is always empty.

The `sonar.pullrequest.branch` and `sonar.scm.revision` parameters do not change the workspace HEAD. They only control PR decoration and SCM blame, not the changed-files diff.

**Fix**

Add `git checkout ${{ env.HEAD_REF }}` after the fetch step.

This moves workspace HEAD from Axual/ksml:main to the fork branch tip. Sonar then diffs the fork tip against the server base and correctly finds the files the PR changed.

The compiled classes in target/ are not tracked by git and survive the checkout unchanged, so the Sonar analysis still uses the artifact from W1.

**Testing**

After merging, push any commit to KasparMetsa/ksml:test-sonar-fork-pr. The W2 log should show:

Analyzing 1 new or changed file(s) (PR analysis).

and the quality gate should fail with java:S106 and java:S1144 on AvroDataObjectMapper.java.