### PR TITLE
Ksml metrics help text

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -93,6 +93,16 @@ Complete documentation of KSML configuration options:
 - Logging configuration
 - Environment variables
 
+### [Metrics Reference](metrics-reference.md)
+
+Complete documentation of the Prometheus metrics exposed by KSML:
+
+- Enabling the metrics endpoint
+- Custom KSML metrics, their labels and units
+- User-defined metrics from Python functions
+- Exported series per metric type
+- Other exposed metrics (Kafka, JVM, operating system)
+
 ## How to Use This Reference
 
 You can read through these reference topics in order for a comprehensive understanding, or jump to specific topics as needed:

--- a/docs/reference/metrics-reference.md
+++ b/docs/reference/metrics-reference.md
@@ -1,0 +1,154 @@
+# Metrics Reference
+
+This document describes the metrics that the KSML Runner exposes for Prometheus, including the custom
+KSML metrics, their labels and units, and the other metrics that are available on the same endpoint.
+
+## Enabling the Metrics Endpoint
+
+Metrics are exposed over HTTP by the Prometheus JMX Exporter that is built into the KSML Runner. The
+endpoint is disabled by default and is enabled through the `prometheus` section of `ksml-runner.yaml`:
+
+```yaml
+ksml:
+  prometheus:
+    enabled: true
+    host: 0.0.0.0
+    port: 9999
+```
+
+See the [Configuration Reference](configuration-reference.md) for all available options. Once enabled,
+the metrics are served at:
+
+```
+http://<host>:<port>/metrics
+```
+
+Every metric carries a `# HELP` line describing what it measures, so the quickest way to discover the
+metrics exposed by a running pipeline is:
+
+```bash
+curl -s localhost:9999/metrics | grep '^# HELP'
+```
+
+## KSML Custom Metrics
+
+KSML publishes its own metrics under the `ksml_` prefix. Each metric is labelled so that values can be
+attributed to a specific function, pipeline or processor node.
+
+The metrics listed in this section are the complete set of metrics that KSML defines itself. Each one
+is given a descriptive `# HELP` line at runtime.
+
+### Function Execution Time
+
+`ksml_execution_time` measures the wall-clock time spent in a user function for every invocation. It is
+recorded for all function types (forEach, mapper, predicate, etc.).
+
+| Property | Value |
+|----------|-------|
+| Metric   | `ksml_execution_time` |
+| Type     | Timer |
+| Unit     | Durations in milliseconds, rates per second |
+| Labels   | `function_name`, `function_type`, `namespace`, `pipeline`, `operation_name` (and `step` or `branch` where applicable) |
+
+### Record End-to-End Latency
+
+The `ksml_record_e2e_latency_*_ms` gauges report the latency of a record measured from the source topic
+to a specific processor node, as reported by Kafka Streams and enriched with KSML context.
+
+| Property | Value |
+|----------|-------|
+| Metrics  | `ksml_record_e2e_latency_avg_ms`, `ksml_record_e2e_latency_min_ms`, `ksml_record_e2e_latency_max_ms` |
+| Type     | Gauge |
+| Unit     | Milliseconds |
+| Labels   | `namespace`, `pipeline`, `operation_name`, `processor_node_id`, `step`, `task_id`, `subtopology`, `partition`, `unit` |
+
+### User-Defined Metrics
+
+Pipeline functions can publish their own metrics through the `metrics` object that is injected into
+every Python function. These appear under the `ksml_user_defined_*` prefix.
+
+| Property | Value |
+|----------|-------|
+| Metrics  | `ksml_user_defined_counter`, `ksml_user_defined_meter`, `ksml_user_defined_timer` |
+| Type     | Counter, Meter, Timer |
+| Unit     | Timer durations in milliseconds, meter and timer rates per second |
+| Labels   | `custom_name` (the metric name passed in code), plus any custom tags supplied |
+
+The `metrics` object exposes three factory methods, each with an optional tags map:
+
+```python
+# A counter that increments on every invocation
+calls = metrics.counter("log_message-calls")
+calls.increment()
+
+# A meter that tracks the rate of processed records, tagged by format
+rate = metrics.meter("records-in", {"format": "AVRO"})
+rate.mark()
+
+# A timer that records processing durations, tagged by format
+duration = metrics.timer("received-records-processing-time", {"format": "AVRO"})
+duration.updateMillis(42)
+```
+
+The `name` argument becomes the `custom_name` label and the tags map adds further labels, so the same
+metric name can be reused with different tag combinations to produce distinct series.
+
+### Application Information
+
+`ksml_app` is a constant gauge (value `1`) that carries build and version information as labels.
+
+| Property | Value |
+|----------|-------|
+| Metric   | `ksml_app` |
+| Type     | Gauge |
+| Labels   | `app_id`, `name`, `version`, `build-time` |
+
+## Exported Series per Metric Type
+
+A single counter, meter, timer or gauge is exported as several Prometheus series that share the metric
+name as a prefix. For example, a timer named `ksml_execution_time` produces `ksml_execution_time_count`,
+`ksml_execution_time_max`, `ksml_execution_time_50thpercentile`, and so on.
+
+| Type    | Exported series |
+|---------|-----------------|
+| Counter | `_count` |
+| Gauge   | `_value` (and `_number`) |
+| Meter   | `_count`, `_meanrate`, `_oneminuterate`, `_fiveminuterate`, `_fifteenminuterate` |
+| Timer   | `_count`, `_min`, `_max`, `_mean`, `_stddev`, `_meanrate`, `_oneminuterate`, `_fiveminuterate`, `_fifteenminuterate`, and the `_50thpercentile` through `_999thpercentile` quantiles |
+
+## Other Exposed Metrics
+
+The same endpoint also exposes standard metrics collected by the underlying libraries. These are not
+defined by KSML and are documented by their respective projects, so they are listed here by category
+rather than individually:
+
+- Kafka Streams, producer, consumer and admin client metrics, under their original `kafka.*` names. These are described in the [Apache Kafka Monitoring documentation](https://kafka.apache.org/documentation/#monitoring).
+- JVM metrics (memory, garbage collection, threads) under the `jvm_` prefix.
+- Operating system metrics (memory and CPU) under the `os_` prefix.
+- Exporter operational metrics such as `jmx_scrape_duration_seconds` and `jmx_config_reload_success_total`.
+
+## Example Output
+
+The following is a trimmed scrape of the metrics endpoint while a pipeline is processing records.
+
+??? info "Example /metrics output (click to expand)"
+
+    ```
+    # HELP ksml_execution_time_count Execution time statistics of a KSML user function per invocation; durations are in milliseconds and rates are per second
+    # TYPE ksml_execution_time_count gauge
+    ksml_execution_time_count{function_name="pipelines_consume_avro_forEach",function_type="forEach",namespace="inspect",operation_name="inspect_pipelines_consume_avro_forEach",pipeline="consume_avro"} 18.0
+
+    # HELP ksml_record_e2e_latency_avg_ms_value Average end-to-end latency of records from the source topic to this KSML processor node, in milliseconds
+    # TYPE ksml_record_e2e_latency_avg_ms_value gauge
+    ksml_record_e2e_latency_avg_ms_value{namespace="inspect",operation_name="peek",pipeline="consume_avro",processor_node_id="...",task_id="0_0",unit="ms"} 12.5
+
+    # HELP ksml_user_defined_counter_count User-defined counter metric registered from KSML user code
+    # TYPE ksml_user_defined_counter_count counter
+    ksml_user_defined_counter_count{custom_name="received-records",format="AVRO"} 18.0
+    ```
+
+## Related Documentation
+
+- [Configuration Reference](configuration-reference.md) for the `prometheus` configuration options.
+- [Logging and Monitoring](../tutorials/beginner/logging-monitoring.md) for logging and peek-based monitoring.
+- [Function Reference](function-reference.md) for writing the Python functions that publish user-defined metrics.

--- a/docs/reference/metrics-reference.md
+++ b/docs/reference/metrics-reference.md
@@ -101,7 +101,7 @@ metric name can be reused with different tag combinations to produce distinct se
 |----------|-------|
 | Metric   | `ksml_app` |
 | Type     | Gauge |
-| Labels   | `app_id`, `name`, `version`, `build-time` |
+| Labels   | `app_id`, `name`, `version`, `build_time` |
 
 ## Exported Series per Metric Type
 

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/prometheus/HelpEnrichingCollector.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/prometheus/HelpEnrichingCollector.java
@@ -1,0 +1,117 @@
+package io.axual.ksml.runner.prometheus;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Runner
+ * %%
+ * Copyright (C) 2021 - 2026 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import io.prometheus.metrics.model.registry.MultiCollector;
+import io.prometheus.metrics.model.registry.PrometheusScrapeRequest;
+import io.prometheus.metrics.model.snapshots.CounterSnapshot;
+import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
+import io.prometheus.metrics.model.snapshots.MetricMetadata;
+import io.prometheus.metrics.model.snapshots.MetricSnapshot;
+import io.prometheus.metrics.model.snapshots.MetricSnapshots;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+/**
+ * Wraps another collector (the Prometheus JMX exporter) and replaces the generic
+ * "Attribute exposed for management ..." HELP text of KSML custom metrics with a human-readable
+ * description. Metric names, labels, values and types are passed through unchanged.
+ * <p>
+ * The JMX exporter can only attach a HELP text to a rule that also defines an explicit metric name,
+ * but naming a rule discards the bean properties that KSML relies on for its metric labels (function
+ * name, pipeline, namespace, ...). Rewriting the HELP text after collection therefore lets us
+ * document the metrics without losing those labels.
+ */
+@RequiredArgsConstructor
+public final class HelpEnrichingCollector implements MultiCollector {
+    // HELP text per KSML metric name prefix; a timer/meter expands into several metrics
+    // (_count, _max, percentiles, rates) that share the prefix and therefore the description.
+    private static final Map<String, String> HELP_BY_NAME_PREFIX = Map.of(
+            "ksml_execution_time", "Execution time statistics of a KSML user function per invocation; durations are in milliseconds and rates are per second",
+            "ksml_record_e2e_latency_avg_ms", "Average end-to-end latency of records from the source topic to this KSML processor node, in milliseconds",
+            "ksml_record_e2e_latency_min_ms", "Minimum end-to-end latency of records from the source topic to this KSML processor node, in milliseconds",
+            "ksml_record_e2e_latency_max_ms", "Maximum end-to-end latency of records from the source topic to this KSML processor node, in milliseconds",
+            "ksml_user_defined_counter", "User-defined counter metric registered from KSML user code",
+            "ksml_user_defined_meter", "User-defined meter metric registered from KSML user code; rates are in events per second",
+            "ksml_user_defined_timer", "User-defined timer metric registered from KSML user code; durations are in milliseconds and rates are per second");
+
+    private final MultiCollector delegate;
+
+    @Override
+    public MetricSnapshots collect() {
+        return enrich(delegate.collect());
+    }
+
+    @Override
+    public MetricSnapshots collect(Predicate<String> includedNames) {
+        return enrich(delegate.collect(includedNames));
+    }
+
+    @Override
+    public MetricSnapshots collect(Predicate<String> includedNames, PrometheusScrapeRequest scrapeRequest) {
+        return enrich(delegate.collect(includedNames, scrapeRequest));
+    }
+
+    @Override
+    public List<String> getPrometheusNames() {
+        return delegate.getPrometheusNames();
+    }
+
+    private MetricSnapshots enrich(MetricSnapshots snapshots) {
+        final var builder = MetricSnapshots.builder();
+        for (final var snapshot : snapshots) {
+            builder.metricSnapshot(withHelp(snapshot));
+        }
+        return builder.build();
+    }
+
+    private MetricSnapshot withHelp(MetricSnapshot snapshot) {
+        final var metadata = snapshot.getMetadata();
+        final var name = metadata.getName();
+        final var help = helpFor(name);
+        if (help == null || help.equals(metadata.getHelp())) {
+            return snapshot;
+        }
+        final var enriched = metadata.getUnit() != null
+                ? new MetricMetadata(name, help, metadata.getUnit())
+                : new MetricMetadata(name, help);
+        if (snapshot instanceof GaugeSnapshot gauge) {
+            return new GaugeSnapshot(enriched, gauge.getDataPoints());
+        }
+        if (snapshot instanceof CounterSnapshot counter) {
+            return new CounterSnapshot(enriched, counter.getDataPoints());
+        }
+        // KSML custom metrics only surface as gauges or counters; leave anything else untouched.
+        return snapshot;
+    }
+
+    private String helpFor(String metricName) {
+        for (final var entry : HELP_BY_NAME_PREFIX.entrySet()) {
+            if (metricName.startsWith(entry.getKey())) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/prometheus/HelpEnrichingCollector.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/prometheus/HelpEnrichingCollector.java
@@ -48,6 +48,7 @@ public final class HelpEnrichingCollector implements MultiCollector {
     // HELP text per KSML metric name prefix; a timer/meter expands into several metrics
     // (_count, _max, percentiles, rates) that share the prefix and therefore the description.
     private static final Map<String, String> HELP_BY_NAME_PREFIX = Map.of(
+            "ksml_app", "Build and version information for the running KSML application; the value is always 1 and the details are exposed as labels",
             "ksml_execution_time", "Execution time statistics of a KSML user function per invocation; durations are in milliseconds and rates are per second",
             "ksml_record_e2e_latency_avg_ms", "Average end-to-end latency of records from the source topic to this KSML processor node, in milliseconds",
             "ksml_record_e2e_latency_min_ms", "Minimum end-to-end latency of records from the source topic to this KSML processor node, in milliseconds",
@@ -78,6 +79,9 @@ public final class HelpEnrichingCollector implements MultiCollector {
         return delegate.getPrometheusNames();
     }
 
+    // A scrape returns a MetricSnapshots collection: one immutable MetricSnapshot per metric, each
+    // holding its metadata (name + HELP) and data points. We copy them through, swapping the HELP
+    // text on the ones we recognise.
     private MetricSnapshots enrich(MetricSnapshots snapshots) {
         final var builder = MetricSnapshots.builder();
         for (final var snapshot : snapshots) {
@@ -90,12 +94,18 @@ public final class HelpEnrichingCollector implements MultiCollector {
         final var metadata = snapshot.getMetadata();
         final var name = metadata.getName();
         final var help = helpFor(name);
+        // Not a KSML metric we describe, or it already has the right text: leave it as-is.
         if (help == null || help.equals(metadata.getHelp())) {
             return snapshot;
         }
+        // Snapshots are immutable, so we cannot just set the HELP; we rebuild the snapshot with new
+        // metadata (same name/unit, new help) and the original data points (the values + labels).
         final var enriched = metadata.getUnit() != null
                 ? new MetricMetadata(name, help, metadata.getUnit())
                 : new MetricMetadata(name, help);
+        // A snapshot has a concrete type per metric kind. GaugeSnapshot = a value that goes up/down
+        // (latency, execution time); CounterSnapshot = a value that only increases. We must rebuild
+        // the same type so the metric keeps its semantics.
         if (snapshot instanceof GaugeSnapshot gauge) {
             return new GaugeSnapshot(enriched, gauge.getDataPoints());
         }

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/prometheus/PrometheusExport.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/prometheus/PrometheusExport.java
@@ -31,7 +31,10 @@ import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import lombok.Synchronized;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.management.MalformedObjectNameException;
 import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
 import java.net.InetAddress;
 import java.util.Optional;
 
@@ -57,7 +60,7 @@ public class PrometheusExport implements Closeable {
             log.info("Prometheus export is disabled");
             return;
         }
-        var configFile = config.getConfigFile();
+        final var configFile = config.getConfigFile();
         if (configFile == null) {
             log.info("No Prometheus export config file found, export disabled");
             return;
@@ -66,10 +69,7 @@ public class PrometheusExport implements Closeable {
 
         new BuildInfoMetrics().register(PrometheusRegistry.defaultRegistry);
         JvmMetrics.builder().register(PrometheusRegistry.defaultRegistry);
-        new JmxCollector(configFile, JmxCollector.Mode.AGENT)
-                .register(PrometheusRegistry.defaultRegistry);
-
-
+        registerJmxCollectorWithHelpText(PrometheusRegistry.defaultRegistry, configFile);
 
         httpServer = new HTTPServerFactory()
                 .createHTTPServer(
@@ -77,6 +77,22 @@ public class PrometheusExport implements Closeable {
                         config.getPort(),
                         PrometheusRegistry.defaultRegistry,
                         configFile);
+    }
+
+    /**
+     * Registers the JMX exporter on the given registry with KSML metric HELP text enrichment.
+     * <p>
+     * The collector is registered first so it initializes its operational metrics
+     * (jmx_scrape_duration_seconds, jmx_config_reload_*) as separate collectors on the registry. It is
+     * then unregistered and replaced by a {@link HelpEnrichingCollector} wrapper: unregistering the
+     * MultiCollector leaves those operational metrics in place, while the wrapper exposes the JMX
+     * metrics with descriptive HELP text.
+     */
+    static void registerJmxCollectorWithHelpText(PrometheusRegistry registry, File configFile) throws IOException, MalformedObjectNameException {
+        final var jmxCollector = new JmxCollector(configFile, JmxCollector.Mode.AGENT);
+        jmxCollector.register(registry);
+        registry.unregister(jmxCollector);
+        registry.register(new HelpEnrichingCollector(jmxCollector));
     }
 
     public synchronized void stop() {

--- a/ksml-runner/src/main/resources/prometheus/default_config.yaml
+++ b/ksml-runner/src/main/resources/prometheus/default_config.yaml
@@ -1,7 +1,10 @@
 lowercaseOutputName: true
 lowercaseOutputLabelNames: true
 rules:
-  - pattern: 'ksml<type=app-info, app-id=(.+), app-name=(.+), app-version=(.+), build-time=(.+)>Value:'
+  # app-name, app-version and build-time are ObjectName.quote()'d by KsmlInfo (the build timestamp
+  # contains colons), so they appear wrapped in double quotes in the bean name. Capture inside the
+  # quotes to keep the label values clean, and consume the trailing empty-attribute group (><>).
+  - pattern: 'ksml<type=app-info, app-id=(.+), app-name="(.+)", app-version="(.*)", build-time="(.*)"><>Value:'
     name: ksml_app
     labels:
       app_id: "$1"

--- a/ksml-runner/src/main/resources/prometheus/default_config.yaml
+++ b/ksml-runner/src/main/resources/prometheus/default_config.yaml
@@ -10,7 +10,7 @@ rules:
       app_id: "$1"
       name: "$2"
       version: "$3"
-      build-time: "$4"
+      build_time: "$4"
     type: GAUGE
     value: 1
     cached: true

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/prometheus/AppInfoMetricTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/prometheus/AppInfoMetricTest.java
@@ -1,0 +1,79 @@
+package io.axual.ksml.runner.prometheus;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Runner
+ * %%
+ * Copyright (C) 2021 - 2026 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import io.axual.ksml.runner.KsmlInfo;
+import io.axual.ksml.runner.config.PrometheusConfig;
+import io.prometheus.jmx.JmxCollector;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
+import io.prometheus.metrics.model.snapshots.Labels;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Verifies that the {@code ksml_app} build-info metric, produced by the app-info rule in the shipped
+ * default configuration, exposes clean label values (no leftover JMX quoting or bracket artifacts).
+ */
+class AppInfoMetricTest {
+    private static final String APP_ID = "io.axual.ksml.test.app";
+
+    @AfterEach
+    void unregisterAppInfoBean() throws Exception {
+        final var server = ManagementFactory.getPlatformMBeanServer();
+        for (final var name : server.queryNames(new ObjectName("ksml:type=app-info,*"), null)) {
+            server.unregisterMBean(name);
+        }
+    }
+
+    @Test
+    @DisplayName("ksml_app exposes app metadata as clean labels, without JMX quotes or brackets")
+    void exposesCleanAppInfoLabels() throws Exception {
+        KsmlInfo.registerKsmlAppInfo(APP_ID);
+
+        final var prometheusConfig = new PrometheusConfig();
+        prometheusConfig.enabled(true);
+        final var collector = new JmxCollector(prometheusConfig.getConfigFile())
+                .register(new PrometheusRegistry());
+
+        final var appInfo = collector.collect().stream()
+                .filter(s -> s.getMetadata().getName().equals("ksml_app"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("ksml_app metric was not exported"));
+        final Labels labels = appInfo.getDataPoints().get(0).getLabels();
+
+        assertEquals(APP_ID, labels.get("app_id"));
+        // Values come from ksml/ksml-info.properties; assert they are present and unquoted/untrimmed
+        assertEquals(KsmlInfo.APP_NAME, labels.get("name"));
+        assertEquals(KsmlInfo.APP_VERSION, labels.get("version"));
+        assertEquals(KsmlInfo.BUILD_TIME, labels.get("build_time"));
+        // Guard against the previous mangling (surrounding quotes and a trailing "><")
+        final var buildTime = labels.get("build_time");
+        assertFalse(buildTime.contains("\"") || buildTime.contains(">") || buildTime.contains("<"),
+                "build_time label is mangled: " + buildTime);
+    }
+}

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/prometheus/HelpEnrichingCollectorTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/prometheus/HelpEnrichingCollectorTest.java
@@ -58,6 +58,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 class HelpEnrichingCollectorTest {
     private static final String EXECUTION_TIME_HELP = "Execution time statistics of a KSML user function per invocation; durations are in milliseconds and rates are per second";
     private static final String COUNTER_HELP = "User-defined counter metric registered from KSML user code";
+    private static final String APP_INFO_HELP = "Build and version information for the running KSML application; the value is always 1 and the details are exposed as labels";
     private static final String DEFAULT_HELP_PREFIX = "Attribute exposed for management";
 
     /**
@@ -191,6 +192,7 @@ class HelpEnrichingCollectorTest {
         void rewritesGaugeAndCounter() {
             final var input = MetricSnapshots.builder()
                     .metricSnapshot(gauge("ksml_execution_time_count", "Attribute exposed for management ..."))
+                    .metricSnapshot(gauge("ksml_app", "ksml:name=null,type=app-info,attribute=Value"))
                     .metricSnapshot(counter("ksml_user_defined_counter_count", "Attribute exposed for management ..."))
                     .build();
             final var collector = new HelpEnrichingCollector(new StubCollector(input));
@@ -198,6 +200,7 @@ class HelpEnrichingCollectorTest {
             final var result = collector.collect();
 
             assertEquals(EXECUTION_TIME_HELP, helpOf(result, "ksml_execution_time_count"));
+            assertEquals(APP_INFO_HELP, helpOf(result, "ksml_app"));
             assertEquals(COUNTER_HELP, helpOf(result, "ksml_user_defined_counter_count"));
             // the counter must stay a counter, not be downgraded to a gauge
             assertInstanceOf(CounterSnapshot.class, byName(result, "ksml_user_defined_counter_count"));

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/prometheus/HelpEnrichingCollectorTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/prometheus/HelpEnrichingCollectorTest.java
@@ -1,0 +1,295 @@
+package io.axual.ksml.runner.prometheus;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Runner
+ * %%
+ * Copyright (C) 2021 - 2026 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import io.axual.ksml.metric.MetricName;
+import io.axual.ksml.metric.MetricTag;
+import io.axual.ksml.metric.MetricTags;
+import io.axual.ksml.metric.MetricsRegistry;
+import io.axual.ksml.runner.config.PrometheusConfig;
+import io.prometheus.jmx.JmxCollector;
+import io.prometheus.metrics.model.registry.MultiCollector;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
+import io.prometheus.metrics.model.registry.PrometheusScrapeRequest;
+import io.prometheus.metrics.model.snapshots.CounterSnapshot;
+import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
+import io.prometheus.metrics.model.snapshots.Labels;
+import io.prometheus.metrics.model.snapshots.MetricSnapshot;
+import io.prometheus.metrics.model.snapshots.MetricSnapshots;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Tests for {@link HelpEnrichingCollector}. Runs entirely in-process (no external system): one group
+ * drives the real Prometheus JMX exporter against in-JVM MBeans and the shipped default configuration,
+ * the other exercises the rewrite logic in isolation with a stub delegate.
+ */
+class HelpEnrichingCollectorTest {
+    private static final String EXECUTION_TIME_HELP = "Execution time statistics of a KSML user function per invocation; durations are in milliseconds and rates are per second";
+    private static final String COUNTER_HELP = "User-defined counter metric registered from KSML user code";
+    private static final String DEFAULT_HELP_PREFIX = "Attribute exposed for management";
+
+    /**
+     * Verifies the whole chain: KSML custom metrics exported through the shipped default Prometheus
+     * configuration and wrapped by {@link HelpEnrichingCollector} expose an informative HELP text while
+     * keeping the labels that the JMX exporter derives from the metric's JMX bean properties.
+     */
+    @Nested
+    @DisplayName("Through the real JMX exporter and shipped default configuration")
+    class ViaJmxExporter {
+        private static final String JMX_DOMAIN = "ksml";
+
+        private MetricsRegistry registry;
+
+        @BeforeEach
+        void registerKsmlMetricsAsJmxBeans() {
+            registry = new MetricsRegistry();
+            registry.enableJmx(JMX_DOMAIN, List.<MetricTag>of());
+
+            // execution-time: registered by io.axual.ksml.python.Invoker for every user function
+            registry.registerTimer(new MetricName("execution-time", new MetricTags()
+                    .append("function-type", "forEach")
+                    .append("function-name", "pipelines_consume_avro_forEach")));
+
+            // record_e2e_latency_*_ms: registered by io.axual.ksml.metric.KsmlTagEnricher
+            registry.registerGauge(new MetricName("record_e2e_latency_avg_ms", latencyTags()), () -> 1.0);
+            registry.registerGauge(new MetricName("record_e2e_latency_min_ms", latencyTags()), () -> 1.0);
+            registry.registerGauge(new MetricName("record_e2e_latency_max_ms", latencyTags()), () -> 1.0);
+
+            // user-defined-*: registered by io.axual.ksml.proxy.metric.MetricsBridge from user code
+            registry.registerCounter(new MetricName("user-defined-counter", new MetricTags().append("custom-name", "my_counter")));
+            registry.registerMeter(new MetricName("user-defined-meter", new MetricTags().append("custom-name", "my_meter")));
+            registry.registerTimer(new MetricName("user-defined-timer", new MetricTags().append("custom-name", "my_timer")));
+        }
+
+        private MetricTags latencyTags() {
+            return new MetricTags().append("namespace", "inspect").append("pipeline", "consume_avro");
+        }
+
+        @AfterEach
+        void cleanup() {
+            registry.removeAll();
+            registry.disableJmx();
+        }
+
+        @Test
+        @DisplayName("Every KSML custom metric gets an informative HELP text while keeping its labels")
+        void enrichesHelpTextAndPreservesLabels() throws Exception {
+            final var prometheusConfig = new PrometheusConfig();
+            prometheusConfig.enabled(true);
+            final var jmxCollector = new JmxCollector(prometheusConfig.getConfigFile())
+                    .register(new PrometheusRegistry());
+            final var collector = new HelpEnrichingCollector(jmxCollector);
+
+            final var snapshots = collector.collect();
+
+            assertHelp(snapshots, "ksml_execution_time", "Execution time statistics", List.of("function_name", "function_type"));
+            assertHelp(snapshots, "ksml_record_e2e_latency_avg_ms", "Average end-to-end latency", List.of("namespace", "pipeline"));
+            assertHelp(snapshots, "ksml_record_e2e_latency_min_ms", "Minimum end-to-end latency", List.of("namespace", "pipeline"));
+            assertHelp(snapshots, "ksml_record_e2e_latency_max_ms", "Maximum end-to-end latency", List.of("namespace", "pipeline"));
+            assertHelp(snapshots, "ksml_user_defined_counter", "User-defined counter", List.of("custom_name"));
+            assertHelp(snapshots, "ksml_user_defined_meter", "User-defined meter", List.of("custom_name"));
+            assertHelp(snapshots, "ksml_user_defined_timer", "User-defined timer", List.of("custom_name"));
+        }
+
+        @Test
+        @DisplayName("PrometheusExport wiring keeps the JMX exporter's operational metrics and enriches KSML help")
+        void wiringPreservesOperationalMetricsAndEnrichesHelp() throws Exception {
+            final var prometheusConfig = new PrometheusConfig();
+            prometheusConfig.enabled(true);
+            final var prometheusRegistry = new PrometheusRegistry();
+
+            PrometheusExport.registerJmxCollectorWithHelpText(prometheusRegistry, prometheusConfig.getConfigFile());
+
+            final var snapshots = prometheusRegistry.scrape();
+            final var names = snapshots.stream().map(s -> s.getMetadata().getName()).toList();
+
+            // The JMX exporter's own operational metrics must survive the unregister of the raw collector
+            assertTrue(names.contains("jmx_scrape_duration_seconds"),
+                    "jmx_scrape_duration_seconds operational metric was lost. Exported names: " + names.stream().sorted().toList());
+            assertTrue(names.contains("jmx_config_reload_success"),
+                    "jmx_config_reload_success operational metric was lost. Exported names: " + names.stream().sorted().toList());
+
+            // ... and the KSML custom metrics must be exposed with the enriched HELP text and their labels
+            assertHelp(snapshots, "ksml_execution_time", "Execution time statistics", List.of("function_name", "function_type"));
+        }
+
+        /**
+         * Asserts that every exported snapshot whose name starts with {@code namePrefix} carries a HELP
+         * text containing {@code expectedHelpFragment} (and not the generic JMX exporter default), and
+         * that each of {@code expectedLabels} is present on its first data point.
+         */
+        private void assertHelp(MetricSnapshots snapshots, String namePrefix, String expectedHelpFragment, List<String> expectedLabels) {
+            final var matches = snapshots.stream()
+                    .filter(s -> s.getMetadata().getName().startsWith(namePrefix))
+                    .toList();
+
+            if (matches.isEmpty()) {
+                fail("No exported metric found with name starting with '" + namePrefix + "'. Exported names: "
+                        + snapshots.stream().map(s -> s.getMetadata().getName()).sorted().toList());
+            }
+
+            for (final var snapshot : matches) {
+                final var help = snapshot.getMetadata().getHelp();
+                assertFalse(help != null && help.startsWith(DEFAULT_HELP_PREFIX),
+                        "Metric '" + snapshot.getMetadata().getName() + "' still uses the generic default HELP text: " + help);
+                assertTrue(help != null && help.contains(expectedHelpFragment),
+                        "Metric '" + snapshot.getMetadata().getName() + "' HELP '" + help + "' does not contain '" + expectedHelpFragment + "'");
+
+                final var labels = snapshot.getDataPoints().get(0).getLabels();
+                for (final var expectedLabel : expectedLabels) {
+                    assertTrue(labels.contains(expectedLabel),
+                            "Metric '" + snapshot.getMetadata().getName() + "' lost expected label '" + expectedLabel
+                                    + "'. Present labels: " + labels);
+                }
+            }
+        }
+    }
+
+    /**
+     * Exercises the rewrite logic with a stub delegate, covering branches the JMX-backed group cannot
+     * reach: counter-typed metrics, non-matching/pre-set HELP passthrough, the predicate-based collect
+     * overloads, and name delegation.
+     */
+    @Nested
+    @DisplayName("Rewrite logic with a stub delegate")
+    class WithStubDelegate {
+
+        @Test
+        @DisplayName("Rewrites HELP for matching gauges and counters, preserving the snapshot type")
+        void rewritesGaugeAndCounter() {
+            final var input = MetricSnapshots.builder()
+                    .metricSnapshot(gauge("ksml_execution_time_count", "Attribute exposed for management ..."))
+                    .metricSnapshot(counter("ksml_user_defined_counter_count", "Attribute exposed for management ..."))
+                    .build();
+            final var collector = new HelpEnrichingCollector(new StubCollector(input));
+
+            final var result = collector.collect();
+
+            assertEquals(EXECUTION_TIME_HELP, helpOf(result, "ksml_execution_time_count"));
+            assertEquals(COUNTER_HELP, helpOf(result, "ksml_user_defined_counter_count"));
+            // the counter must stay a counter, not be downgraded to a gauge
+            assertInstanceOf(CounterSnapshot.class, byName(result, "ksml_user_defined_counter_count"));
+        }
+
+        @Test
+        @DisplayName("Leaves non-KSML metrics and already-described metrics untouched (same instance)")
+        void leavesOthersUntouched() {
+            final var nonKsml = gauge("jvm_threads_current", "JVM thread count");
+            final var alreadySet = gauge("ksml_execution_time_count", EXECUTION_TIME_HELP);
+            final var input = MetricSnapshots.builder().metricSnapshot(nonKsml).metricSnapshot(alreadySet).build();
+            final var collector = new HelpEnrichingCollector(new StubCollector(input));
+
+            final var result = collector.collect();
+
+            // unchanged snapshots are passed through as the exact same object (no needless rebuild)
+            assertSame(nonKsml, byName(result, "jvm_threads_current"));
+            assertSame(alreadySet, byName(result, "ksml_execution_time_count"));
+        }
+
+        @Test
+        @DisplayName("Both predicate collect overloads and getPrometheusNames delegate and enrich")
+        void delegatesAllCollectVariants() {
+            final var input = MetricSnapshots.builder()
+                    .metricSnapshot(gauge("ksml_execution_time_count", "Attribute exposed for management ...")).build();
+            final var stub = new StubCollector(input);
+            final var collector = new HelpEnrichingCollector(stub);
+            final Predicate<String> all = name -> true;
+
+            assertEquals(stub.names, collector.getPrometheusNames());
+            assertEquals(EXECUTION_TIME_HELP, helpOf(collector.collect(all), "ksml_execution_time_count"));
+            assertEquals(EXECUTION_TIME_HELP, helpOf(collector.collect(all, (PrometheusScrapeRequest) null), "ksml_execution_time_count"));
+        }
+    }
+
+    private static GaugeSnapshot gauge(String name, String help) {
+        return GaugeSnapshot.builder()
+                .name(name)
+                .help(help)
+                .dataPoint(GaugeSnapshot.GaugeDataPointSnapshot.builder()
+                        .labels(Labels.of("function_name", "f"))
+                        .value(1.0)
+                        .build())
+                .build();
+    }
+
+    private static CounterSnapshot counter(String name, String help) {
+        return CounterSnapshot.builder()
+                .name(name)
+                .help(help)
+                .dataPoint(CounterSnapshot.CounterDataPointSnapshot.builder()
+                        .labels(Labels.of("custom_name", "c"))
+                        .value(2.0)
+                        .build())
+                .build();
+    }
+
+    private static String helpOf(MetricSnapshots snapshots, String name) {
+        return byName(snapshots, name).getMetadata().getHelp();
+    }
+
+    private static MetricSnapshot byName(MetricSnapshots snapshots, String name) {
+        return snapshots.stream().filter(s -> s.getMetadata().getName().equals(name)).findFirst().orElseThrow();
+    }
+
+    /** Minimal delegate that returns a fixed set of snapshots for every collect variant. */
+    private static final class StubCollector implements MultiCollector {
+        private final MetricSnapshots snapshots;
+        private final List<String> names = List.of("ksml_execution_time_count");
+
+        private StubCollector(MetricSnapshots snapshots) {
+            this.snapshots = snapshots;
+        }
+
+        @Override
+        public MetricSnapshots collect() {
+            return snapshots;
+        }
+
+        @Override
+        public MetricSnapshots collect(Predicate<String> includedNames) {
+            return snapshots;
+        }
+
+        @Override
+        public MetricSnapshots collect(Predicate<String> includedNames, PrometheusScrapeRequest scrapeRequest) {
+            return snapshots;
+        }
+
+        @Override
+        public List<String> getPrometheusNames() {
+            return names;
+        }
+    }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,4 +96,5 @@ nav:
       - Data Types and Notations Reference: reference/data-and-formats-reference.md
       - State Store Reference: reference/state-store-reference.md
       - Configuration Reference: reference/configuration-reference.md
+      - Metrics Reference: reference/metrics-reference.md
   - Release Notes: release-notes.md


### PR DESCRIPTION
# Add HELP text for KSML Prometheus metrics + fix ksml_app label mangling

## Summary

  System admins scraping KSML metrics saw uninformative auto-generated HELP text (e.g. # HELP ksml_execution_time_count Attribute exposed for management ksml:name=null,type=execution-time,attribute=Count) and a mangled ksml_app metric. This PR makes every ksml_ metric self-documenting and cleans up the app-info labels.

## Changes

  - HelpEnrichingCollector (new) — a MultiCollector that wraps the Prometheus JMX exporter and rewrites only the HELP text of ksml_ metrics, passing names, labels, values, and types through unchanged. Covers all four KSML metric families: ksml_app, ksml_execution_time, ksml_record_e2e_latency_{avg,min,max}_ms, and ksml_user_defined_{counter,meter,timer}, with correct units noted (durations in ms, rates per second).
  - PrometheusExport — wires the wrapper in via an extracted helper registerJmxCollectorWithHelpText(...): register the JmxCollector (so it initializes its operational metrics), unregister it, then register the wrapper around it.
  - default_config.yaml — fixed the app-info rule regex so ksml_app labels (name, version, build_time) are clean instead of carrying leftover JMX quotes and a >< artifact.
  - Docs — new reference/metrics-reference.md cataloguing all KSML metrics, their labels, units, and the Python user-metrics API; wired into mkdocs.yml and the references overview.

## Why this approach

  The obvious fix — adding help: to rules in default_config.yaml — does not work, verified against jmx_exporter 1.0.1:

  1. The exporter rejects any rule with help but no name (Must provide name, if help or labels are given), which fails config load and stops all metric export.
  2. A rule with an explicit name does not auto-generate labels from JMX bean properties, so KSML's dynamic labels (function_name, pipeline, namespace, custom_name, …) get dropped.

  Since rule-based HELP is incompatible with preserving those labels, rewriting HELP after collection is the only approach that documents metrics without losing labels. The register → unregister → register sequence preserves the exporter's own operational metrics (jmx_scrape_duration_seconds, jmx_config_reload_*). The app-info label fix lives in the config regex (not KsmlInfo) because the ObjectName.quote() quoting is required for a valid JMX ObjectName.

## Testing

  - HelpEnrichingCollectorTest (@Nested, 5 tests):
    - Through the real JMX exporter + shipped config: every KSML family gets enriched HELP while keeping its JMX-derived labels; and the PrometheusExport wiring keeps the exporter's operational metrics.
    - Rewrite logic with a stub delegate: counter type preserved (not downgraded to gauge), non-matching/already-described metrics passed through as the same instance, both predicate collect overloads and getPrometheusNames delegate correctly.
    - Coverage on HelpEnrichingCollector: 93% instructions, 88% branches, 100% methods.
  - AppInfoMetricTest: registers the real app-info MBean and scrapes through the real JmxCollector + shipped config, asserting ksml_app labels are clean (no quotes, no </>).

  Live verification (Docker: Kafka + schema registry + producer + example 17, scraping :9999/metrics):

  - Confirmed the bug existed on main (every ksml_ metric showed Attribute exposed for management …).
  - With the change: all ksml_ metrics show descriptive HELP, labels preserved, e.g.
  # HELP ksml_execution_time_count Execution time statistics of a KSML user function per invocation; durations are in milliseconds and rates are per second
  ksml_execution_time_count{function_name="pipelines_consume_avro_forEach",function_type="forEach",namespace="inspect",operation_name="...",pipeline="consume_avro"}
  18.0
  - ksml_app before vs after:
  before: build_time="\"2026-...Z\"><",name="\"KSML Runner\"",version="\"2.0.0-SNAPSHOT\""
  after:  build_time="2026-06-24T13:52:32Z",name="KSML Runner",version="2.0.0-SNAPSHOT"
  - Confirmed nothing else broke: all metric families still present (~same count), no metric left with the default/mangled help, and JVM/Kafka/operational metrics intact.

## Note

  The pre-existing ksml<type=user_defined_counter, ...> rule in default_config.yaml uses underscores but the real JMX type is user-defined-counter (hyphens), so user-defined counters currently export as gauges. Fixing it changes the metric type (_total suffix), so it's left out of this PR's scope — worth a separate ticket.