### PR TITLE
Fix Dependabot PR CI failures

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -33,6 +33,10 @@ jobs:
           cache: 'maven'
 
       - name: Log in to Docker Hub
+        # Dependabot runs without access to repository secrets, so the Docker Hub
+        # credentials are empty and login would fail. Skip it for Dependabot; the
+        # integration tests then pull container images anonymously.
+        if: github.actor != 'dependabot[bot]'
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -45,6 +49,9 @@ jobs:
           TESTCONTAINERS_RYUK_DISABLED: false
 
       - name: SonarCloud analysis
+        # SonarCloud needs SONAR_TOKEN, which is unavailable to Dependabot runs.
+        # Skip the analysis for Dependabot so the build does not fail on auth.
+        if: github.actor != 'dependabot[bot]'
         timeout-minutes: 15
         run: |
           SONAR_ARGS=""


### PR DESCRIPTION
### Problem

- Dependabot PRs (#601, #602) fail at the "Log in to Docker Hub" step.
- GitHub runs Dependabot workflows without access to repository secrets.
- So the Docker Hub username and password are empty and the login fails before any test runs.

### Fix

- Skip the "Log in to Docker Hub" step for Dependabot (login can't work without secrets; tests pull images anonymously instead).
- Skip the "SonarCloud analysis" step for Dependabot (it needs `SONAR_TOKEN`, which is also unavailable - it would be the next step to fail).

### Notes

- Uses `if: github.actor != 'dependabot[bot]'`, matching the existing guard already on the "Publish test results" step.
- Dependabot PRs still get a full `mvn clean verify` build and test run.