### PR TITLE
Fix for sonar fork PR

### DIFF
--- a/.github/workflows/ci-pr-fork-sonar.yml
+++ b/.github/workflows/ci-pr-fork-sonar.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           git remote add fork https://github.com/${{ env.FORK_REPO }}
           git fetch fork ${{ env.HEAD_REF }}:${{ env.HEAD_REF }}
-          git checkout ${{ env.HEAD_REF }}
+          git checkout -f ${{ env.HEAD_REF }}
 
       - name: Discover build output paths
         run: |


### PR DESCRIPTION
`-f` discards the "local changes" before switching. The result on disk is identical - the fork's version - just arrived at via git checkout instead of the artifact overlay. The compiled classes in target/ are untracked and survive untouched.