### PR TITLE
Fix Apicurio auth

### DIFF
--- a/ksml-data-avro-apicurio/src/main/java/io/axual/ksml/data/notation/avro/apicurio/ApicurioAvroNotationProvider.java
+++ b/ksml-data-avro-apicurio/src/main/java/io/axual/ksml/data/notation/avro/apicurio/ApicurioAvroNotationProvider.java
@@ -61,7 +61,8 @@ public class ApicurioAvroNotationProvider extends VendorNotationProvider {
                 clientConfig.topicResolver());
     }
 
-    private RegistryClient createSrClient(Map<String, Object> serdeConfigs) {
+    // Package-private so it can be unit-tested directly.
+    RegistryClient createSrClient(Map<String, Object> serdeConfigs) {
         if (!serdeConfigs.containsKey(SerdeConfig.REGISTRY_URL)) return null;
         final var url = MapUtil.stringValues(serdeConfigs).get(SerdeConfig.REGISTRY_URL);
         // We build the client here and give it to the serde. When we do that, the Apicurio serde does

--- a/ksml-data-avro-apicurio/src/main/java/io/axual/ksml/data/notation/avro/apicurio/ApicurioAvroNotationProvider.java
+++ b/ksml-data-avro-apicurio/src/main/java/io/axual/ksml/data/notation/avro/apicurio/ApicurioAvroNotationProvider.java
@@ -20,9 +20,12 @@ package io.axual.ksml.data.notation.avro.apicurio;
  * =========================LICENSE_END==================================
  */
 
+import io.apicurio.registry.resolver.config.DefaultSchemaResolverConfig;
 import io.apicurio.registry.rest.client.RegistryClient;
 import io.apicurio.registry.rest.client.RegistryClientFactory;
 import io.apicurio.registry.serde.SerdeConfig;
+import io.apicurio.rest.client.auth.Auth;
+import io.apicurio.rest.client.auth.BasicAuth;
 import io.axual.ksml.client.resolving.ResolvingClientConfig;
 import io.axual.ksml.data.notation.Notation;
 import io.axual.ksml.data.notation.NotationContext;
@@ -60,6 +63,25 @@ public class ApicurioAvroNotationProvider extends VendorNotationProvider {
 
     private RegistryClient createSrClient(Map<String, Object> serdeConfigs) {
         if (!serdeConfigs.containsKey(SerdeConfig.REGISTRY_URL)) return null;
-        return RegistryClientFactory.create(MapUtil.stringValues(serdeConfigs).get(SerdeConfig.REGISTRY_URL), serdeConfigs);
+        final var url = MapUtil.stringValues(serdeConfigs).get(SerdeConfig.REGISTRY_URL);
+        // We build the client here and give it to the serde. When we do that, the Apicurio serde does
+        // not add the username and password itself (it only does that when we do not give it a client).
+        // So we must add them here. If we do not, calls to a registry that needs a login fail with 401.
+        // create(url, configs) sets the URL and SSL, but not the login, so we pass the login as 'auth'.
+        final var auth = buildAuth(serdeConfigs);
+        return auth != null
+                ? RegistryClientFactory.create(url, serdeConfigs, auth)
+                : RegistryClientFactory.create(url, serdeConfigs);
+    }
+
+    // Reads the login from the config and returns it as an 'auth' object, or null when no login is set.
+    // We read the keys with Apicurio's own config class, so the key names are the same as the serde uses.
+    // For now this supports username and password (apicurio.auth.username / apicurio.auth.password).
+    // Token-based (OIDC) login can be added here in the same way later.
+    private Auth buildAuth(Map<String, Object> serdeConfigs) {
+        final var config = new DefaultSchemaResolverConfig(serdeConfigs);
+        final var username = config.getAuthUsername();
+        if (username == null) return null;
+        return new BasicAuth(username, config.getAuthPassword());
     }
 }

--- a/ksml-data-avro-apicurio/src/main/java/io/axual/ksml/data/notation/avro/apicurio/ApicurioAvroNotationProvider.java
+++ b/ksml-data-avro-apicurio/src/main/java/io/axual/ksml/data/notation/avro/apicurio/ApicurioAvroNotationProvider.java
@@ -78,7 +78,8 @@ public class ApicurioAvroNotationProvider extends VendorNotationProvider {
     // We read the keys with Apicurio's own config class, so the key names are the same as the serde uses.
     // For now this supports username and password (apicurio.auth.username / apicurio.auth.password).
     // Token-based (OIDC) login can be added here in the same way later.
-    private Auth buildAuth(Map<String, Object> serdeConfigs) {
+    // Package-private so it can be unit-tested directly.
+    Auth buildAuth(Map<String, Object> serdeConfigs) {
         final var config = new DefaultSchemaResolverConfig(serdeConfigs);
         final var username = config.getAuthUsername();
         if (username == null) return null;

--- a/ksml-data-avro-apicurio/src/test/java/io/axual/ksml/data/notation/avro/apicurio/ApicurioAvroNotationProviderTest.java
+++ b/ksml-data-avro-apicurio/src/test/java/io/axual/ksml/data/notation/avro/apicurio/ApicurioAvroNotationProviderTest.java
@@ -1,0 +1,68 @@
+package io.axual.ksml.data.notation.avro.apicurio;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Data Library - AVRO Apicurio
+ * %%
+ * Copyright (C) 2021 - 2026 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import io.apicurio.rest.client.auth.Auth;
+import io.apicurio.rest.client.auth.BasicAuth;
+import io.axual.ksml.data.notation.avro.AvroNotation;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApicurioAvroNotationProviderTest {
+
+    @Test
+    @DisplayName("Provider exposes notation/vendor names for Apicurio Avro")
+    void providerMetadata_isCorrect() {
+        assertThat(new ApicurioAvroNotationProvider())
+                .returns(AvroNotation.NOTATION_NAME, ApicurioAvroNotationProvider::notationName)
+                .returns("apicurio", ApicurioAvroNotationProvider::vendorName);
+    }
+
+    @Test
+    @DisplayName("buildAuth returns HTTP Basic auth when a username and password are set")
+    void buildAuth_withUsernameAndPassword_returnsBasicAuth() {
+        final Map<String, Object> config = new HashMap<>();
+        config.put("apicurio.registry.url", "http://registry:8081/apis/registry/v2");
+        config.put("apicurio.auth.username", "alice");
+        config.put("apicurio.auth.password", "secret");
+
+        final Auth auth = new ApicurioAvroNotationProvider().buildAuth(config);
+
+        assertThat(auth).isInstanceOf(BasicAuth.class);
+        final var basicAuth = (BasicAuth) auth;
+        assertThat(basicAuth.getUsername()).isEqualTo("alice");
+        assertThat(basicAuth.getPassword()).isEqualTo("secret");
+    }
+
+    @Test
+    @DisplayName("buildAuth returns null when no username is set (behavior unchanged)")
+    void buildAuth_withoutUsername_returnsNull() {
+        final Map<String, Object> config = new HashMap<>();
+        config.put("apicurio.registry.url", "http://registry:8081/apis/registry/v2");
+
+        assertThat(new ApicurioAvroNotationProvider().buildAuth(config)).isNull();
+    }
+}

--- a/ksml-data-avro-apicurio/src/test/java/io/axual/ksml/data/notation/avro/apicurio/ApicurioAvroNotationProviderTest.java
+++ b/ksml-data-avro-apicurio/src/test/java/io/axual/ksml/data/notation/avro/apicurio/ApicurioAvroNotationProviderTest.java
@@ -65,4 +65,30 @@ class ApicurioAvroNotationProviderTest {
 
         assertThat(new ApicurioAvroNotationProvider().buildAuth(config)).isNull();
     }
+
+    @Test
+    @DisplayName("createSrClient returns null when no registry URL is configured")
+    void createSrClient_withoutRegistryUrl_returnsNull() {
+        assertThat(new ApicurioAvroNotationProvider().createSrClient(new HashMap<>())).isNull();
+    }
+
+    @Test
+    @DisplayName("createSrClient builds a client when a URL is set but no login")
+    void createSrClient_withUrlNoAuth_returnsClient() {
+        final Map<String, Object> config = new HashMap<>();
+        config.put("apicurio.registry.url", "http://registry:8081/apis/registry/v2");
+
+        assertThat(new ApicurioAvroNotationProvider().createSrClient(config)).isNotNull();
+    }
+
+    @Test
+    @DisplayName("createSrClient builds a client when a URL and a login are set")
+    void createSrClient_withUrlAndAuth_returnsClient() {
+        final Map<String, Object> config = new HashMap<>();
+        config.put("apicurio.registry.url", "http://registry:8081/apis/registry/v2");
+        config.put("apicurio.auth.username", "alice");
+        config.put("apicurio.auth.password", "secret");
+
+        assertThat(new ApicurioAvroNotationProvider().createSrClient(config)).isNotNull();
+    }
 }


### PR DESCRIPTION
## What this fixes

When `apicurio_avro` talks to an Apicurio Schema Registry that needs a login, KSML sent no username and password. The registry rejected the call (error 401), so the message could not be written. The error was "NotAuthorizedException: Authentication exception".

## Why it happened

KSML builds the client that talks to the registry, and gives it to the Apicurio serializer. When the serializer is given a ready client, it does not add the login by itself. It only adds the login when it builds the client on its own. The way KSML built the client set the address and SSL, but not the login. So the login was dropped.

(Confluent already works, because the Confluent client is built in a way that adds the login from the config.)

## The fix

Build the client with the login:

- read the username and password from the config (`apicurio.auth.username` / `apicurio.auth.password`), and
- give them to the client.

If there is no username in the config, nothing changes.

## What it covers

- Only `apicurio_avro`. `apicurio_protobuf` and `apicurio_jsonschema` let the serializer build its own client, so they already send the login.
- It adds username and password login. Token (OIDC) login is not used anywhere in KSML today, and it can be added the same way later.

## How it was tested

Built a local image and ran the same setup as the issue: a Generator that writes Avro with the Confluent registry, and a Mapper that reads that Avro and writes `apicurio_avro` to the Apicurio registry. The Apicurio registry needed a login.

| Image            | Apicurio write              | What the registry saw |
|------------------|-----------------------------|-----------------------|
| 1.2.1 (no fix)   | fails (error 401)           | no login              |
| local (this fix) | works (messages written)    | login sent            |


Steps to reproduce:
[apicurio-auth-exact-repro-steps.md](https://github.com/user-attachments/files/29206368/apicurio-auth-exact-repro-steps.md)
