### PR TITLE
Bump Confluent serdes 8.2.1 -> 8.3.0 and fix test mock

### DIFF
--- a/ksml/src/test/java/io/axual/ksml/data/notation/confluent/MockConfluentSchemaRegistryClient.java
+++ b/ksml/src/test/java/io/axual/ksml/data/notation/confluent/MockConfluentSchemaRegistryClient.java
@@ -80,7 +80,7 @@ public class MockConfluentSchemaRegistryClient implements SchemaRegistryClient {
     }
 
     @Override
-    public synchronized RegisterSchemaResponse registerWithResponse(String subject, ParsedSchema schema, boolean normalize, boolean propagateSchemaTags) throws RestClientException {
+    public synchronized RegisterSchemaResponse registerWithResponse(String subject, ParsedSchema schema, boolean normalize, boolean propagateSchemaTags) throws IOException, RestClientException {
         return wrappedClient.registerWithResponse(subject, schema, normalize, propagateSchemaTags);
     }
 
@@ -120,7 +120,7 @@ public class MockConfluentSchemaRegistryClient implements SchemaRegistryClient {
     }
 
     @Override
-    public synchronized SchemaMetadata getSchemaMetadata(String subject, int version, boolean lookupDeletedSchema) throws RestClientException {
+    public synchronized SchemaMetadata getSchemaMetadata(String subject, int version, boolean lookupDeletedSchema) throws IOException, RestClientException {
         return wrappedClient.getSchemaMetadata(subject, version, lookupDeletedSchema);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <apicurio.version>2.6.13.Final</apicurio.version>
         <axual.utils.version>1.0.0</axual.utils.version>
         <commons.io.version>2.22.0</commons.io.version>
-        <confluent.version>8.2.1</confluent.version>
+        <confluent.version>8.3.0</confluent.version>
         <dropwizard.version>4.2.39</dropwizard.version>
         <findbugs.jsr305.version>3.0.2</findbugs.jsr305.version>
         <graalvm.version>25.0.3</graalvm.version>


### PR DESCRIPTION
Confluent 8.3.0 adds `throws IOException` to two SchemaRegistryClient methods (registerWithResponse(..., propagateSchemaTags) and getSchemaMetadata(..., lookupDeletedSchema)). Update the test mock MockConfluentSchemaRegistryClient to declare IOException on those two overrides so the test code compiles. The bump and this fix must land together: the fix is invalid on 8.2.1 and required on 8.3.0.

Supersedes the duplicate Dependabot PRs #621 and #622.