### PR TITLE
Added unit tests to increase test coverage in ksml-runner package

### DIFF
--- a/ksml-runner/src/main/java/io/axual/ksml/runner/KSMLRunner.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/KSMLRunner.java
@@ -54,8 +54,10 @@ import io.axual.ksml.runner.backend.KafkaProducerRunner;
 import io.axual.ksml.runner.backend.KafkaStreamsRunner;
 import io.axual.ksml.runner.backend.Runner;
 import io.axual.ksml.runner.config.ErrorHandlingConfig;
+import io.axual.ksml.runner.config.KSMLConfig;
 import io.axual.ksml.runner.config.KSMLRunnerConfig;
 import io.axual.ksml.runner.config.NotationConfig;
+import io.axual.ksml.runner.config.SchemaRegistryConfig;
 import io.axual.ksml.runner.config.internal.KsmlFileOrDefinitionProvider;
 import io.axual.ksml.runner.config.internal.KsmlFileOrDefinitionSubTypeResolver;
 import io.axual.ksml.runner.config.internal.StringMapDefinitionPropertiesResolver;
@@ -153,22 +155,7 @@ public class KSMLRunner {
             // Load name and version from manifest
             var ksmlTitle = determineTitle();
 
-            boolean shouldExit = false;
-            // Check if we need to output the KSML schema and then exit
-            if (cmd.shouldPrintKsmlSchema()) {
-                log.info("Generating KSML definitions schema");
-                shouldExit = true;
-                printKsmlDefinitionSchema(cmd.ksmlSchemaLocation());
-            }
-
-            // Check if we need to output the runner schema and then exit
-            if (cmd.shouldPrintKsmlRunnerSchema()) {
-                log.info("Generating KSML Runner Configuration Schema");
-                shouldExit = true;
-                printRunnerSchema(cmd.ksmlRunnerSchemaLocation());
-            }
-
-            if (shouldExit) {
+            if (shouldExit(cmd)) {
                 log.info("Exiting after schema");
                 return;
             }
@@ -187,174 +174,30 @@ public class KSMLRunner {
             log.info("Using directories: config: {}, schema: {}, storage: {}", ksmlConfig.configDirectory(), ksmlConfig.schemaDirectory(), ksmlConfig.storageDirectory());
 
             final var definitions = ksmlConfig.definitions();
-            if (definitions == null || definitions.isEmpty()) {
-                throw new ConfigException("definitions", definitions, "No KSML definitions found in configuration");
-            }
+            validateDefinitions(definitions);
 
             KsmlInfo.registerKsmlAppInfo(config.getApplicationId());
 
             // Start the appserver if needed
-            final var appServer = ksmlConfig.applicationServerConfig();
-            RestServer restServer = null;
-            // Start rest server to provide service endpoints
-            if (appServer.enabled()) {
-                HostInfo hostInfo = new HostInfo(appServer.getHost(), appServer.getPort());
-                restServer = new RestServer(hostInfo);
-                restServer.start();
-            }
+            final var restServer = createRestServer(ksmlConfig.applicationServerConfig());
 
             // Set up the default schema directory
             ExecutionContext.INSTANCE.schemaLibrary().schemaDirectory(ksmlConfig.schemaDirectory());
 
-            // Set up all default notations and register them in the NotationLibrary
-            final var notationFactories = new NotationFactories(config.getKafkaConfigMap());
-            for (final var notation : notationFactories.notations().entrySet()) {
-                ExecutionContext.INSTANCE.notationLibrary().register(notation.getKey(), notation.getValue().create(null));
-            }
+            // Set up all notations (defaults, configured overrides and the AVRO fallback)
+            registerNotations(ksmlConfig, config.getKafkaConfigMap());
 
-            // Set up all notation overrides from the KSML config
-            for (final var notationEntry : ksmlConfig.notations().entrySet()) {
-                final var notationStr = notationEntry.getKey() != null ? notationEntry.getKey() : "undefined";
+            setupErrorHandling(ksmlConfig.errorHandlingConfig());
+            ExecutionContext.INSTANCE.serdeWrapper(serde -> wrapSerde(serde, config.getKafkaConfigMap()));
 
-                final var notationConfigs = new HashMap<String, String>();
-                final var schemaRegistryName = notationEntry.getValue().schemaRegistry();
-                if (schemaRegistryName != null) {
-                    final var srConfigs = ksmlConfig.schemaRegistries().get(schemaRegistryName);
-                    if (srConfigs != null && srConfigs.config() != null) {
-                        notationConfigs.putAll(srConfigs.config());
-                    } else {
-                        log.warn("No schema registry configuration found for schema registry: {}", schemaRegistryName);
-                    }
-                }
+            final var parsedDefinitions = parseDefinitions(definitions);
+            final var definitionSplit = splitDefinitions(parsedDefinitions, ksmlConfig.enableProducers(), ksmlConfig.enablePipelines());
 
-                final var notationConfig = notationEntry.getValue();
-                final var factoryName = resolveFactoryName(notationConfig);
-                if (notationConfig != null && factoryName != null) {
-                    final var factory = notationFactories.notations().get(factoryName);
-                    if (factory == null) {
-                        throw FatalError.report(new ConfigException("Unknown notation type: " + factoryName));
-                    }
-                    if (notationConfig.config() != null) notationConfigs.putAll(notationConfig.config());
-                    ExecutionContext.INSTANCE.notationLibrary().register(notationStr, factory.create(notationConfigs));
-                } else {
-                    log.warn("Notation configuration incomplete: notation={}, serde={}", notationStr, factoryName);
-                }
-            }
-
-            // Ensure typical defaults are used for AVRO
-            // WARNING: Defaults for notations will be deprecated in the future. Make sure you explicitly configure
-            // notations with multiple implementations (like AVRO) in your ksml-runner.yaml.
-            if (ksmlConfig.notations().isEmpty()) {
-                final var dataMapper = new DataObjectFlattener();
-                final var dataTypeMapper = new DataTypeFlattener();
-                final var defaultAvro = new ConfluentAvroNotationProvider().createNotation(new NotationContext(dataMapper, dataTypeMapper, config.getKafkaConfigMap()));
-                ExecutionContext.INSTANCE.notationLibrary().register(AvroNotation.NOTATION_NAME, defaultAvro);
-                log.warn("No notations configured. Loading default Avro notation with Confluent implementation. If you use AVRO in your KSML definition, please explicitly configure notations in the ksml-runner.yaml.");
-            }
-
-            final var errorHandling = ksmlConfig.errorHandlingConfig();
-            if (errorHandling != null) {
-                ExecutionContext.INSTANCE.errorHandling().setConsumeHandler(getErrorHandler(errorHandling.consumerErrorHandlingConfig()));
-                ExecutionContext.INSTANCE.errorHandling().setProduceHandler(getErrorHandler(errorHandling.producerErrorHandlingConfig()));
-                ExecutionContext.INSTANCE.errorHandling().setProcessHandler(getErrorHandler(errorHandling.processErrorHandlingConfig()));
-            }
-            ExecutionContext.INSTANCE.serdeWrapper(
-                    serde -> new Serdes.WrapperSerde<>(
-                            new ResolvingSerializer<>(serde.serializer(), config.getKafkaConfigMap()),
-                            new ResolvingDeserializer<>(serde.deserializer(), config.getKafkaConfigMap())));
-
-            final Map<String, TopologyDefinition> producerDefinitions = new HashMap<>();
-            final Map<String, TopologyDefinition> pipelineDefinitions = new HashMap<>();
-            definitions.forEach((name, definition) -> {
-                final var parser = new TopologyDefinitionParser(name);
-                final var topologyDefinition = parser.parse(ParseNode.fromRoot(definition, name));
-                if (!topologyDefinition.producers().isEmpty()) producerDefinitions.put(name, topologyDefinition);
-                if (!topologyDefinition.pipelines().isEmpty()) pipelineDefinitions.put(name, topologyDefinition);
-            });
-
-            if (!ksmlConfig.enableProducers() && !producerDefinitions.isEmpty()) {
-                log.warn("Producers are disabled for this runner. The supplied producer specifications will be ignored.");
-                producerDefinitions.clear();
-            }
-            if (!ksmlConfig.enablePipelines() && !pipelineDefinitions.isEmpty()) {
-                log.warn("Pipelines are disabled for this runner. The supplied pipeline specifications will be ignored.");
-                pipelineDefinitions.clear();
-            }
-
-            final var producer = producerDefinitions.isEmpty() ? null : new KafkaProducerRunner(
-                    KafkaProducerRunner.Config.builder()
-                            .definitions(producerDefinitions)
-                            .kafkaConfig(config.getKafkaConfigMap())
-                            .pythonContextConfig(ksmlConfig.pythonContextConfig())
-                            .build()
-            );
-            final var streams = pipelineDefinitions.isEmpty() ? null : new KafkaStreamsRunner(KafkaStreamsRunner.Config.builder()
-                    .storageDirectory(ksmlConfig.storageDirectory())
-                    .appServer(ksmlConfig.applicationServerConfig())
-                    .definitions(pipelineDefinitions)
-                    .kafkaConfig(config.getKafkaConfigMap())
-                    .pythonContextConfig(ksmlConfig.pythonContextConfig())
-                    .build());
+            final var producer = createProducerRunner(definitionSplit.producers(), config, ksmlConfig);
+            final var streams = createStreamsRunner(definitionSplit.pipelines(), config, ksmlConfig);
 
             if (producer != null || streams != null) {
-                var shutdownHook = new Thread(() -> {
-                    try {
-                        log.debug("In KSML shutdown hook");
-                        if (producer != null) producer.stop();
-                        if (streams != null) streams.stop();
-                    } catch (Exception e) {
-                        log.error("Could not properly shut down KSML", e);
-                    }
-                });
-
-                Runtime.getRuntime().addShutdownHook(shutdownHook);
-
-                try (var prometheusExport = new PrometheusExport(config.getKsmlConfig().prometheusConfig())) {
-                    prometheusExport.start();
-                    final var executorService = Executors.newFixedThreadPool(2);
-
-                    final var producerFuture = producer == null ? CompletableFuture.completedFuture(null) : CompletableFuture.runAsync(producer, executorService);
-                    final var streamsFuture = streams == null ? CompletableFuture.completedFuture(null) : CompletableFuture.runAsync(streams, executorService);
-
-                    try {
-                        // Allow the runner(s) to start
-                        Utils.sleep(2000);
-
-                        if (restServer != null) {
-                            // Run with the REST server
-                            restServer.initGlobalQuerier(getQuerier(streams, producer));
-                        }
-
-                        producerFuture.whenComplete((result, exc) -> {
-                            if (exc != null) {
-                                log.info("Producer failed", exc);
-                                // Exception, always stop streams too
-                                if (streams != null) {
-                                    streams.stop();
-                                }
-                            }
-                        });
-                        streamsFuture.whenComplete((result, exc) -> {
-                            if (exc != null) {
-                                log.info("Stream processing failed", exc);
-                                // Exception, always stop producer too
-                                if (producer != null) {
-                                    producer.stop();
-                                }
-                            }
-                        });
-
-                        final var allFutures = CompletableFuture.allOf(producerFuture, streamsFuture);
-                        // wait for all futures to finish
-                        allFutures.join();
-
-                        closeExecutorService(executorService);
-                    } finally {
-                        if (restServer != null) restServer.close();
-                    }
-                } finally {
-                    Runtime.getRuntime().removeShutdownHook(shutdownHook);
-                }
+                runRunners(producer, streams, restServer, ksmlConfig.prometheusConfig());
             }
         } catch (Throwable t) {
             log.error("KSML Stopping because of unhandled exception");
@@ -362,6 +205,113 @@ public class KSMLRunner {
         }
         // Explicit exit, need to find out which threads are actually stopping us
         System.exit(0);
+    }
+
+    /**
+     * Creates and starts the REST server for state-store queries and health checks, or returns
+     * {@code null} when the application server is disabled. Extracted from {@code main} for readability.
+     *
+     * @param appServer the application server configuration
+     * @return a started {@link RestServer}, or {@code null} when disabled
+     */
+    static RestServer createRestServer(io.axual.ksml.runner.config.ApplicationServerConfig appServer) {
+        if (!appServer.enabled()) {
+            return null;
+        }
+        final var hostInfo = new HostInfo(appServer.getHost(), appServer.getPort());
+        final var restServer = new RestServer(hostInfo);
+        restServer.start();
+        return restServer;
+    }
+
+    /**
+     * Creates a {@link KafkaProducerRunner} for the given producer definitions, or {@code null} when
+     * there are none. Extracted from {@code main} for readability.
+     *
+     * @param producerDefinitions the producer definitions to run
+     * @param config              the runner configuration (for Kafka settings)
+     * @param ksmlConfig          the KSML configuration (for the Python context)
+     * @return a producer runner, or {@code null} when there are no producer definitions
+     */
+    static KafkaProducerRunner createProducerRunner(Map<String, TopologyDefinition> producerDefinitions, KSMLRunnerConfig config, KSMLConfig ksmlConfig) {
+        if (producerDefinitions.isEmpty()) {
+            return null;
+        }
+        return new KafkaProducerRunner(KafkaProducerRunner.Config.builder()
+                .definitions(producerDefinitions)
+                .kafkaConfig(config.getKafkaConfigMap())
+                .pythonContextConfig(ksmlConfig.pythonContextConfig())
+                .build());
+    }
+
+    /**
+     * Creates a {@link KafkaStreamsRunner} for the given pipeline definitions, or {@code null} when
+     * there are none. Extracted from {@code main} for readability.
+     *
+     * @param pipelineDefinitions the pipeline definitions to run
+     * @param config              the runner configuration (for Kafka settings)
+     * @param ksmlConfig          the KSML configuration (storage directory, app server, Python context)
+     * @return a streams runner, or {@code null} when there are no pipeline definitions
+     */
+    static KafkaStreamsRunner createStreamsRunner(Map<String, TopologyDefinition> pipelineDefinitions, KSMLRunnerConfig config, KSMLConfig ksmlConfig) {
+        if (pipelineDefinitions.isEmpty()) {
+            return null;
+        }
+        return new KafkaStreamsRunner(KafkaStreamsRunner.Config.builder()
+                .storageDirectory(ksmlConfig.storageDirectory())
+                .appServer(ksmlConfig.applicationServerConfig())
+                .definitions(pipelineDefinitions)
+                .kafkaConfig(config.getKafkaConfigMap())
+                .pythonContextConfig(ksmlConfig.pythonContextConfig())
+                .build());
+    }
+
+    /**
+     * Runs the producer and/or streams runners to completion: registers a shutdown hook, starts the
+     * Prometheus exporter, submits the runners to an executor, wires the REST querier and the
+     * cross-stop-on-failure handlers, waits for both to finish and finally cleans everything up.
+     * Extracted from {@code main} to keep the orchestration in one cohesive, readable place.
+     *
+     * @param producer         the producer runner, or {@code null}
+     * @param streams          the streams runner, or {@code null}
+     * @param restServer       the REST server, or {@code null} when disabled
+     * @param prometheusConfig the Prometheus exporter configuration
+     * @throws Exception when the Prometheus exporter or executor shutdown fails
+     */
+    static void runRunners(KafkaProducerRunner producer, KafkaStreamsRunner streams, RestServer restServer, io.axual.ksml.runner.config.PrometheusConfig prometheusConfig) throws Exception {
+        var shutdownHook = new Thread(() -> stopRunnersQuietly(producer, streams));
+        Runtime.getRuntime().addShutdownHook(shutdownHook);
+
+        try (var prometheusExport = new PrometheusExport(prometheusConfig)) {
+            prometheusExport.start();
+            final var executorService = Executors.newFixedThreadPool(2);
+
+            final var producerFuture = producer == null ? CompletableFuture.completedFuture(null) : CompletableFuture.runAsync(producer, executorService);
+            final var streamsFuture = streams == null ? CompletableFuture.completedFuture(null) : CompletableFuture.runAsync(streams, executorService);
+
+            try {
+                // Allow the runner(s) to start
+                Utils.sleep(2000);
+
+                if (restServer != null) {
+                    // Run with the REST server
+                    restServer.initGlobalQuerier(getQuerier(streams, producer));
+                }
+
+                // If one runner fails, always stop the other one too
+                producerFuture.whenComplete((result, exc) -> stopOtherOnFailure(exc, "Producer failed", streams));
+                streamsFuture.whenComplete((result, exc) -> stopOtherOnFailure(exc, "Stream processing failed", producer));
+
+                // wait for all futures to finish
+                CompletableFuture.allOf(producerFuture, streamsFuture).join();
+
+                closeExecutorService(executorService);
+            } finally {
+                if (restServer != null) restServer.close();
+            }
+        } finally {
+            Runtime.getRuntime().removeShutdownHook(shutdownHook);
+        }
     }
 
     /**
@@ -375,7 +325,230 @@ public class KSMLRunner {
         return notationConfig.type().jsonValue();
     }
 
-    private static void closeExecutorService(final ExecutorService executorService) throws ExecutionException {
+    /**
+     * Wraps a serde so that its serializer and deserializer resolve topic/group names using the runner's
+     * Kafka configuration. Extracted from {@code main} for testability.
+     *
+     * @param serde       the serde to wrap
+     * @param kafkaConfig the Kafka configuration used by the resolving (de)serializers
+     * @return a serde whose (de)serializers resolve names according to the configuration
+     */
+    static <T> org.apache.kafka.common.serialization.Serde<T> wrapSerde(org.apache.kafka.common.serialization.Serde<T> serde, Map<String, String> kafkaConfig) {
+        return new Serdes.WrapperSerde<>(
+                new ResolvingSerializer<>(serde.serializer(), kafkaConfig),
+                new ResolvingDeserializer<>(serde.deserializer(), kafkaConfig));
+    }
+
+    /**
+     * Parses each raw KSML definition into a {@link TopologyDefinition}. Extracted from {@code main}
+     * for testability.
+     *
+     * @param definitions the raw definitions keyed by namespace
+     * @return the parsed topology definitions keyed by namespace
+     */
+    static Map<String, TopologyDefinition> parseDefinitions(Map<String, com.fasterxml.jackson.databind.JsonNode> definitions) {
+        final Map<String, TopologyDefinition> parsedDefinitions = new HashMap<>();
+        definitions.forEach((name, definition) -> {
+            final var parser = new TopologyDefinitionParser(name);
+            parsedDefinitions.put(name, parser.parse(ParseNode.fromRoot(definition, name)));
+        });
+        return parsedDefinitions;
+    }
+
+    /**
+     * Stops the producer and streams runners, swallowing any exception so a shutdown hook never fails.
+     * Either runner may be {@code null}. Extracted from {@code main} for testability.
+     *
+     * @param producer the producer runner, or {@code null}
+     * @param streams  the streams runner, or {@code null}
+     */
+    static void stopRunnersQuietly(Runner producer, Runner streams) {
+        try {
+            log.debug("In KSML shutdown hook");
+            if (producer != null) producer.stop();
+            if (streams != null) streams.stop();
+        } catch (Exception e) {
+            log.error("Could not properly shut down KSML", e);
+        }
+    }
+
+    /**
+     * Determines whether the runner should exit after printing a schema.
+     * 
+     * @param cmd the parsed command line arguments
+     * @return {@code true} when the runner should exit, {@code false} otherwise
+     */
+    static boolean shouldExit(Arguments cmd) {
+        var shouldExit = false;
+        // Check if we need to output the KSML schema and then exit
+        if (cmd.shouldPrintKsmlSchema()) {
+            log.info("Generating KSML definitions schema");
+            shouldExit = true;
+            printKsmlDefinitionSchema(cmd.ksmlSchemaLocation());
+        }
+
+        // Check if we need to output the runner schema and then exit
+        if (cmd.shouldPrintKsmlRunnerSchema()) {
+            log.info("Generating KSML Runner Configuration Schema");
+            shouldExit = true;
+            printRunnerSchema(cmd.ksmlRunnerSchemaLocation());
+        }
+        return shouldExit;
+    }
+
+    /**
+     * When a runner completes exceptionally, stops the other runner so the whole application winds down.
+     * Used as the completion handler for the producer and streams futures. Extracted from {@code main}
+     * for testability.
+     *
+     * @param exc        the exception the future completed with, or {@code null} on success
+     * @param logMessage the message to log when a failure occurred
+     * @param other      the other runner to stop, or {@code null}
+     */
+    static void stopOtherOnFailure(Throwable exc, String logMessage, Runner other) {
+        if (exc != null) {
+            log.info(logMessage, exc);
+            // Exception, always stop the other runner too
+            if (other != null) {
+                other.stop();
+            }
+        }
+    }
+
+    /**
+     * Result of splitting parsed KSML definitions into the ones containing producers and the ones
+     * containing pipelines. A single definition can appear in both maps.
+     */
+    record DefinitionSplit(Map<String, TopologyDefinition> producers, Map<String, TopologyDefinition> pipelines) {
+    }
+
+    /**
+     * Splits the parsed definitions into producer and pipeline definitions and applies the runner's
+     * enable toggles. When producers or pipelines are disabled, the corresponding definitions are
+     * dropped (with a warning). Extracted from {@code main} for testability.
+     *
+     * @param parsedDefinitions the parsed topology definitions keyed by namespace
+     * @param enableProducers   whether producers are enabled for this runner
+     * @param enablePipelines   whether pipelines are enabled for this runner
+     * @return the producer and pipeline definitions that should actually run
+     */
+    static DefinitionSplit splitDefinitions(Map<String, TopologyDefinition> parsedDefinitions, boolean enableProducers, boolean enablePipelines) {
+        final Map<String, TopologyDefinition> producerDefinitions = new HashMap<>();
+        final Map<String, TopologyDefinition> pipelineDefinitions = new HashMap<>();
+        parsedDefinitions.forEach((name, topologyDefinition) -> {
+            if (!topologyDefinition.producers().isEmpty()) producerDefinitions.put(name, topologyDefinition);
+            if (!topologyDefinition.pipelines().isEmpty()) pipelineDefinitions.put(name, topologyDefinition);
+        });
+
+        if (!enableProducers && !producerDefinitions.isEmpty()) {
+            log.warn("Producers are disabled for this runner. The supplied producer specifications will be ignored.");
+            producerDefinitions.clear();
+        }
+        if (!enablePipelines && !pipelineDefinitions.isEmpty()) {
+            log.warn("Pipelines are disabled for this runner. The supplied pipeline specifications will be ignored.");
+            pipelineDefinitions.clear();
+        }
+        return new DefinitionSplit(producerDefinitions, pipelineDefinitions);
+    }
+
+    /**
+     * Validates that the runner has at least one KSML definition to run. Extracted from {@code main}
+     * for testability.
+     *
+     * @param definitions the resolved KSML definitions keyed by namespace
+     * @throws ConfigException when no definitions are configured
+     */
+    static void validateDefinitions(Map<String, ?> definitions) {
+        if (definitions == null || definitions.isEmpty()) {
+            throw new ConfigException("definitions", definitions, "No KSML definitions found in configuration");
+        }
+    }
+
+    /**
+     * Registers all notations in the {@link ExecutionContext}: first the built-in defaults provided by
+     * {@link NotationFactories}, then the configured notation overrides, and finally a Confluent AVRO
+     * fallback when no notations are configured at all. Extracted from {@code main} for testability.
+     *
+     * @param ksmlConfig     the KSML configuration holding notation overrides and schema registries
+     * @param kafkaConfigMap the effective Kafka configuration passed to the notation factories
+     */
+    static void registerNotations(KSMLConfig ksmlConfig, Map<String, String> kafkaConfigMap) {
+        // Set up all default notations and register them in the NotationLibrary
+        final var notationFactories = new NotationFactories(kafkaConfigMap);
+        for (final var notation : notationFactories.notations().entrySet()) {
+            ExecutionContext.INSTANCE.notationLibrary().register(notation.getKey(), notation.getValue().create(null));
+        }
+
+        // Set up all notation overrides from the KSML config
+        for (final var notationEntry : ksmlConfig.notations().entrySet()) {
+            final var notationStr = notationEntry.getKey() != null ? notationEntry.getKey() : "undefined";
+
+            final var notationConfig = notationEntry.getValue();
+            final var factoryName = resolveFactoryName(notationConfig);
+            if (notationConfig != null && factoryName != null) {
+                final var factory = notationFactories.notations().get(factoryName);
+                if (factory == null) {
+                    throw FatalError.report(new ConfigException("Unknown notation type: " + factoryName));
+                }
+                final var notationConfigs = mergeNotationConfigs(notationConfig, ksmlConfig.schemaRegistries());
+                ExecutionContext.INSTANCE.notationLibrary().register(notationStr, factory.create(notationConfigs));
+            } else {
+                log.warn("Notation configuration incomplete: notation={}, serde={}", notationStr, factoryName);
+            }
+        }
+
+        // Ensure typical defaults are used for AVRO
+        // WARNING: Defaults for notations will be deprecated in the future. Make sure you explicitly configure
+        // notations with multiple implementations (like AVRO) in your ksml-runner.yaml.
+        if (ksmlConfig.notations().isEmpty()) {
+            final var dataMapper = new DataObjectFlattener();
+            final var dataTypeMapper = new DataTypeFlattener();
+            final var defaultAvro = new ConfluentAvroNotationProvider().createNotation(new NotationContext(dataMapper, dataTypeMapper, kafkaConfigMap));
+            ExecutionContext.INSTANCE.notationLibrary().register(AvroNotation.NOTATION_NAME, defaultAvro);
+            log.warn("No notations configured. Loading default Avro notation with Confluent implementation. If you use AVRO in your KSML definition, please explicitly configure notations in the ksml-runner.yaml.");
+        }
+    }
+
+    /**
+     * Merges the configuration that a notation factory should receive: first the referenced schema
+     * registry configuration (when present), then the notation's own configuration overrides.
+     * Extracted from {@code main} for testability.
+     *
+     * @param notationConfig   the notation configuration entry
+     * @param schemaRegistries the configured schema registries, keyed by name
+     * @return the merged configuration map passed to the notation factory
+     */
+    static Map<String, String> mergeNotationConfigs(NotationConfig notationConfig, Map<String, SchemaRegistryConfig> schemaRegistries) {
+        final var notationConfigs = new HashMap<String, String>();
+        final var schemaRegistryName = notationConfig.schemaRegistry();
+        if (schemaRegistryName != null) {
+            final var srConfigs = schemaRegistries.get(schemaRegistryName);
+            if (srConfigs != null && srConfigs.config() != null) {
+                notationConfigs.putAll(srConfigs.config());
+            } else {
+                log.warn("No schema registry configuration found for schema registry: {}", schemaRegistryName);
+            }
+        }
+        if (notationConfig.config() != null) notationConfigs.putAll(notationConfig.config());
+        return notationConfigs;
+    }
+
+    /**
+     * Registers the consume, produce and process error handlers in the {@link ExecutionContext}.
+     * A {@code null} configuration leaves the existing handlers untouched. Extracted from {@code main}
+     * for testability.
+     *
+     * @param errorHandling the error handling configuration, or {@code null}
+     */
+    static void setupErrorHandling(ErrorHandlingConfig errorHandling) {
+        if (errorHandling != null) {
+            ExecutionContext.INSTANCE.errorHandling().setConsumeHandler(getErrorHandler(errorHandling.consumerErrorHandlingConfig()));
+            ExecutionContext.INSTANCE.errorHandling().setProduceHandler(getErrorHandler(errorHandling.producerErrorHandlingConfig()));
+            ExecutionContext.INSTANCE.errorHandling().setProcessHandler(getErrorHandler(errorHandling.processErrorHandlingConfig()));
+        }
+    }
+
+    static void closeExecutorService(final ExecutorService executorService) throws ExecutionException {
         executorService.shutdown();
         try {
             if (!executorService.awaitTermination(2000, TimeUnit.MILLISECONDS)) {
@@ -536,6 +709,7 @@ public class KSMLRunner {
         return defaultValue;
     }
 
+    @SuppressWarnings("java:S106")
     private static void printKsmlDefinitionSchema(String filename) {
         // Check if the runner was started with "--schema". If so, then we output the JSON schema to validate the
         // KSML definitions with on stdout and exit
@@ -563,7 +737,7 @@ public class KSMLRunner {
         }
     }
 
-    private static KSMLRunnerConfig readConfiguration(File configFile) {
+    static KSMLRunnerConfig readConfiguration(File configFile) {
         final var mapper = new ObjectMapper(new YAMLFactory());
         try {
             final var config = mapper.readValue(configFile, KSMLRunnerConfig.class);

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/KSMLRunner.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/KSMLRunner.java
@@ -4,7 +4,7 @@ package io.axual.ksml.runner;
  * ========================LICENSE_START=================================
  * KSML Runner
  * %%
- * Copyright (C) 2021 - 2023 Axual B.V.
+ * Copyright (C) 2021 - 2026 Axual B.V.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ package io.axual.ksml.runner;
  */
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.github.victools.jsonschema.generator.FieldScope;
@@ -53,10 +54,12 @@ import io.axual.ksml.rest.server.RestServer;
 import io.axual.ksml.runner.backend.KafkaProducerRunner;
 import io.axual.ksml.runner.backend.KafkaStreamsRunner;
 import io.axual.ksml.runner.backend.Runner;
+import io.axual.ksml.runner.config.ApplicationServerConfig;
 import io.axual.ksml.runner.config.ErrorHandlingConfig;
 import io.axual.ksml.runner.config.KSMLConfig;
 import io.axual.ksml.runner.config.KSMLRunnerConfig;
 import io.axual.ksml.runner.config.NotationConfig;
+import io.axual.ksml.runner.config.PrometheusConfig;
 import io.axual.ksml.runner.config.SchemaRegistryConfig;
 import io.axual.ksml.runner.config.internal.KsmlFileOrDefinitionProvider;
 import io.axual.ksml.runner.config.internal.KsmlFileOrDefinitionSubTypeResolver;
@@ -68,6 +71,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Utils;
@@ -214,7 +218,7 @@ public class KSMLRunner {
      * @param appServer the application server configuration
      * @return a started {@link RestServer}, or {@code null} when disabled
      */
-    static RestServer createRestServer(io.axual.ksml.runner.config.ApplicationServerConfig appServer) {
+    static RestServer createRestServer(ApplicationServerConfig appServer) {
         if (!appServer.enabled()) {
             return null;
         }
@@ -278,7 +282,7 @@ public class KSMLRunner {
      * @param prometheusConfig the Prometheus exporter configuration
      * @throws Exception when the Prometheus exporter or executor shutdown fails
      */
-    static void runRunners(KafkaProducerRunner producer, KafkaStreamsRunner streams, RestServer restServer, io.axual.ksml.runner.config.PrometheusConfig prometheusConfig) throws Exception {
+    static void runRunners(KafkaProducerRunner producer, KafkaStreamsRunner streams, RestServer restServer, PrometheusConfig prometheusConfig) throws Exception {
         var shutdownHook = new Thread(() -> stopRunnersQuietly(producer, streams));
         Runtime.getRuntime().addShutdownHook(shutdownHook);
 
@@ -333,7 +337,7 @@ public class KSMLRunner {
      * @param kafkaConfig the Kafka configuration used by the resolving (de)serializers
      * @return a serde whose (de)serializers resolve names according to the configuration
      */
-    static <T> org.apache.kafka.common.serialization.Serde<T> wrapSerde(org.apache.kafka.common.serialization.Serde<T> serde, Map<String, String> kafkaConfig) {
+    static <T> Serde<T> wrapSerde(Serde<T> serde, Map<String, String> kafkaConfig) {
         return new Serdes.WrapperSerde<>(
                 new ResolvingSerializer<>(serde.serializer(), kafkaConfig),
                 new ResolvingDeserializer<>(serde.deserializer(), kafkaConfig));
@@ -346,7 +350,7 @@ public class KSMLRunner {
      * @param definitions the raw definitions keyed by namespace
      * @return the parsed topology definitions keyed by namespace
      */
-    static Map<String, TopologyDefinition> parseDefinitions(Map<String, com.fasterxml.jackson.databind.JsonNode> definitions) {
+    static Map<String, TopologyDefinition> parseDefinitions(Map<String, JsonNode> definitions) {
         final Map<String, TopologyDefinition> parsedDefinitions = new HashMap<>();
         definitions.forEach((name, definition) -> {
             final var parser = new TopologyDefinitionParser(name);
@@ -484,13 +488,15 @@ public class KSMLRunner {
             final var notationStr = notationEntry.getKey() != null ? notationEntry.getKey() : "undefined";
 
             final var notationConfig = notationEntry.getValue();
+            // Resolve the schema-registry and notation configuration up front so a missing schema
+            // registry is reported even when the notation type itself is incomplete.
+            final var notationConfigs = mergeNotationConfigs(notationConfig, ksmlConfig.schemaRegistries());
             final var factoryName = resolveFactoryName(notationConfig);
             if (notationConfig != null && factoryName != null) {
                 final var factory = notationFactories.notations().get(factoryName);
                 if (factory == null) {
                     throw FatalError.report(new ConfigException("Unknown notation type: " + factoryName));
                 }
-                final var notationConfigs = mergeNotationConfigs(notationConfig, ksmlConfig.schemaRegistries());
                 ExecutionContext.INSTANCE.notationLibrary().register(notationStr, factory.create(notationConfigs));
             } else {
                 log.warn("Notation configuration incomplete: notation={}, serde={}", notationStr, factoryName);

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/backend/KafkaProducerRunner.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/backend/KafkaProducerRunner.java
@@ -4,7 +4,7 @@ package io.axual.ksml.runner.backend;
  * ========================LICENSE_START=================================
  * KSML Runner
  * %%
- * Copyright (C) 2021 - 2023 Axual B.V.
+ * Copyright (C) 2021 - 2026 Axual B.V.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/backend/KafkaProducerRunner.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/backend/KafkaProducerRunner.java
@@ -45,7 +45,8 @@ import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_
 @Slf4j
 public class KafkaProducerRunner implements Runner {
     private static final String UNDEFINED = "undefined";
-    private final IntervalSchedule scheduler = new IntervalSchedule();
+    // Package-private so tests can schedule producers directly when exercising the produce loop.
+    final IntervalSchedule scheduler = new IntervalSchedule();
     private final AtomicBoolean hasFailed = new AtomicBoolean(false);
     private final AtomicBoolean stopRunning = new AtomicBoolean(false);
     private final Config config;
@@ -84,6 +85,26 @@ public class KafkaProducerRunner implements Runner {
         log.info("Registering Kafka producer(s)");
         setState(State.STARTING);
 
+        registerProducers();
+
+        try (final Producer<byte[], byte[]> producer = producerFactory.apply(getProducerConfigs())) {
+            setState(State.STARTED);
+            log.info("Starting Kafka producer(s)");
+            runScheduledProducers(producer);
+        } catch (Exception e) {
+            setState(State.FAILED);
+            throw new RunnerException("Unhandled producer exception", e);
+        }
+        setState(State.STOPPED);
+        log.info("Producer(s) stopped");
+    }
+
+    /**
+     * Sets up the Python context for every definition, pre-registers its functions and schedules its
+     * producers. Extracted from {@link #run()} to separate the (Python-bound) registration phase from
+     * the produce loop.
+     */
+    private void registerProducers() {
         try {
             config.definitions.forEach((defName, definition) -> {
                 // Log the start of the producer
@@ -106,29 +127,30 @@ public class KafkaProducerRunner implements Runner {
             setState(State.FAILED);
             throw new RunnerException("Error while registering functions and producers", e);
         }
+    }
 
-        try (final Producer<byte[], byte[]> producer = producerFactory.apply(getProducerConfigs())) {
-            setState(State.STARTED);
-            log.info("Starting Kafka producer(s)");
-            while (!stopRunning.get() && !hasFailed.get() && scheduler.hasScheduledItems()) {
-                var scheduledGenerator = scheduler.getScheduledItem();
-                if (scheduledGenerator != null) {
-                    scheduledGenerator.producer().produceMessages(producer);
-                    if (scheduledGenerator.producer().shouldReschedule()) {
-                        final var interval = scheduledGenerator.producer().interval() != null
-                                ? scheduledGenerator.producer().interval().toMillis()
-                                : 0L;
-                        final long nextTime = scheduledGenerator.startTime() + interval;
-                        scheduler.schedule(scheduledGenerator.producer(), nextTime);
-                    }
+    /**
+     * Drives the scheduled producers: repeatedly takes the next due producer, produces its messages and
+     * reschedules it at {@code startTime + interval} when it asks to be rescheduled, until the runner is
+     * stopped, has failed, or nothing is scheduled anymore. Extracted from {@link #run()} so the
+     * scheduling/reschedule logic can be unit-tested with a stubbed producer.
+     *
+     * @param producer the Kafka producer the messages are sent with
+     */
+    void runScheduledProducers(Producer<byte[], byte[]> producer) {
+        while (!stopRunning.get() && !hasFailed.get() && scheduler.hasScheduledItems()) {
+            var scheduledGenerator = scheduler.getScheduledItem();
+            if (scheduledGenerator != null) {
+                scheduledGenerator.producer().produceMessages(producer);
+                if (scheduledGenerator.producer().shouldReschedule()) {
+                    final var interval = scheduledGenerator.producer().interval() != null
+                            ? scheduledGenerator.producer().interval().toMillis()
+                            : 0L;
+                    final long nextTime = scheduledGenerator.startTime() + interval;
+                    scheduler.schedule(scheduledGenerator.producer(), nextTime);
                 }
             }
-        } catch (Exception e) {
-            setState(State.FAILED);
-            throw new RunnerException("Unhandled producer exception", e);
         }
-        setState(State.STOPPED);
-        log.info("Producer(s) stopped");
     }
 
     private Map<String, Object> getProducerConfigs() {

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/config/NotationConfig.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/config/NotationConfig.java
@@ -53,6 +53,7 @@ public record NotationConfig(
     @JsonClassDescription("Supported notation serializer implementations.")
     @Getter(onMethod_ = @JsonValue)
     @RequiredArgsConstructor
+    @SuppressWarnings("java:S1135")
     public enum NotationType {
         // Schema-registry-backed notations (loaded via ServiceLoader)
         APICURIO_AVRO("apicurio_avro"),

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/config/NotationConfig.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/config/NotationConfig.java
@@ -4,7 +4,7 @@ package io.axual.ksml.runner.config;
  * ========================LICENSE_START=================================
  * KSML Runner
  * %%
- * Copyright (C) 2021 - 2023 Axual B.V.
+ * Copyright (C) 2021 - 2026 Axual B.V.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/producer/ExecutableProducer.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/producer/ExecutableProducer.java
@@ -60,6 +60,7 @@ import static io.axual.ksml.type.UserType.DEFAULT_NOTATION;
 @Slf4j
 public class ExecutableProducer {
     private static final DataObjectConverter DATA_OBJECT_CONVERTER = new DataObjectConverter();
+    private static final int MAX_GENERATE_RETRIES = 10;
 
     @Getter
     private final String name;
@@ -156,34 +157,13 @@ public class ExecutableProducer {
         final var futures = new ArrayList<Future<RecordMetadata>>();
         try {
             for (final var message : messages) {
-                if (partitioner != null) {
-                    // If a partitioner is defined, then call the function and generate producer records for every
-                    // partition the message is sent to
-                    final var numPartitions = producer.partitionsFor(topic).size();
-                    Optional<Set<Integer>> partitions = partitioner.partitions(topic, message.key(), message.value(), numPartitions);
-                    if (partitions.isPresent()) {
-                        for (int partition : partitions.get()) {
-                            ProducerRecord<byte[], byte[]> rec = new ProducerRecord<>(topic, partition, message.key(), message.value(), message.headers());
-                            futures.add(producer.send(rec));
-                        }
-                    }
-                } else {
-                    // No partitioner is defined, so create just one producer record without specifying a partition
-                    ProducerRecord<byte[], byte[]> rec = new ProducerRecord<>(topic, null, message.key(), message.value(), message.headers());
-                    futures.add(producer.send(rec));
-                }
+                sendMessage(producer, message, futures);
             }
 
             batchCount++;
 
             for (var future : futures) {
-                final var metadata = future.get();
-                if (metadata != null && metadata.hasOffset()) {
-                    producerStrategy.successfullyProducedOneMessage();
-                    log.info("Produced message: producer={}, batch #{}, message #{}, topic={}, partition={}, offset={}", name, batchCount, producerStrategy.messagesProduced(), metadata.topic(), metadata.partition(), metadata.offset());
-                } else {
-                    log.error("Error producing message to topic {}", topic);
-                }
+                logProducedMessage(future.get());
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -193,44 +173,92 @@ public class ExecutableProducer {
         }
     }
 
+    /**
+     * Sends a single generated message: when a partitioner is configured the message is sent to every
+     * partition it selects, otherwise it is sent once without specifying a partition. The resulting send
+     * futures are appended to {@code futures}. Extracted from {@link #produceMessages} to keep its
+     * cognitive complexity low.
+     */
+    private void sendMessage(Producer<byte[], byte[]> producer, GeneratedMessage message, List<Future<RecordMetadata>> futures) {
+        if (partitioner == null) {
+            // No partitioner is defined, so create just one producer record without specifying a partition
+            futures.add(producer.send(new ProducerRecord<>(topic, null, message.key(), message.value(), message.headers())));
+            return;
+        }
+
+        // A partitioner is defined, so call the function and generate a producer record for every
+        // partition the message is sent to
+        final var numPartitions = producer.partitionsFor(topic).size();
+        final Optional<Set<Integer>> partitions = partitioner.partitions(topic, message.key(), message.value(), numPartitions);
+        if (partitions.isEmpty()) {
+            return;
+        }
+        for (int partition : partitions.get()) {
+            futures.add(producer.send(new ProducerRecord<>(topic, partition, message.key(), message.value(), message.headers())));
+        }
+    }
+
+    /**
+     * Records the outcome of a single send: a message with an assigned offset counts as produced,
+     * anything else is logged as an error. Extracted from {@link #produceMessages} to keep its
+     * cognitive complexity low.
+     */
+    private void logProducedMessage(RecordMetadata metadata) {
+        if (metadata != null && metadata.hasOffset()) {
+            producerStrategy.successfullyProducedOneMessage();
+            log.info("Produced message: producer={}, batch #{}, message #{}, topic={}, partition={}, offset={}", name, batchCount, producerStrategy.messagesProduced(), metadata.topic(), metadata.partition(), metadata.offset());
+        } else {
+            log.error("Error producing message to topic {}", topic);
+        }
+    }
+
     private List<GeneratedMessage> generateBatch() {
         final var result = new ArrayList<GeneratedMessage>();
-        for (int index = 0; index < producerStrategy.batchSize(); index++) {
-            Pair<DataObject, DataObject> message = null;
-            for (int t = 0; t < 10; t++) {
-                message = generateMessage();
-                if (message != null) break;
-            }
-
-            if (message != null) {
-                final var key = message.left();
-                final var value = message.right();
-
-                // Log the generated messages
-                final var keyStr = key != null ? key.toString(DataObject.Printer.EXTERNAL_TOP_SCHEMA).replace("\n", "\\\\n") : "null";
-                final var valueStr = value != null ? value.toString(DataObject.Printer.EXTERNAL_TOP_SCHEMA).replace("\n", "\\\\n") : "null";
-                log.info("Message: key={}, value={}", keyStr, valueStr);
-
-                // Serialize the message
-                final var headers = new RecordHeaders();
-                final var serializedKey = keySerializer.serialize(topic, headers, key);
-                final var serializedValue = valueSerializer.serialize(topic, headers, value);
-
-                // Add the serialized message to the batch
-                result.add(new GeneratedMessage(headers, serializedKey, serializedValue));
-
-                // Check if this should be the last message produced
-                if (!producerStrategy.continueAfterMessage(key, value)) {
-                    stopProducing = true;
-                    break;
-                }
+        var keepGenerating = true;
+        for (var index = 0; index < producerStrategy.batchSize() && keepGenerating; index++) {
+            final var message = generateMessageWithRetries();
+            if (message == null) {
+                log.warn("Could not generate a valid message after {} tries, skipping...", MAX_GENERATE_RETRIES);
             } else {
-                log.warn("Could not generate a valid message after 10 tries, skipping...");
+                // Add the serialized message to the batch
+                result.add(serializeMessage(message));
+
+                // Stop after this message when the strategy says it should be the last one produced
+                if (!producerStrategy.continueAfterMessage(message.left(), message.right())) {
+                    stopProducing = true;
+                    keepGenerating = false;
+                }
             }
         }
 
         // Return the batch of messages
         return result;
+    }
+
+    /** Generates a message, retrying up to {@link #MAX_GENERATE_RETRIES} times, or {@code null} when none could be generated. */
+    private Pair<DataObject, DataObject> generateMessageWithRetries() {
+        for (int t = 0; t < MAX_GENERATE_RETRIES; t++) {
+            final var message = generateMessage();
+            if (message != null) return message;
+        }
+        return null;
+    }
+
+    /** Logs and serializes a generated (key, value) message into a {@link GeneratedMessage}. */
+    private GeneratedMessage serializeMessage(Pair<DataObject, DataObject> message) {
+        final var key = message.left();
+        final var value = message.right();
+
+        // Log the generated messages
+        final var keyStr = key != null ? key.toString(DataObject.Printer.EXTERNAL_TOP_SCHEMA).replace("\n", "\\\\n") : "null";
+        final var valueStr = value != null ? value.toString(DataObject.Printer.EXTERNAL_TOP_SCHEMA).replace("\n", "\\\\n") : "null";
+        log.info("Message: key={}, value={}", keyStr, valueStr);
+
+        // Serialize the message
+        final var headers = new RecordHeaders();
+        final var serializedKey = keySerializer.serialize(topic, headers, key);
+        final var serializedValue = valueSerializer.serialize(topic, headers, value);
+        return new GeneratedMessage(headers, serializedKey, serializedValue);
     }
 
     private Pair<DataObject, DataObject> generateMessage() {

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/producer/ExecutableProducer.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/producer/ExecutableProducer.java
@@ -4,7 +4,7 @@ package io.axual.ksml.runner.producer;
  * ========================LICENSE_START=================================
  * KSML Data Generator
  * %%
- * Copyright (C) 2021 - 2023 Axual B.V.
+ * Copyright (C) 2021 - 2026 Axual B.V.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/producer/ExecutableProducer.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/producer/ExecutableProducer.java
@@ -75,15 +75,17 @@ public class ExecutableProducer {
     private boolean stopProducing = false;
     private final List<Pair<DataObject, DataObject>> messageQueue = new LinkedList<>();
 
-    private ExecutableProducer(UserFunction generator,
-                               ProducerStrategy producerStrategy,
-                               MetricTags tags,
-                               String topic,
-                               UserType keyType,
-                               UserType valueType,
-                               UserFunction partitioner,
-                               Serializer<Object> keySerializer,
-                               Serializer<Object> valueSerializer) {
+    // Package-private (instead of private) so tests can construct a producer with a stubbed generator
+    // and serializers, exercising the produce/batch logic without a Python/GraalVM runtime.
+    ExecutableProducer(UserFunction generator,
+                       ProducerStrategy producerStrategy,
+                       MetricTags tags,
+                       String topic,
+                       UserType keyType,
+                       UserType valueType,
+                       UserFunction partitioner,
+                       Serializer<Object> keySerializer,
+                       Serializer<Object> valueSerializer) {
         this.name = generator.name;
         this.generator = new UserGenerator(generator, tags);
         this.producerStrategy = producerStrategy;
@@ -231,17 +233,30 @@ public class ExecutableProducer {
     }
 
     private List<Pair<DataObject, DataObject>> generateMessages() {
+        return extractMessages(generator.apply(), keyType, valueType, producerStrategy);
+    }
+
+    /**
+     * Turns a generated {@link DataObject} into zero or more validated key/value messages. A single
+     * (key, value) tuple yields one message, while a {@link DataList} yields one message per valid
+     * tuple element; anything else is skipped. Extracted as a package-private static method for
+     * testability.
+     *
+     * @param generated        the object returned by the generator function
+     * @param keyType          the expected key type
+     * @param valueType        the expected value type
+     * @param producerStrategy the strategy used to validate and shape each message
+     * @return the list of validated, type-checked messages (possibly empty)
+     */
+    static List<Pair<DataObject, DataObject>> extractMessages(DataObject generated, UserType keyType, UserType valueType, ProducerStrategy producerStrategy) {
         final var result = new ArrayList<Pair<DataObject, DataObject>>();
-        final var generated = generator.apply();
         if (generated instanceof DataTuple tuple && tuple.elements().size() == 2) {
-            final var msg = shapeMessage(tuple);
-            if (msg != null) result.add(msg);
+            addShapedMessage(result, tuple, keyType, valueType, producerStrategy);
         }
         if (generated instanceof DataList list) {
-            for (DataObject element : list) {
+            for (final var element : list) {
                 if (element instanceof DataTuple tuple && tuple.elements().size() == 2) {
-                    final var msg = shapeMessage(tuple);
-                    if (msg != null) result.add(msg);
+                    addShapedMessage(result, tuple, keyType, valueType, producerStrategy);
                 } else {
                     log.warn("Skipping invalid message: {}", element);
                 }
@@ -250,7 +265,24 @@ public class ExecutableProducer {
         return result;
     }
 
-    private Pair<DataObject, DataObject> shapeMessage(DataTuple tuple) {
+    private static void addShapedMessage(List<Pair<DataObject, DataObject>> result, DataTuple tuple, UserType keyType, UserType valueType, ProducerStrategy producerStrategy) {
+        final var msg = shapeMessage(tuple, keyType, valueType, producerStrategy);
+        if (msg != null) result.add(msg);
+    }
+
+    /**
+     * Validates a (key, value) tuple against the producer strategy, converts both to the target types
+     * and verifies they are assignable to the configured key/value types. Returns {@code null} when the
+     * message is rejected by the strategy or has the wrong type. Extracted as a package-private static
+     * method for testability.
+     *
+     * @param tuple            the generated (key, value) tuple
+     * @param keyType          the expected key type
+     * @param valueType        the expected value type
+     * @param producerStrategy the strategy used to validate the message
+     * @return the shaped (key, value) pair, or {@code null} when the message should be skipped
+     */
+    static Pair<DataObject, DataObject> shapeMessage(DataTuple tuple, UserType keyType, UserType valueType, ProducerStrategy producerStrategy) {
         var key = tuple.elements().get(0);
         var value = tuple.elements().get(1);
 

--- a/ksml-runner/src/main/java/io/axual/ksml/runner/producer/ExecutableProducer.java
+++ b/ksml-runner/src/main/java/io/axual/ksml/runner/producer/ExecutableProducer.java
@@ -80,21 +80,29 @@ public class ExecutableProducer {
     ExecutableProducer(UserFunction generator,
                        ProducerStrategy producerStrategy,
                        MetricTags tags,
-                       String topic,
-                       UserType keyType,
-                       UserType valueType,
                        UserFunction partitioner,
-                       Serializer<Object> keySerializer,
-                       Serializer<Object> valueSerializer) {
+                       ProducerTarget target) {
         this.name = generator.name;
         this.generator = new UserGenerator(generator, tags);
         this.producerStrategy = producerStrategy;
-        this.topic = topic;
-        this.keyType = keyType;
-        this.valueType = valueType;
+        this.topic = target.topic();
+        this.keyType = target.keyType();
+        this.valueType = target.valueType();
         this.partitioner = partitioner != null ? new UserStreamPartitioner(partitioner, tags) : null;
-        this.keySerializer = keySerializer;
-        this.valueSerializer = valueSerializer;
+        this.keySerializer = target.keySerializer();
+        this.valueSerializer = target.valueSerializer();
+    }
+
+    /**
+     * Groups the destination topic together with the key/value types and their serializers. Keeping
+     * these related values in one parameter object keeps the {@link ExecutableProducer} constructor
+     * below the parameter-count threshold and documents that they describe a single producer target.
+     */
+    record ProducerTarget(String topic,
+                          UserType keyType,
+                          UserType valueType,
+                          Serializer<Object> keySerializer,
+                          Serializer<Object> valueSerializer) {
     }
 
     @SuppressWarnings("java:S6218")
@@ -139,7 +147,8 @@ public class ExecutableProducer {
         final var valueSerializer = new ResolvingSerializer<>(valueSerde.serializer(), kafkaConfig);
 
         // Set up the producer
-        return new ExecutableProducer(generator, producerStrategy, tags, target.topic(), target.keyType(), target.valueType(), partitioner, keySerializer, valueSerializer);
+        final var producerTarget = new ProducerTarget(target.topic(), target.keyType(), target.valueType(), keySerializer, valueSerializer);
+        return new ExecutableProducer(generator, producerStrategy, tags, partitioner, producerTarget);
     }
 
     public void produceMessages(Producer<byte[], byte[]> producer) {

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/KSMLRunnerHelpersTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/KSMLRunnerHelpersTest.java
@@ -4,7 +4,7 @@ package io.axual.ksml.runner;
  * ========================LICENSE_START=================================
  * KSML Runner
  * %%
- * Copyright (C) 2021 - 2024 Axual B.V.
+ * Copyright (C) 2021 - 2026 Axual B.V.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,11 +25,14 @@ import io.axual.ksml.client.serde.ResolvingDeserializer;
 import io.axual.ksml.client.serde.ResolvingSerializer;
 import io.axual.ksml.data.notation.binary.BinaryNotation;
 import io.axual.ksml.data.notation.json.JsonNotation;
+import io.axual.ksml.definition.PipelineDefinition;
+import io.axual.ksml.definition.ProducerDefinition;
 import io.axual.ksml.execution.ErrorHandler;
 import io.axual.ksml.execution.ExecutionContext;
 import io.axual.ksml.generator.TopologyDefinition;
 import io.axual.ksml.generator.YAMLObjectMapper;
 import io.axual.ksml.runner.backend.Runner;
+import io.axual.ksml.runner.config.ApplicationServerConfig;
 import io.axual.ksml.runner.config.ErrorHandlingConfig;
 import io.axual.ksml.runner.config.KSMLConfig;
 import io.axual.ksml.runner.config.KSMLRunnerConfig;
@@ -48,6 +51,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -127,8 +131,8 @@ class KSMLRunnerHelpersTest {
 
     private static TopologyDefinition definitionWith(boolean hasProducers, boolean hasPipelines) {
         final var def = mock(TopologyDefinition.class);
-        when(def.producers()).thenReturn(hasProducers ? Map.of("p", mock(io.axual.ksml.definition.ProducerDefinition.class)) : Map.of());
-        when(def.pipelines()).thenReturn(hasPipelines ? Map.of("l", mock(io.axual.ksml.definition.PipelineDefinition.class)) : Map.of());
+        when(def.producers()).thenReturn(hasProducers ? Map.of("p", mock(ProducerDefinition.class)) : Map.of());
+        when(def.pipelines()).thenReturn(hasPipelines ? Map.of("l", mock(PipelineDefinition.class)) : Map.of());
         return def;
     }
 
@@ -176,14 +180,6 @@ class KSMLRunnerHelpersTest {
 
         assertThat(split.producers()).isEmpty();
         assertThat(split.pipelines()).isEmpty();
-    }
-
-    // ---- setupErrorHandling --------------------------------------------------------------------
-
-    private static ErrorHandler reflectHandler(String fieldName) throws Exception {
-        final Field field = ExecutionContext.INSTANCE.errorHandling().getClass().getDeclaredField(fieldName);
-        field.setAccessible(true);
-        return (ErrorHandler) field.get(ExecutionContext.INSTANCE.errorHandling());
     }
 
     // ---- validateDefinitions -------------------------------------------------------------------
@@ -292,7 +288,7 @@ class KSMLRunnerHelpersTest {
     @DisplayName("stopRunnersQuietly tolerates a null runner and a failing stop")
     void stopRunnersQuietlyToleratesNullAndExceptions() {
         final var failing = mock(Runner.class);
-        org.mockito.Mockito.doThrow(new RuntimeException("stop failed")).when(failing).stop();
+        doThrow(new RuntimeException("stop failed")).when(failing).stop();
 
         // Null streams must not NPE, and an exception from stop() must be swallowed.
         assertThatCode(() -> KSMLRunner.stopRunnersQuietly(failing, null)).doesNotThrowAnyException();
@@ -351,7 +347,7 @@ class KSMLRunnerHelpersTest {
         final var runner = KSMLRunner.createProducerRunner(definitions, runnerConfig(), new KSMLConfig());
 
         assertThat(runner).isNotNull();
-        assertThat(runner.getState()).isEqualTo(io.axual.ksml.runner.backend.Runner.State.CREATED);
+        assertThat(runner.getState()).isEqualTo(Runner.State.CREATED);
     }
 
     @Test
@@ -364,10 +360,16 @@ class KSMLRunnerHelpersTest {
     @DisplayName("createRestServer returns null when the application server is disabled")
     void createRestServerNullWhenDisabled() {
         // A default ApplicationServerConfig is disabled, so no server is started.
-        assertThat(KSMLRunner.createRestServer(new io.axual.ksml.runner.config.ApplicationServerConfig())).isNull();
+        assertThat(KSMLRunner.createRestServer(new ApplicationServerConfig())).isNull();
     }
 
     // ---- setupErrorHandling --------------------------------------------------------------------
+
+    private static ErrorHandler reflectHandler(String fieldName) throws Exception {
+        final Field field = ExecutionContext.INSTANCE.errorHandling().getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return (ErrorHandler) field.get(ExecutionContext.INSTANCE.errorHandling());
+    }
 
     @Test
     @DisplayName("A null error-handling config leaves the handlers untouched")

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/KSMLRunnerHelpersTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/KSMLRunnerHelpersTest.java
@@ -1,0 +1,388 @@
+package io.axual.ksml.runner;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Runner
+ * %%
+ * Copyright (C) 2021 - 2024 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.axual.ksml.client.serde.ResolvingDeserializer;
+import io.axual.ksml.client.serde.ResolvingSerializer;
+import io.axual.ksml.data.notation.binary.BinaryNotation;
+import io.axual.ksml.data.notation.json.JsonNotation;
+import io.axual.ksml.execution.ErrorHandler;
+import io.axual.ksml.execution.ExecutionContext;
+import io.axual.ksml.generator.TopologyDefinition;
+import io.axual.ksml.generator.YAMLObjectMapper;
+import io.axual.ksml.runner.backend.Runner;
+import io.axual.ksml.runner.config.ErrorHandlingConfig;
+import io.axual.ksml.runner.config.KSMLConfig;
+import io.axual.ksml.runner.config.KSMLRunnerConfig;
+import io.axual.ksml.runner.config.NotationConfig;
+import io.axual.ksml.runner.config.NotationConfig.NotationType;
+import io.axual.ksml.runner.config.SchemaRegistryConfig;
+import io.axual.ksml.runner.config.internal.StringMap;
+import io.axual.ksml.runner.exception.ConfigException;
+import org.apache.kafka.common.serialization.Serdes;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the pure helpers extracted from {@link KSMLRunner#main(String[])}: notation config
+ * merging, definition splitting and error-handler wiring. These cover the branch-heavy logic that
+ * used to be buried inside {@code main}.
+ */
+class KSMLRunnerHelpersTest {
+
+    // ---- mergeNotationConfigs ------------------------------------------------------------------
+
+    private static StringMap stringMap(String key, String value) {
+        final var map = new StringMap();
+        map.put(key, value);
+        return map;
+    }
+
+    @Test
+    @DisplayName("Without a schema registry or config the merged notation config is empty")
+    void mergeWithoutRegistryOrConfig() {
+        final var notationConfig = NotationConfig.builder().type(NotationType.JSON).build();
+
+        assertThat(KSMLRunner.mergeNotationConfigs(notationConfig, Map.of())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("A referenced schema registry's config is included in the merged notation config")
+    void mergeIncludesSchemaRegistryConfig() {
+        final var srConfig = SchemaRegistryConfig.builder().config(stringMap("schema.registry.url", "http://sr:8081")).build();
+        final var notationConfig = NotationConfig.builder().type(NotationType.CONFLUENT_AVRO).schemaRegistry("primary").build();
+
+        final var merged = KSMLRunner.mergeNotationConfigs(notationConfig, Map.of("primary", srConfig));
+
+        assertThat(merged).containsEntry("schema.registry.url", "http://sr:8081");
+    }
+
+    @Test
+    @DisplayName("A missing schema registry reference is ignored and yields no config")
+    void mergeIgnoresUnknownSchemaRegistry() {
+        final var notationConfig = NotationConfig.builder().type(NotationType.CONFLUENT_AVRO).schemaRegistry("does-not-exist").build();
+
+        // schemaRegistries map does not contain the referenced name -> warn branch, empty result.
+        assertThat(KSMLRunner.mergeNotationConfigs(notationConfig, Map.of())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("A schema registry entry without config contributes nothing")
+    void mergeHandlesRegistryWithoutConfig() {
+        final var srConfig = SchemaRegistryConfig.builder().config(null).build();
+        final var notationConfig = NotationConfig.builder().type(NotationType.CONFLUENT_AVRO).schemaRegistry("primary").build();
+
+        assertThat(KSMLRunner.mergeNotationConfigs(notationConfig, Map.of("primary", srConfig))).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Notation-level config is merged on top of the schema registry config")
+    void mergeNotationConfigOverridesRegistryConfig() {
+        final var srConfig = SchemaRegistryConfig.builder()
+                .config(stringMap("shared.key", "from-registry"))
+                .build();
+        final var notationConfig = NotationConfig.builder()
+                .type(NotationType.CONFLUENT_AVRO)
+                .schemaRegistry("primary")
+                .config(stringMap("shared.key", "from-notation"))
+                .build();
+
+        final var merged = KSMLRunner.mergeNotationConfigs(notationConfig, Map.of("primary", srConfig));
+
+        // The notation's own config is applied last, so it wins on key collisions.
+        assertThat(merged).containsEntry("shared.key", "from-notation");
+    }
+
+    // ---- splitDefinitions ----------------------------------------------------------------------
+
+    private static TopologyDefinition definitionWith(boolean hasProducers, boolean hasPipelines) {
+        final var def = mock(TopologyDefinition.class);
+        when(def.producers()).thenReturn(hasProducers ? Map.of("p", mock(io.axual.ksml.definition.ProducerDefinition.class)) : Map.of());
+        when(def.pipelines()).thenReturn(hasPipelines ? Map.of("l", mock(io.axual.ksml.definition.PipelineDefinition.class)) : Map.of());
+        return def;
+    }
+
+    @Test
+    @DisplayName("A definition is routed to producers and/or pipelines based on its content")
+    void splitRoutesDefinitionsByContent() {
+        final var producerOnly = definitionWith(true, false);
+        final var pipelineOnly = definitionWith(false, true);
+        final var both = definitionWith(true, true);
+
+        final var split = KSMLRunner.splitDefinitions(
+                Map.of("producerOnly", producerOnly, "pipelineOnly", pipelineOnly, "both", both),
+                true, true);
+
+        assertThat(split.producers()).containsOnlyKeys("producerOnly", "both");
+        assertThat(split.pipelines()).containsOnlyKeys("pipelineOnly", "both");
+    }
+
+    @Test
+    @DisplayName("Disabling producers drops producer definitions but keeps pipelines")
+    void splitHonoursDisabledProducers() {
+        final var both = definitionWith(true, true);
+
+        final var split = KSMLRunner.splitDefinitions(Map.of("both", both), false, true);
+
+        assertThat(split.producers()).isEmpty();
+        assertThat(split.pipelines()).containsOnlyKeys("both");
+    }
+
+    @Test
+    @DisplayName("Disabling pipelines drops pipeline definitions but keeps producers")
+    void splitHonoursDisabledPipelines() {
+        final var both = definitionWith(true, true);
+
+        final var split = KSMLRunner.splitDefinitions(Map.of("both", both), true, false);
+
+        assertThat(split.producers()).containsOnlyKeys("both");
+        assertThat(split.pipelines()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Splitting an empty definition set yields two empty maps")
+    void splitEmptyDefinitions() {
+        final var split = KSMLRunner.splitDefinitions(Map.of(), true, true);
+
+        assertThat(split.producers()).isEmpty();
+        assertThat(split.pipelines()).isEmpty();
+    }
+
+    // ---- setupErrorHandling --------------------------------------------------------------------
+
+    private static ErrorHandler reflectHandler(String fieldName) throws Exception {
+        final Field field = ExecutionContext.INSTANCE.errorHandling().getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return (ErrorHandler) field.get(ExecutionContext.INSTANCE.errorHandling());
+    }
+
+    // ---- validateDefinitions -------------------------------------------------------------------
+
+    @Test
+    @DisplayName("validateDefinitions rejects a null or empty definition set")
+    void validateDefinitionsRejectsEmpty() {
+        assertThatThrownBy(() -> KSMLRunner.validateDefinitions(null)).isInstanceOf(ConfigException.class);
+        assertThatThrownBy(() -> KSMLRunner.validateDefinitions(Map.of())).isInstanceOf(ConfigException.class);
+    }
+
+    @Test
+    @DisplayName("validateDefinitions accepts a non-empty definition set")
+    void validateDefinitionsAcceptsNonEmpty() {
+        assertThatCode(() -> KSMLRunner.validateDefinitions(Map.of("ns", new Object()))).doesNotThrowAnyException();
+    }
+
+    // ---- registerNotations ---------------------------------------------------------------------
+
+    @Test
+    @DisplayName("registerNotations registers the built-in notations and the AVRO fallback when none are configured")
+    void registerNotationsRegistersDefaultsAndAvroFallback() {
+        final var ksmlConfig = new KSMLConfig(); // no notation overrides configured
+
+        KSMLRunner.registerNotations(ksmlConfig, Map.of());
+
+        final var library = ExecutionContext.INSTANCE.notationLibrary();
+        assertThat(library.getIfExists(JsonNotation.NOTATION_NAME)).as("json default").isNotNull();
+        assertThat(library.getIfExists(BinaryNotation.NOTATION_NAME)).as("binary default").isNotNull();
+        // With no notations configured, the Confluent AVRO fallback is registered.
+        assertThat(library.getIfExists("avro")).as("avro fallback").isNotNull();
+    }
+
+    @Test
+    @DisplayName("registerNotations registers a configured notation override under its name")
+    void registerNotationsRegistersConfiguredOverride() {
+        final var notations = new KSMLConfig.NotationMap();
+        notations.add("myJson", NotationConfig.builder().type(NotationType.JSON).build());
+        final var ksmlConfig = new KSMLConfig();
+        ksmlConfig.notations(notations);
+
+        KSMLRunner.registerNotations(ksmlConfig, Map.of());
+
+        assertThat(ExecutionContext.INSTANCE.notationLibrary().getIfExists("myJson")).isNotNull();
+    }
+
+    @Test
+    @DisplayName("registerNotations skips a notation override whose type is missing")
+    void registerNotationsSkipsOverrideWithoutType() {
+        final var notations = new KSMLConfig.NotationMap();
+        notations.add("incomplete", NotationConfig.builder().type(null).build()); // no type -> incomplete
+        final var ksmlConfig = new KSMLConfig();
+        ksmlConfig.notations(notations);
+
+        // The incomplete entry is logged and skipped; no exception, and it is not registered.
+        assertThatCode(() -> KSMLRunner.registerNotations(ksmlConfig, Map.of())).doesNotThrowAnyException();
+        assertThat(ExecutionContext.INSTANCE.notationLibrary().getIfExists("incomplete")).isNull();
+    }
+
+    // ---- wrapSerde -----------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("wrapSerde wraps a serde in resolving (de)serializers")
+    void wrapSerdeWrapsInResolvingSerdes() {
+        final var wrapped = KSMLRunner.wrapSerde(Serdes.String(), Map.of("bootstrap.servers", "localhost:9092"));
+
+        assertThat(wrapped.serializer()).isInstanceOf(ResolvingSerializer.class);
+        assertThat(wrapped.deserializer()).isInstanceOf(ResolvingDeserializer.class);
+    }
+
+    // ---- parseDefinitions ----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("parseDefinitions parses each raw definition into a TopologyDefinition")
+    void parseDefinitionsParsesEachNamespace() throws Exception {
+        final JsonNode definition = YAMLObjectMapper.INSTANCE.readValue(
+                """
+                streams:
+                  some_stream:
+                    topic: some_topic
+                    keyType: string
+                    valueType: string
+                """, JsonNode.class);
+
+        final var parsed = KSMLRunner.parseDefinitions(Map.of("ns", definition));
+
+        assertThat(parsed).containsKey("ns");
+        assertThat(parsed.get("ns")).isNotNull();
+    }
+
+    // ---- stopRunnersQuietly --------------------------------------------------------------------
+
+    @Test
+    @DisplayName("stopRunnersQuietly stops both runners when present")
+    void stopRunnersQuietlyStopsBoth() {
+        final var producer = mock(Runner.class);
+        final var streams = mock(Runner.class);
+
+        KSMLRunner.stopRunnersQuietly(producer, streams);
+
+        verify(producer).stop();
+        verify(streams).stop();
+    }
+
+    @Test
+    @DisplayName("stopRunnersQuietly tolerates a null runner and a failing stop")
+    void stopRunnersQuietlyToleratesNullAndExceptions() {
+        final var failing = mock(Runner.class);
+        org.mockito.Mockito.doThrow(new RuntimeException("stop failed")).when(failing).stop();
+
+        // Null streams must not NPE, and an exception from stop() must be swallowed.
+        assertThatCode(() -> KSMLRunner.stopRunnersQuietly(failing, null)).doesNotThrowAnyException();
+        verify(failing).stop();
+    }
+
+    // ---- stopOtherOnFailure --------------------------------------------------------------------
+
+    @Test
+    @DisplayName("stopOtherOnFailure stops the other runner when a failure occurred")
+    void stopOtherOnFailureStopsOther() {
+        final var other = mock(Runner.class);
+
+        KSMLRunner.stopOtherOnFailure(new RuntimeException("boom"), "Producer failed", other);
+
+        verify(other).stop();
+    }
+
+    @Test
+    @DisplayName("stopOtherOnFailure does nothing on success")
+    void stopOtherOnFailureNoopOnSuccess() {
+        final var other = mock(Runner.class);
+
+        KSMLRunner.stopOtherOnFailure(null, "Producer failed", other);
+
+        verify(other, never()).stop();
+    }
+
+    @Test
+    @DisplayName("stopOtherOnFailure tolerates a null other runner on failure")
+    void stopOtherOnFailureToleratesNullOther() {
+        assertThatCode(() -> KSMLRunner.stopOtherOnFailure(new RuntimeException("boom"), "Producer failed", null))
+                .doesNotThrowAnyException();
+    }
+
+    // ---- runner / rest-server factories --------------------------------------------------------
+
+    private static KSMLRunnerConfig runnerConfig() {
+        final var config = new KSMLRunnerConfig();
+        config.setKafkaConfig(new KSMLRunnerConfig.KafkaConfig());
+        config.setKsmlConfig(new KSMLConfig());
+        return config;
+    }
+
+    @Test
+    @DisplayName("createProducerRunner returns null when there are no producer definitions")
+    void createProducerRunnerNullWhenEmpty() {
+        assertThat(KSMLRunner.createProducerRunner(Map.of(), runnerConfig(), new KSMLConfig())).isNull();
+    }
+
+    @Test
+    @DisplayName("createProducerRunner builds a runner when producer definitions are present")
+    void createProducerRunnerBuildsRunner() {
+        final var definitions = Map.of("ns", mock(TopologyDefinition.class));
+
+        final var runner = KSMLRunner.createProducerRunner(definitions, runnerConfig(), new KSMLConfig());
+
+        assertThat(runner).isNotNull();
+        assertThat(runner.getState()).isEqualTo(io.axual.ksml.runner.backend.Runner.State.CREATED);
+    }
+
+    @Test
+    @DisplayName("createStreamsRunner returns null when there are no pipeline definitions")
+    void createStreamsRunnerNullWhenEmpty() {
+        assertThat(KSMLRunner.createStreamsRunner(Map.of(), runnerConfig(), new KSMLConfig())).isNull();
+    }
+
+    @Test
+    @DisplayName("createRestServer returns null when the application server is disabled")
+    void createRestServerNullWhenDisabled() {
+        // A default ApplicationServerConfig is disabled, so no server is started.
+        assertThat(KSMLRunner.createRestServer(new io.axual.ksml.runner.config.ApplicationServerConfig())).isNull();
+    }
+
+    // ---- setupErrorHandling --------------------------------------------------------------------
+
+    @Test
+    @DisplayName("A null error-handling config leaves the handlers untouched")
+    void setupErrorHandlingToleratesNull() {
+        assertThatCode(() -> KSMLRunner.setupErrorHandling(null)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("Error handling wires consume, produce and process handlers with their default loggers")
+    void setupErrorHandlingWiresAllChannels() throws Exception {
+        KSMLRunner.setupErrorHandling(new ErrorHandlingConfig());
+
+        // All three channels are wired from the config, each with its documented default logger name.
+        assertThat(reflectHandler("consumeHandler").loggerName()).isEqualTo("ConsumeError");
+        assertThat(reflectHandler("produceHandler").loggerName()).isEqualTo("ProduceError");
+        assertThat(reflectHandler("processHandler").loggerName()).isEqualTo("ProcessError");
+    }
+}

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/KSMLRunnerQuerierTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/KSMLRunnerQuerierTest.java
@@ -95,6 +95,29 @@ class KSMLRunnerQuerierTest {
     }
 
     @Test
+    @DisplayName("Key metadata and store queries are delegated to the underlying Kafka Streams instance")
+    void delegatesKeyMetadataAndStoreQueries() {
+        final var kafkaStreams = mock(KafkaStreams.class);
+        final var streamsRunner = mock(KafkaStreamsRunner.class);
+        when(streamsRunner.kafkaStreams()).thenReturn(kafkaStreams);
+
+        final var keyMetadata = mock(org.apache.kafka.streams.KeyQueryMetadata.class);
+        final var serializer = new org.apache.kafka.common.serialization.StringSerializer();
+        when(kafkaStreams.queryMetadataForKey("store", "key", serializer)).thenReturn(keyMetadata);
+
+        final var querier = KSMLRunner.getQuerier(streamsRunner, null);
+
+        assertThat(querier.queryMetadataForKey("store", "key", serializer)).isSameAs(keyMetadata);
+
+        // store() simply forwards the StoreQueryParameters to Kafka Streams.
+        final var params = org.apache.kafka.streams.StoreQueryParameters
+                .fromNameAndType("store", org.apache.kafka.streams.state.QueryableStoreTypes.<String, String>keyValueStore());
+        final org.apache.kafka.streams.state.ReadOnlyKeyValueStore<String, String> store = mock(org.apache.kafka.streams.state.ReadOnlyKeyValueStore.class);
+        when(kafkaStreams.store(params)).thenReturn(store);
+        assertThat(querier.store(params)).isSameAs(store);
+    }
+
+    @Test
     @DisplayName("populate() applies the default config file path when no arguments are supplied")
     void populateDefaultsConfigFile() {
         final var args = KSMLRunner.Arguments.populate(new String[]{});

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/KSMLRunnerQuerierTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/KSMLRunnerQuerierTest.java
@@ -4,7 +4,7 @@ package io.axual.ksml.runner;
  * ========================LICENSE_START=================================
  * KSML Runner
  * %%
- * Copyright (C) 2021 - 2024 Axual B.V.
+ * Copyright (C) 2021 - 2026 Axual B.V.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/KSMLRunnerQuerierTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/KSMLRunnerQuerierTest.java
@@ -1,0 +1,143 @@
+package io.axual.ksml.runner;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Runner
+ * %%
+ * Copyright (C) 2021 - 2024 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import io.axual.ksml.rest.server.ComponentState;
+import io.axual.ksml.runner.backend.KafkaProducerRunner;
+import io.axual.ksml.runner.backend.KafkaStreamsRunner;
+import io.axual.ksml.runner.backend.Runner;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsMetadata;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.io.File;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for the static helpers in {@link KSMLRunner} that can be exercised without bootstrapping a
+ * full Kafka/streams runtime: the read-only querier and the command-line argument parsing.
+ */
+class KSMLRunnerQuerierTest {
+
+    @Test
+    @DisplayName("The querier reports NOT_APPLICABLE and empty results when no runners are present")
+    void querierWithoutRunnersIsInert() {
+        // Both runners are null, mirroring a runner started with neither pipelines nor producers.
+        final var querier = KSMLRunner.getQuerier(null, null);
+
+        assertThat(querier.getStreamRunnerState()).isEqualTo(ComponentState.NOT_APPLICABLE);
+        assertThat(querier.getProducerState()).isEqualTo(ComponentState.NOT_APPLICABLE);
+        assertThat(querier.allMetadataForStore("any-store")).isEmpty();
+        assertThat(querier.queryMetadataForKey("any-store", "key", null)).isNull();
+        assertThat(querier.<Object>store(null)).isNull();
+    }
+
+    @ParameterizedTest(name = "runner state {0} -> component state {1}")
+    @DisplayName("Each runner state is translated to the matching component state")
+    @CsvSource({
+            "CREATED,  CREATED",
+            "STARTING, STARTING",
+            "STARTED,  STARTED",
+            "STOPPING, STOPPING",
+            "STOPPED,  STOPPED",
+            "FAILED,   FAILED"
+    })
+    void translatesRunnerStateToComponentState(Runner.State runnerState, ComponentState expected) {
+        final var streamsRunner = mock(KafkaStreamsRunner.class);
+        when(streamsRunner.getState()).thenReturn(runnerState);
+        final var producerRunner = mock(KafkaProducerRunner.class);
+        when(producerRunner.getState()).thenReturn(runnerState);
+
+        final var querier = KSMLRunner.getQuerier(streamsRunner, producerRunner);
+
+        assertThat(querier.getStreamRunnerState()).isEqualTo(expected);
+        assertThat(querier.getProducerState()).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("Store queries are delegated to the underlying Kafka Streams instance")
+    void delegatesStoreQueriesToKafkaStreams() {
+        final var kafkaStreams = mock(KafkaStreams.class);
+        final var streamsRunner = mock(KafkaStreamsRunner.class);
+        when(streamsRunner.kafkaStreams()).thenReturn(kafkaStreams);
+
+        final var metadata = List.of(mock(StreamsMetadata.class));
+        when(kafkaStreams.streamsMetadataForStore("store")).thenReturn(metadata);
+
+        final var querier = KSMLRunner.getQuerier(streamsRunner, null);
+
+        assertThat(querier.allMetadataForStore("store")).isEqualTo(metadata);
+    }
+
+    @Test
+    @DisplayName("populate() applies the default config file path when no arguments are supplied")
+    void populateDefaultsConfigFile() {
+        final var args = KSMLRunner.Arguments.populate(new String[]{});
+
+        assertThat(args.configFile()).isEqualTo(new File("ksml-runner.yaml"));
+        assertThat(args.shouldPrintKsmlSchema()).isFalse();
+        assertThat(args.shouldPrintKsmlRunnerSchema()).isFalse();
+    }
+
+    @Test
+    @DisplayName("populate() reads the configuration file path positional argument")
+    void populateReadsConfigFileArgument() {
+        final var args = KSMLRunner.Arguments.populate(new String[]{"/etc/ksml/my-runner.yaml"});
+
+        assertThat(args.configFile()).isEqualTo(new File("/etc/ksml/my-runner.yaml"));
+    }
+
+    @Test
+    @DisplayName("--schema without a value flags schema printing with no target location")
+    void populateSchemaFlagWithoutLocation() {
+        final var args = KSMLRunner.Arguments.populate(new String[]{"--schema"});
+
+        assertThat(args.shouldPrintKsmlSchema()).isTrue();
+        assertThat(args.ksmlSchemaLocation()).isNull();
+    }
+
+    @Test
+    @DisplayName("--schema with a value flags schema printing and captures the target location")
+    void populateSchemaFlagWithLocation() {
+        final var args = KSMLRunner.Arguments.populate(new String[]{"--schema", "/tmp/schema.json"});
+
+        assertThat(args.shouldPrintKsmlSchema()).isTrue();
+        assertThat(args.ksmlSchemaLocation()).isEqualTo("/tmp/schema.json");
+    }
+
+    @Test
+    @DisplayName("--runner-schema with a value flags runner-schema printing and captures the location")
+    void populateRunnerSchemaFlagWithLocation() {
+        final var args = KSMLRunner.Arguments.populate(new String[]{"--runner-schema", "/tmp/runner.json"});
+
+        assertThat(args.shouldPrintKsmlRunnerSchema()).isTrue();
+        assertThat(args.ksmlRunnerSchemaLocation()).isEqualTo("/tmp/runner.json");
+        // The KSML definition schema flag remains untouched.
+        assertThat(args.shouldPrintKsmlSchema()).isFalse();
+    }
+}

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/KSMLRunnerTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/KSMLRunnerTest.java
@@ -4,7 +4,7 @@ package io.axual.ksml.runner;
  * ========================LICENSE_START=================================
  * KSML Runner
  * %%
- * Copyright (C) 2021 - 2024 Axual B.V.
+ * Copyright (C) 2021 - 2026 Axual B.V.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,8 +35,6 @@ import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class KSMLRunnerTest {
 
@@ -48,14 +46,14 @@ class KSMLRunnerTest {
         // main() writes the runner configuration schema and returns (no System.exit) when --runner-schema is set
         KSMLRunner.main(new String[]{"--runner-schema", out.toString()});
 
-        assertTrue(Files.exists(out), "runner schema file should have been written");
+        assertThat(Files.exists(out)).as("runner schema file should have been written").isTrue();
         final var schema = Files.readString(out);
 
         // resolveDefaultValue converts the @JsonProperty defaultValue to the field's type:
-        assertTrue(schema.contains("\"default\" : false"), "boolean defaults should be emitted as JSON booleans");
-        assertTrue(schema.contains("\"default\" : true"), "boolean defaults should be emitted as JSON booleans");
-        assertTrue(schema.contains("\"default\" : 9999"), "integer defaults should be emitted as JSON numbers");
-        assertTrue(schema.contains("\"default\" : \"0.0.0.0\""), "string defaults should be emitted as JSON strings");
+        assertThat(schema.contains("\"default\" : false")).as("boolean defaults should be emitted as JSON booleans").isTrue();
+        assertThat(schema.contains("\"default\" : true")).as("boolean defaults should be emitted as JSON booleans").isTrue();
+        assertThat(schema.contains("\"default\" : 9999")).as("integer defaults should be emitted as JSON numbers").isTrue();
+        assertThat(schema.contains("\"default\" : \"0.0.0.0\"")).as("string defaults should be emitted as JSON strings").isTrue();
     }
 
     @Test
@@ -66,7 +64,7 @@ class KSMLRunnerTest {
         // main() writes the KSML definition schema and returns when --schema is set
         KSMLRunner.main(new String[]{"--schema", out.toString()});
 
-        assertTrue(Files.exists(out), "KSML definition schema file should have been written");
+        assertThat(Files.exists(out)).as("KSML definition schema file should have been written").isTrue();
         // The generated schema is a JSON document describing the KSML definition structure.
         assertThat(Files.readString(out)).contains("$schema");
     }
@@ -78,8 +76,8 @@ class KSMLRunnerTest {
 
         final var config = KSMLRunner.readConfiguration(configFile);
 
-        assertNotNull(config.getKsmlConfig());
-        assertNotNull(config.getKafkaConfigMap());
+        assertThat(config.getKsmlConfig()).isNotNull();
+        assertThat(config.getKafkaConfigMap()).isNotNull();
     }
 
     @Test
@@ -99,8 +97,8 @@ class KSMLRunnerTest {
 
         KSMLRunner.closeExecutorService(executor);
 
-        assertTrue(executor.isShutdown());
-        assertTrue(executor.isTerminated(), "an idle executor terminates within the grace period");
+        assertThat(executor.isShutdown()).isTrue();
+        assertThat(executor.isTerminated()).as("an idle executor terminates within the grace period").isTrue();
     }
 
     @Test
@@ -118,10 +116,10 @@ class KSMLRunnerTest {
                 Thread.currentThread().interrupt();
             }
         });
-        assertTrue(started.await(5, TimeUnit.SECONDS));
+        assertThat(started.await(5, TimeUnit.SECONDS)).isTrue();
 
         KSMLRunner.closeExecutorService(executor);
 
-        assertTrue(executor.isShutdown());
+        assertThat(executor.isShutdown()).isTrue();
     }
 }

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/KSMLRunnerTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/KSMLRunnerTest.java
@@ -20,13 +20,22 @@ package io.axual.ksml.runner;
  * =========================LICENSE_END==================================
  */
 
+import io.axual.ksml.runner.exception.ConfigException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class KSMLRunnerTest {
@@ -47,5 +56,72 @@ class KSMLRunnerTest {
         assertTrue(schema.contains("\"default\" : true"), "boolean defaults should be emitted as JSON booleans");
         assertTrue(schema.contains("\"default\" : 9999"), "integer defaults should be emitted as JSON numbers");
         assertTrue(schema.contains("\"default\" : \"0.0.0.0\""), "string defaults should be emitted as JSON strings");
+    }
+
+    @Test
+    @DisplayName("The KSML definition schema is written to file when --schema is supplied")
+    void ksmlDefinitionSchemaIsWritten(@TempDir Path tempDir) throws Exception {
+        final var out = tempDir.resolve("ksml-spec.json");
+
+        // main() writes the KSML definition schema and returns when --schema is set
+        KSMLRunner.main(new String[]{"--schema", out.toString()});
+
+        assertTrue(Files.exists(out), "KSML definition schema file should have been written");
+        // The generated schema is a JSON document describing the KSML definition structure.
+        assertThat(Files.readString(out)).contains("$schema");
+    }
+
+    @Test
+    @DisplayName("readConfiguration parses a valid runner configuration file")
+    void readConfigurationParsesValidFile() throws Exception {
+        final var configFile = new File(getClass().getClassLoader().getResource("ksml-runner-config.yaml").toURI());
+
+        final var config = KSMLRunner.readConfiguration(configFile);
+
+        assertNotNull(config.getKsmlConfig());
+        assertNotNull(config.getKafkaConfigMap());
+    }
+
+    @Test
+    @DisplayName("readConfiguration throws a ConfigException for an unparseable file")
+    void readConfigurationThrowsForInvalidFile(@TempDir Path tempDir) throws Exception {
+        final var badFilePath = tempDir.resolve("bad-runner.yaml");
+        Files.writeString(badFilePath, "kafka: [unterminated");
+        final var badFile = badFilePath.toFile();
+        assertThatThrownBy(() -> KSMLRunner.readConfiguration(badFile))
+                .isInstanceOf(ConfigException.class);
+    }
+
+    @Test
+    @DisplayName("closeExecutorService shuts an idle executor down gracefully")
+    void closeExecutorServiceShutsDownGracefully() throws Exception {
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+        KSMLRunner.closeExecutorService(executor);
+
+        assertTrue(executor.isShutdown());
+        assertTrue(executor.isTerminated(), "an idle executor terminates within the grace period");
+    }
+
+    @Test
+    @DisplayName("closeExecutorService force-stops an executor that does not terminate in time")
+    @SuppressWarnings("java:S2925")
+    void closeExecutorServiceForcesShutdownOnTimeout() throws Exception {
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        final var started = new CountDownLatch(1);
+        // A task that blocks past the 2s grace period forces the shutdownNow path.
+        executor.submit(() -> {
+            started.countDown();
+            try {
+                Thread.sleep(10_000);
+            } catch (InterruptedException _) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        assertTrue(started.await(5, TimeUnit.SECONDS));
+
+        KSMLRunner.closeExecutorService(executor);
+
+        assertTrue(executor.isShutdown());
     }
 }

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/KSMLRunnerTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/KSMLRunnerTest.java
@@ -46,14 +46,16 @@ class KSMLRunnerTest {
         // main() writes the runner configuration schema and returns (no System.exit) when --runner-schema is set
         KSMLRunner.main(new String[]{"--runner-schema", out.toString()});
 
-        assertThat(Files.exists(out)).as("runner schema file should have been written").isTrue();
+        assertThat(out).as("runner schema file should have been written").exists();
         final var schema = Files.readString(out);
 
-        // resolveDefaultValue converts the @JsonProperty defaultValue to the field's type:
-        assertThat(schema.contains("\"default\" : false")).as("boolean defaults should be emitted as JSON booleans").isTrue();
-        assertThat(schema.contains("\"default\" : true")).as("boolean defaults should be emitted as JSON booleans").isTrue();
-        assertThat(schema.contains("\"default\" : 9999")).as("integer defaults should be emitted as JSON numbers").isTrue();
-        assertThat(schema.contains("\"default\" : \"0.0.0.0\"")).as("string defaults should be emitted as JSON strings").isTrue();
+        // resolveDefaultValue converts the @JsonProperty defaultValue to the field's type, so the
+        // schema must contain each default rendered with its JSON type (boolean, integer, string).
+        assertThat(schema).as("typed defaults should be emitted with their JSON types").contains(
+                "\"default\" : false",
+                "\"default\" : true",
+                "\"default\" : 9999",
+                "\"default\" : \"0.0.0.0\"");
     }
 
     @Test
@@ -64,7 +66,7 @@ class KSMLRunnerTest {
         // main() writes the KSML definition schema and returns when --schema is set
         KSMLRunner.main(new String[]{"--schema", out.toString()});
 
-        assertThat(Files.exists(out)).as("KSML definition schema file should have been written").isTrue();
+        assertThat(out).as("KSML definition schema file should have been written").exists();
         // The generated schema is a JSON document describing the KSML definition structure.
         assertThat(Files.readString(out)).contains("$schema");
     }

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/KsmlInfoTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/KsmlInfoTest.java
@@ -1,0 +1,91 @@
+package io.axual.ksml.runner;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Runner
+ * %%
+ * Copyright (C) 2021 - 2024 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import io.axual.ksml.metric.Metrics;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class KsmlInfoTest {
+
+    /**
+     * Builds the same object name {@link KsmlInfo#registerKsmlAppInfo(String)} uses, so the test can
+     * look the registered MBean up afterwards.
+     */
+    private static ObjectName objectNameFor(String appId) throws Exception {
+        final var name = "%s:type=app-info,app-id=%s,app-name=%s,app-version=%s,build-time=%s".formatted(
+                Metrics.DOMAIN,
+                appId,
+                ObjectName.quote(KsmlInfo.APP_NAME),
+                ObjectName.quote(KsmlInfo.APP_VERSION),
+                ObjectName.quote(KsmlInfo.BUILD_TIME));
+        return ObjectName.getInstance(name);
+    }
+
+    @Test
+    @DisplayName("App info is loaded from the ksml-info.properties on the classpath")
+    void loadsAppInfoFromProperties() {
+        // Values come from src/test/resources/ksml/ksml-info.properties
+        assertThat(KsmlInfo.APP_NAME).isEqualTo("ksml-for-testing");
+        assertThat(KsmlInfo.APP_VERSION).isEqualTo("testing");
+        assertThat(KsmlInfo.BUILD_TIME).isEqualTo("2024-01-01T01:00:00Z");
+    }
+
+    @Test
+    @DisplayName("registerKsmlAppInfo registers the app-info MBean and is idempotent on repeated calls")
+    void registersAppInfoMBeanIdempotently() throws Exception {
+        final var appId = "ksmlinfo-test-" + System.nanoTime();
+        final var objectName = objectNameFor(appId);
+        final var beanServer = ManagementFactory.getPlatformMBeanServer();
+
+        // KsmlInfo.BEAN_CONTENT is a shared static instance, so this test registers a single
+        // object name and unregisters it afterwards to keep the platform MBean server clean.
+        try {
+            assertThat(beanServer.isRegistered(objectName)).isFalse();
+
+            KsmlInfo.registerKsmlAppInfo(appId);
+
+            assertThat(beanServer.isRegistered(objectName)).isTrue();
+            assertThat(beanServer.getAttribute(objectName, "Value")).isEqualTo(1);
+
+            // A second call for the same app-id hits the "already registered" branch and must not throw.
+            assertThatCode(() -> KsmlInfo.registerKsmlAppInfo(appId)).doesNotThrowAnyException();
+            assertThat(beanServer.isRegistered(objectName)).isTrue();
+        } finally {
+            if (beanServer.isRegistered(objectName)) {
+                beanServer.unregisterMBean(objectName);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("The KsmlInfoMBean always reports a value of 1")
+    void mBeanReportsConstantValue() {
+        assertThat(KsmlInfo.BEAN_CONTENT.getValue()).isEqualTo(1);
+        assertThat(new KsmlInfo.KsmlInfoMBean().getValue()).isEqualTo(1);
+    }
+}

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/KsmlInfoTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/KsmlInfoTest.java
@@ -4,7 +4,7 @@ package io.axual.ksml.runner;
  * ========================LICENSE_START=================================
  * KSML Runner
  * %%
- * Copyright (C) 2021 - 2024 Axual B.V.
+ * Copyright (C) 2021 - 2026 Axual B.V.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,15 +47,6 @@ class KsmlInfoTest {
     }
 
     @Test
-    @DisplayName("App info is loaded from the ksml-info.properties on the classpath")
-    void loadsAppInfoFromProperties() {
-        // Values come from src/test/resources/ksml/ksml-info.properties
-        assertThat(KsmlInfo.APP_NAME).isEqualTo("ksml-for-testing");
-        assertThat(KsmlInfo.APP_VERSION).isEqualTo("testing");
-        assertThat(KsmlInfo.BUILD_TIME).isEqualTo("2024-01-01T01:00:00Z");
-    }
-
-    @Test
     @DisplayName("registerKsmlAppInfo registers the app-info MBean and is idempotent on repeated calls")
     void registersAppInfoMBeanIdempotently() throws Exception {
         final var appId = "ksmlinfo-test-" + System.nanoTime();
@@ -80,12 +71,5 @@ class KsmlInfoTest {
                 beanServer.unregisterMBean(objectName);
             }
         }
-    }
-
-    @Test
-    @DisplayName("The KsmlInfoMBean always reports a value of 1")
-    void mBeanReportsConstantValue() {
-        assertThat(KsmlInfo.BEAN_CONTENT.getValue()).isEqualTo(1);
-        assertThat(new KsmlInfo.KsmlInfoMBean().getValue()).isEqualTo(1);
     }
 }

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/backend/KafkaProducerRunnerLifecycleTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/backend/KafkaProducerRunnerLifecycleTest.java
@@ -4,7 +4,7 @@ package io.axual.ksml.runner.backend;
  * ========================LICENSE_START=================================
  * KSML Runner
  * %%
- * Copyright (C) 2021 - 2024 Axual B.V.
+ * Copyright (C) 2021 - 2026 Axual B.V.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/backend/KafkaProducerRunnerLifecycleTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/backend/KafkaProducerRunnerLifecycleTest.java
@@ -1,0 +1,106 @@
+package io.axual.ksml.runner.backend;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Runner
+ * %%
+ * Copyright (C) 2021 - 2024 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import io.axual.ksml.python.PythonContextConfig;
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Lifecycle tests for {@link KafkaProducerRunner} that do not require a Python/GraalVM runtime: with no
+ * producer definitions the runner exercises its full state machine and producer configuration without
+ * ever needing to build an {@code ExecutableProducer}. The message-producing paths (which do need
+ * GraalVM) are covered by {@code KafkaProducerRunnerTest}.
+ */
+class KafkaProducerRunnerLifecycleTest {
+
+    /** Captures the configuration the runner passes to the producer factory. */
+    private static class CapturingProducerFactory implements Function<Map<String, Object>, Producer<byte[], byte[]>> {
+        final List<Map<String, Object>> captured = new ArrayList<>();
+
+        @Override
+        public Producer<byte[], byte[]> apply(Map<String, Object> producerConfig) {
+            captured.add(producerConfig);
+            return new MockProducer<>(true, null, new ByteArraySerializer(), new ByteArraySerializer());
+        }
+    }
+
+    private static KafkaProducerRunner.Config configWith(Map<String, String> kafkaConfig) {
+        return KafkaProducerRunner.Config.builder()
+                .definitions(Map.of()) // no producers -> no Python needed
+                .kafkaConfig(kafkaConfig)
+                .pythonContextConfig(PythonContextConfig.builder().build())
+                .build();
+    }
+
+    @Test
+    @DisplayName("A runner with no producer definitions starts and stops cleanly")
+    void runsToCompletionWithoutProducers() {
+        final var runner = new KafkaProducerRunner(configWith(Map.of("client.id", "test")), new CapturingProducerFactory());
+
+        assertThat(runner.getState()).isEqualTo(Runner.State.CREATED);
+
+        runner.run();
+
+        // Nothing is scheduled, so the runner walks STARTING -> STARTED -> STOPPED and returns.
+        assertThat(runner.getState()).isEqualTo(Runner.State.STOPPED);
+    }
+
+    @Test
+    @DisplayName("The runner injects the byte-array serializers into the producer configuration")
+    void injectsByteArraySerializers() {
+        final var factory = new CapturingProducerFactory();
+        final var runner = new KafkaProducerRunner(configWith(Map.of("bootstrap.servers", "localhost:9092")), factory);
+
+        runner.run();
+
+        assertThat(factory.captured).hasSize(1);
+        final var producerConfig = factory.captured.get(0);
+        assertThat(producerConfig)
+                .containsEntry(KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class)
+                .containsEntry(VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class)
+                // the user-supplied kafka configuration is preserved
+                .containsEntry("bootstrap.servers", "localhost:9092");
+    }
+
+    @Test
+    @DisplayName("stop() requested before running short-circuits the produce loop")
+    void stopBeforeRunStillCompletes() {
+        final var runner = new KafkaProducerRunner(configWith(Map.of()), new CapturingProducerFactory());
+
+        runner.stop();
+        runner.run();
+
+        assertThat(runner.getState()).isEqualTo(Runner.State.STOPPED);
+    }
+}

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/backend/KafkaProducerRunnerLifecycleTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/backend/KafkaProducerRunnerLifecycleTest.java
@@ -21,20 +21,30 @@ package io.axual.ksml.runner.backend;
  */
 
 import io.axual.ksml.python.PythonContextConfig;
+import io.axual.ksml.runner.producer.ExecutableProducer;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+import io.axual.ksml.runner.exception.RunnerException;
+
 import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Lifecycle tests for {@link KafkaProducerRunner} that do not require a Python/GraalVM runtime: with no
@@ -102,5 +112,73 @@ class KafkaProducerRunnerLifecycleTest {
         runner.run();
 
         assertThat(runner.getState()).isEqualTo(Runner.State.STOPPED);
+    }
+
+    @Test
+    @DisplayName("A failing producer factory moves the runner to FAILED and reports a RunnerException")
+    void failingProducerFactoryFailsTheRunner() {
+        final Function<Map<String, Object>, Producer<byte[], byte[]>> failingFactory = config -> {
+            throw new IllegalStateException("cannot create producer");
+        };
+        final var runner = new KafkaProducerRunner(configWith(Map.of()), failingFactory);
+
+        assertThatThrownBy(runner::run)
+                .isInstanceOf(RunnerException.class)
+                .hasMessageContaining("Unhandled producer exception")
+                .hasCauseInstanceOf(IllegalStateException.class);
+
+        assertThat(runner.getState()).isEqualTo(Runner.State.FAILED);
+    }
+
+    @Test
+    @DisplayName("The public constructor wires the default resolving producer and runs with no producers")
+    void publicConstructorUsesDefaultProducerFactory() {
+        // Exercises the production constructor (default ResolvingProducer factory). With no producer
+        // definitions the real producer is created from the config but nothing is ever scheduled.
+        final var config = KafkaProducerRunner.Config.builder()
+                .definitions(Map.of())
+                .kafkaConfig(Map.of("bootstrap.servers", "localhost:9092"))
+                .pythonContextConfig(PythonContextConfig.builder().build())
+                .build();
+        final var runner = new KafkaProducerRunner(config);
+
+        runner.run();
+
+        assertThat(runner.getState()).isEqualTo(Runner.State.STOPPED);
+    }
+
+    @Test
+    @DisplayName("runScheduledProducers produces, reschedules while requested, and stops when nothing is due")
+    void runScheduledProducersReschedulesUntilDone() {
+        final var runner = new KafkaProducerRunner(configWith(Map.of()), new CapturingProducerFactory());
+        final var mockProducer = new MockProducer<>(true, null, new ByteArraySerializer(), new ByteArraySerializer());
+
+        // A stubbed producer that asks to be rescheduled once, then stops.
+        final var executableProducer = mock(ExecutableProducer.class);
+        when(executableProducer.shouldReschedule()).thenReturn(true, false);
+        when(executableProducer.interval()).thenReturn(Duration.ZERO);
+        runner.scheduler.schedule(executableProducer);
+
+        runner.runScheduledProducers(mockProducer);
+
+        // Produced on the initial run and once more after the single reschedule.
+        verify(executableProducer, times(2)).produceMessages(mockProducer);
+        assertThat(runner.scheduler.hasScheduledItems()).isFalse();
+    }
+
+    @Test
+    @DisplayName("runScheduledProducers does not reschedule a producer that is finished")
+    void runScheduledProducersStopsWhenNotRescheduling() {
+        final var runner = new KafkaProducerRunner(configWith(Map.of()), new CapturingProducerFactory());
+        final var mockProducer = new MockProducer<>(true, null, new ByteArraySerializer(), new ByteArraySerializer());
+
+        final var executableProducer = mock(ExecutableProducer.class);
+        when(executableProducer.shouldReschedule()).thenReturn(false);
+        runner.scheduler.schedule(executableProducer);
+
+        runner.runScheduledProducers(mockProducer);
+
+        verify(executableProducer, times(1)).produceMessages(mockProducer);
+        assertThat(runner.scheduler.hasScheduledItems()).isFalse();
     }
 }

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/config/ApplicationServerConfigTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/config/ApplicationServerConfigTest.java
@@ -4,7 +4,7 @@ package io.axual.ksml.runner.config;
  * ========================LICENSE_START=================================
  * KSML Runner
  * %%
- * Copyright (C) 2021 - 2024 Axual B.V.
+ * Copyright (C) 2021 - 2026 Axual B.V.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/config/ApplicationServerConfigTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/config/ApplicationServerConfigTest.java
@@ -1,0 +1,77 @@
+package io.axual.ksml.runner.config;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Runner
+ * %%
+ * Copyright (C) 2021 - 2024 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link ApplicationServerConfig}, mirroring the "hidden when disabled" semantics of the
+ * Prometheus config: host, port and the combined application-server string are only exposed when enabled.
+ */
+class ApplicationServerConfigTest {
+
+    @Test
+    @DisplayName("When disabled, host, port and application server are hidden (null)")
+    void disabledHidesEverything() {
+        final var config = new ApplicationServerConfig(); // enabled defaults to false
+
+        assertThat(config.getHost()).isNull();
+        assertThat(config.getPort()).isNull();
+        assertThat(config.getApplicationServer()).isNull();
+    }
+
+    @Test
+    @DisplayName("When enabled, the default host and port are exposed")
+    void enabledExposesDefaults() {
+        final var config = new ApplicationServerConfig();
+        config.enabled(true);
+
+        assertThat(config.getHost()).isEqualTo("0.0.0.0");
+        assertThat(config.getPort()).isEqualTo(8080);
+        assertThat(config.getApplicationServer()).isEqualTo("0.0.0.0:8080");
+    }
+
+    @Test
+    @DisplayName("When enabled, explicit host and port are used")
+    void enabledUsesExplicitHostAndPort() {
+        final var config = new ApplicationServerConfig();
+        config.enabled(true);
+        config.host("127.0.0.1");
+        config.port(8888);
+
+        assertThat(config.getApplicationServer()).isEqualTo("127.0.0.1:8888");
+    }
+
+    @Test
+    @DisplayName("When enabled with null host/port, the defaults are substituted")
+    void enabledFallsBackToDefaultsForNullValues() {
+        final var config = new ApplicationServerConfig();
+        config.enabled(true);
+        config.host(null);
+        config.port(null);
+
+        assertThat(config.getHost()).isEqualTo("0.0.0.0");
+        assertThat(config.getPort()).isEqualTo(8080);
+    }
+}

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/config/ErrorHandlingConfigTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/config/ErrorHandlingConfigTest.java
@@ -1,0 +1,112 @@
+package io.axual.ksml.runner.config;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Runner
+ * %%
+ * Copyright (C) 2021 - 2024 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import io.axual.ksml.runner.config.ErrorHandlingConfig.ErrorTypeHandlingConfig;
+import io.axual.ksml.runner.config.ErrorHandlingConfig.ErrorTypeHandlingConfig.Handler;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ErrorHandlingConfigTest {
+
+    @Test
+    @DisplayName("Each accessor lazily creates a default config with its own logger name")
+    void accessorsCreateDefaultsWithChannelLoggerNames() {
+        final var config = new ErrorHandlingConfig(); // consume/produce/process all null
+
+        final var consume = config.consumerErrorHandlingConfig();
+        final var produce = config.producerErrorHandlingConfig();
+        final var process = config.processErrorHandlingConfig();
+
+        assertThat(consume.loggerName()).isEqualTo("ConsumeError");
+        assertThat(produce.loggerName()).isEqualTo("ProduceError");
+        assertThat(process.loggerName()).isEqualTo("ProcessError");
+
+        // The lazily created defaults use the documented defaults: logging on, stop-on-fail.
+        assertThat(consume.log()).isTrue();
+        assertThat(consume.logPayload()).isFalse();
+        assertThat(consume.handler()).isEqualTo(Handler.STOP);
+    }
+
+    @Test
+    @DisplayName("Accessors are idempotent and keep returning the same instance")
+    void accessorsAreIdempotent() {
+        final var config = new ErrorHandlingConfig();
+
+        final var first = config.consumerErrorHandlingConfig();
+        final var second = config.consumerErrorHandlingConfig();
+
+        assertThat(second).isSameAs(first);
+    }
+
+    @Test
+    @DisplayName("An explicitly configured logger name is preserved")
+    void preservesExplicitLoggerName() {
+        final var custom = new ErrorTypeHandlingConfig();
+        custom.loggerName("MyConsumeLogger");
+        custom.handler(Handler.CONTINUE);
+        final var config = new ErrorHandlingConfig();
+        config.consume(custom);
+
+        final var consume = config.consumerErrorHandlingConfig();
+
+        assertThat(consume).isSameAs(custom);
+        assertThat(consume.loggerName()).isEqualTo("MyConsumeLogger");
+        assertThat(consume.handler()).isEqualTo(Handler.CONTINUE);
+    }
+
+    @Test
+    @DisplayName("A preset config without a logger name gets the channel default filled in for every channel")
+    void fillsMissingLoggerNameOnPresetConfig() {
+        final var presetConsume = new ErrorTypeHandlingConfig(); // loggerName is null
+        final var presetProduce = new ErrorTypeHandlingConfig();
+        final var presetProcess = new ErrorTypeHandlingConfig();
+        final var config = new ErrorHandlingConfig();
+        config.consume(presetConsume);
+        config.produce(presetProduce);
+        config.process(presetProcess);
+
+        // The same instances are kept, but their missing logger names are defaulted per channel.
+        assertThat(config.consumerErrorHandlingConfig()).isSameAs(presetConsume);
+        assertThat(presetConsume.loggerName()).isEqualTo("ConsumeError");
+        assertThat(config.producerErrorHandlingConfig()).isSameAs(presetProduce);
+        assertThat(presetProduce.loggerName()).isEqualTo("ProduceError");
+        assertThat(config.processErrorHandlingConfig()).isSameAs(presetProcess);
+        assertThat(presetProcess.loggerName()).isEqualTo("ProcessError");
+    }
+
+    @Test
+    @DisplayName("Preset produce and process configs with their own logger names are preserved")
+    void preservesPresetProduceAndProcessLoggers() {
+        final var produceCfg = new ErrorTypeHandlingConfig();
+        produceCfg.loggerName("CustomProduce");
+        final var processCfg = new ErrorTypeHandlingConfig();
+        processCfg.loggerName("CustomProcess");
+        final var config = new ErrorHandlingConfig();
+        config.produce(produceCfg);
+        config.process(processCfg);
+
+        assertThat(config.producerErrorHandlingConfig().loggerName()).isEqualTo("CustomProduce");
+        assertThat(config.processErrorHandlingConfig().loggerName()).isEqualTo("CustomProcess");
+    }
+}

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/config/ErrorHandlingConfigTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/config/ErrorHandlingConfigTest.java
@@ -4,7 +4,7 @@ package io.axual.ksml.runner.config;
  * ========================LICENSE_START=================================
  * KSML Runner
  * %%
- * Copyright (C) 2021 - 2024 Axual B.V.
+ * Copyright (C) 2021 - 2026 Axual B.V.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,20 +93,5 @@ class ErrorHandlingConfigTest {
         assertThat(presetProduce.loggerName()).isEqualTo("ProduceError");
         assertThat(config.processErrorHandlingConfig()).isSameAs(presetProcess);
         assertThat(presetProcess.loggerName()).isEqualTo("ProcessError");
-    }
-
-    @Test
-    @DisplayName("Preset produce and process configs with their own logger names are preserved")
-    void preservesPresetProduceAndProcessLoggers() {
-        final var produceCfg = new ErrorTypeHandlingConfig();
-        produceCfg.loggerName("CustomProduce");
-        final var processCfg = new ErrorTypeHandlingConfig();
-        processCfg.loggerName("CustomProcess");
-        final var config = new ErrorHandlingConfig();
-        config.produce(produceCfg);
-        config.process(processCfg);
-
-        assertThat(config.producerErrorHandlingConfig().loggerName()).isEqualTo("CustomProduce");
-        assertThat(config.processErrorHandlingConfig().loggerName()).isEqualTo("CustomProcess");
     }
 }

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/config/KSMLRunnerKSMLConfigTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/config/KSMLRunnerKSMLConfigTest.java
@@ -21,7 +21,11 @@ package io.axual.ksml.runner.config;
  */
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.axual.ksml.python.PythonContextConfig;
+import io.axual.ksml.runner.config.internal.KsmlFilePath;
+import io.axual.ksml.runner.config.internal.KsmlInlineDefinition;
 import io.axual.ksml.runner.exception.ConfigException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -32,7 +36,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -90,5 +96,112 @@ class KSMLRunnerKSMLConfigTest {
 
         assertEquals(newDir.toAbsolutePath().normalize().toString(), ksmlConfig.storageDirectory());
         assertTrue(Files.isDirectory(newDir), "storage directory should have been created");
+    }
+
+    @Test
+    @DisplayName("notations() and schemaRegistries() default to empty maps when nothing is configured")
+    void collectionAccessorsDefaultToEmpty() {
+        final var ksmlConfig = new KSMLConfig();
+        assertTrue(ksmlConfig.notations().isEmpty(), "notations should default to an empty map");
+        assertTrue(ksmlConfig.schemaRegistries().isEmpty(), "schemaRegistries should default to an empty map");
+        assertTrue(ksmlConfig.definitions().isEmpty(), "definitions should default to an empty map");
+    }
+
+    @Test
+    @DisplayName("notations() exposes the configured entries as an unmodifiable map")
+    void notationsAreExposedReadOnly() {
+        final var notations = new KSMLConfig.NotationMap();
+        notations.add("myAvro", NotationConfig.builder().type(NotationConfig.NotationType.CONFLUENT_AVRO).build());
+        final var ksmlConfig = new KSMLConfig();
+        ksmlConfig.notations(notations);
+
+        assertEquals(1, ksmlConfig.notations().size());
+        assertEquals(NotationConfig.NotationType.CONFLUENT_AVRO, ksmlConfig.notations().get("myAvro").type());
+        assertThrows(UnsupportedOperationException.class,
+                () -> ksmlConfig.notations().clear(),
+                "the accessor must return a read-only view");
+    }
+
+    @Test
+    @DisplayName("schemaRegistries() exposes the configured entries as an unmodifiable map")
+    void schemaRegistriesAreExposedReadOnly() {
+        final var registries = new KSMLConfig.SchemaRegistryMap();
+        registries.add("primary", SchemaRegistryConfig.builder().build());
+        final var ksmlConfig = new KSMLConfig();
+        ksmlConfig.schemaRegistries(registries);
+
+        assertEquals(1, ksmlConfig.schemaRegistries().size());
+        assertTrue(ksmlConfig.schemaRegistries().containsKey("primary"));
+        assertThrows(UnsupportedOperationException.class,
+                () -> ksmlConfig.schemaRegistries().clear(),
+                "the accessor must return a read-only view");
+    }
+
+    @Test
+    @DisplayName("definitions() returns inline definitions unchanged")
+    void definitionsReturnInlineDefinitions() {
+        final ObjectNode inline = objectMapper.createObjectNode().put("hello", "world");
+        final var defs = new KSMLConfig.KsmlDefinitionMap();
+        defs.add("inlineNamespace", new KsmlInlineDefinition(inline));
+        final var ksmlConfig = new KSMLConfig();
+        ksmlConfig.definitions(defs);
+
+        final var result = ksmlConfig.definitions();
+        assertEquals(1, result.size());
+        assertSame(inline, result.get("inlineNamespace"));
+    }
+
+    @Test
+    @DisplayName("definitions() loads a definition referenced by a file path")
+    void definitionsLoadFromFile() {
+        final var defs = new KSMLConfig.KsmlDefinitionMap();
+        defs.add("fileNamespace", new KsmlFilePath("load-definition-test.yaml"));
+        final var ksmlConfig = new KSMLConfig();
+        // The file path is resolved relative to the configDirectory.
+        ksmlConfig.configDirectory("src/test/resources");
+        ksmlConfig.definitions(defs);
+
+        final var result = ksmlConfig.definitions();
+        final var loaded = result.get("fileNamespace");
+        assertNotNull(loaded, "the definition file should have been read");
+        // The YAML content is parsed into a JsonNode tree we can inspect.
+        assertTrue(loaded.path("streams").has("some_stream"), "the parsed definition should contain the stream");
+    }
+
+    @Test
+    @DisplayName("definitions() throws when a referenced file does not exist")
+    void definitionsThrowOnMissingFile() {
+        final var defs = new KSMLConfig.KsmlDefinitionMap();
+        defs.add("missing", new KsmlFilePath("does-not-exist.yaml"));
+        final var ksmlConfig = new KSMLConfig();
+        ksmlConfig.configDirectory("src/test/resources");
+        ksmlConfig.definitions(defs);
+
+        assertThrows(ConfigException.class, ksmlConfig::definitions,
+                "a missing definition file should fail fast");
+    }
+
+    @Test
+    @DisplayName("pythonContextConfig() falls back to a default when none is configured")
+    void pythonContextConfigDefaults() {
+        final var ksmlConfig = new KSMLConfig();
+        assertNotNull(ksmlConfig.pythonContextConfig(), "a default python context config should be provided");
+
+        final var explicit = PythonContextConfig.builder().build();
+        ksmlConfig.pythonContextConfig(explicit);
+        assertSame(explicit, ksmlConfig.pythonContextConfig(), "an explicit config should be returned as-is");
+    }
+
+    @Test
+    @DisplayName("errorHandlingConfig() and applicationServerConfig() recover from a null field")
+    void configAccessorsRecreateNullFields() {
+        final var ksmlConfig = new KSMLConfig();
+        ksmlConfig.errorHandlingConfig(null);
+        ksmlConfig.applicationServerConfig(null);
+
+        assertNotNull(ksmlConfig.errorHandlingConfig(), "a fresh error handling config should be returned");
+        final var appServer = ksmlConfig.applicationServerConfig();
+        assertNotNull(appServer, "a fresh application server config should be returned");
+        assertFalse(appServer.enabled(), "the recreated application server should be disabled by default");
     }
 }

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/config/KSMLRunnerKSMLConfigTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/config/KSMLRunnerKSMLConfigTest.java
@@ -93,7 +93,7 @@ class KSMLRunnerKSMLConfigTest {
         ksmlConfig.createStorageDirectory(true);
 
         assertThat(ksmlConfig.storageDirectory()).isEqualTo(newDir.toAbsolutePath().normalize().toString());
-        assertThat(Files.isDirectory(newDir)).as("storage directory should have been created").isTrue();
+        assertThat(newDir).as("storage directory should have been created").isDirectory();
     }
 
     @Test

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/config/KSMLRunnerKSMLConfigTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/config/KSMLRunnerKSMLConfigTest.java
@@ -4,7 +4,7 @@ package io.axual.ksml.runner.config;
  * ========================LICENSE_START=================================
  * KSML Runner
  * %%
- * Copyright (C) 2021 - 2023 Axual B.V.
+ * Copyright (C) 2021 - 2026 Axual B.V.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,12 +35,8 @@ import org.junit.jupiter.api.io.TempDir;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class KSMLRunnerKSMLConfigTest {
 
@@ -56,7 +52,7 @@ class KSMLRunnerKSMLConfigTest {
     void shouldValidateConfig() throws Exception {
         final var yaml = getClass().getClassLoader().getResourceAsStream("ksml-config.yaml");
         final var ksmlConfig = objectMapper.readValue(yaml, KSMLConfig.class);
-        assertNotNull(ksmlConfig.configDirectory());
+        assertThat(ksmlConfig.configDirectory()).isNotNull();
     }
 
     @Test
@@ -64,7 +60,9 @@ class KSMLRunnerKSMLConfigTest {
     void shouldThrowOnWrongConfigdir() throws Exception {
         final var yaml = getClass().getClassLoader().getResourceAsStream("ksml-config-wrong-configdir.yaml");
         final var ksmlConfig = objectMapper.readValue(yaml, KSMLConfig.class);
-        assertThrows(ConfigException.class, ksmlConfig::configDirectory, "should throw exception for wrong configdir");
+        assertThatThrownBy(ksmlConfig::configDirectory)
+                .as("should throw exception for wrong configdir")
+                .isInstanceOf(ConfigException.class);
     }
 
     @Test
@@ -72,7 +70,7 @@ class KSMLRunnerKSMLConfigTest {
     void shouldDefaultConfigToWorkdir() throws Exception {
         final var yaml = getClass().getClassLoader().getResourceAsStream("ksml-config-no-configdir.yaml");
         final var ksmlConfig = objectMapper.readValue(yaml, KSMLConfig.class);
-        assertEquals(System.getProperty("user.dir"), ksmlConfig.configDirectory(), "config dir should default to working dir");
+        assertThat(ksmlConfig.configDirectory()).as("config dir should default to working dir").isEqualTo(System.getProperty("user.dir"));
     }
 
     @Test
@@ -81,9 +79,9 @@ class KSMLRunnerKSMLConfigTest {
         final var yaml = getClass().getClassLoader().getResourceAsStream("ksml-config.yaml");
         final var ksmlConfig = objectMapper.readValue(yaml, KSMLConfig.class);
         // schemaDirectory is not set in the yaml, so it defaults to the working directory
-        assertEquals(System.getProperty("user.dir"), ksmlConfig.schemaDirectory(), "schema dir should default to working dir");
+        assertThat(ksmlConfig.schemaDirectory()).as("schema dir should default to working dir").isEqualTo(System.getProperty("user.dir"));
         // storageDirectory is set to "." in the yaml, which resolves to the working directory
-        assertEquals(System.getProperty("user.dir"), ksmlConfig.storageDirectory(), "storage dir '.' should resolve to working dir");
+        assertThat(ksmlConfig.storageDirectory()).as("storage dir '.' should resolve to working dir").isEqualTo(System.getProperty("user.dir"));
     }
 
     @Test
@@ -94,17 +92,17 @@ class KSMLRunnerKSMLConfigTest {
         ksmlConfig.storageDirectory(newDir.toString());
         ksmlConfig.createStorageDirectory(true);
 
-        assertEquals(newDir.toAbsolutePath().normalize().toString(), ksmlConfig.storageDirectory());
-        assertTrue(Files.isDirectory(newDir), "storage directory should have been created");
+        assertThat(ksmlConfig.storageDirectory()).isEqualTo(newDir.toAbsolutePath().normalize().toString());
+        assertThat(Files.isDirectory(newDir)).as("storage directory should have been created").isTrue();
     }
 
     @Test
     @DisplayName("notations() and schemaRegistries() default to empty maps when nothing is configured")
     void collectionAccessorsDefaultToEmpty() {
         final var ksmlConfig = new KSMLConfig();
-        assertTrue(ksmlConfig.notations().isEmpty(), "notations should default to an empty map");
-        assertTrue(ksmlConfig.schemaRegistries().isEmpty(), "schemaRegistries should default to an empty map");
-        assertTrue(ksmlConfig.definitions().isEmpty(), "definitions should default to an empty map");
+        assertThat(ksmlConfig.notations()).as("notations should default to an empty map").isEmpty();
+        assertThat(ksmlConfig.schemaRegistries()).as("schemaRegistries should default to an empty map").isEmpty();
+        assertThat(ksmlConfig.definitions()).as("definitions should default to an empty map").isEmpty();
     }
 
     @Test
@@ -115,11 +113,11 @@ class KSMLRunnerKSMLConfigTest {
         final var ksmlConfig = new KSMLConfig();
         ksmlConfig.notations(notations);
         final var ksmlNotations = ksmlConfig.notations();
-        assertEquals(1, ksmlNotations.size());
-        assertEquals(NotationConfig.NotationType.CONFLUENT_AVRO, ksmlNotations.get("myAvro").type());
-        assertThrows(UnsupportedOperationException.class,
-                ksmlNotations::clear,
-                "the accessor must return a read-only view");
+        assertThat(ksmlNotations).hasSize(1);
+        assertThat(ksmlNotations.get("myAvro").type()).isEqualTo(NotationConfig.NotationType.CONFLUENT_AVRO);
+        assertThatThrownBy(ksmlNotations::clear)
+                .as("the accessor must return a read-only view")
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test
@@ -130,11 +128,10 @@ class KSMLRunnerKSMLConfigTest {
         final var ksmlConfig = new KSMLConfig();
         ksmlConfig.schemaRegistries(registries);
         final var ksmlSchemaRegistries = ksmlConfig.schemaRegistries();
-        assertEquals(1, ksmlSchemaRegistries.size());
-        assertTrue(ksmlSchemaRegistries.containsKey("primary"));
-        assertThrows(UnsupportedOperationException.class,
-                ksmlSchemaRegistries::clear,
-                "the accessor must return a read-only view");
+        assertThat(ksmlSchemaRegistries).hasSize(1).containsKey("primary");
+        assertThatThrownBy(ksmlSchemaRegistries::clear)
+                .as("the accessor must return a read-only view")
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test
@@ -147,8 +144,8 @@ class KSMLRunnerKSMLConfigTest {
         ksmlConfig.definitions(defs);
 
         final var result = ksmlConfig.definitions();
-        assertEquals(1, result.size());
-        assertSame(inline, result.get("inlineNamespace"));
+        assertThat(result).hasSize(1);
+        assertThat(result.get("inlineNamespace")).isSameAs(inline);
     }
 
     @Test
@@ -163,9 +160,9 @@ class KSMLRunnerKSMLConfigTest {
 
         final var result = ksmlConfig.definitions();
         final var loaded = result.get("fileNamespace");
-        assertNotNull(loaded, "the definition file should have been read");
+        assertThat(loaded).as("the definition file should have been read").isNotNull();
         // The YAML content is parsed into a JsonNode tree we can inspect.
-        assertTrue(loaded.path("streams").has("some_stream"), "the parsed definition should contain the stream");
+        assertThat(loaded.path("streams").has("some_stream")).as("the parsed definition should contain the stream").isTrue();
     }
 
     @Test
@@ -176,7 +173,7 @@ class KSMLRunnerKSMLConfigTest {
         final var ksmlConfig = new KSMLConfig();
         ksmlConfig.definitions(defs);
 
-        assertTrue(ksmlConfig.definitions().isEmpty(), "null definition entries must be skipped");
+        assertThat(ksmlConfig.definitions()).as("null definition entries must be skipped").isEmpty();
     }
 
     @Test
@@ -187,8 +184,9 @@ class KSMLRunnerKSMLConfigTest {
         final var ksmlConfig = new KSMLConfig();
         ksmlConfig.schemaDirectory(file.toString());
 
-        assertThrows(ConfigException.class, ksmlConfig::schemaDirectory,
-                "a path that is a regular file is not a valid directory");
+        assertThatThrownBy(ksmlConfig::schemaDirectory)
+                .as("a path that is a regular file is not a valid directory")
+                .isInstanceOf(ConfigException.class);
     }
 
     @Test
@@ -200,8 +198,9 @@ class KSMLRunnerKSMLConfigTest {
         ksmlConfig.configDirectory("src/test/resources");
         ksmlConfig.definitions(defs);
 
-        assertThrows(ConfigException.class, ksmlConfig::definitions,
-                "a missing definition file should fail fast");
+        assertThatThrownBy(ksmlConfig::definitions)
+                .as("a missing definition file should fail fast")
+                .isInstanceOf(ConfigException.class);
     }
 
     @Test
@@ -210,9 +209,9 @@ class KSMLRunnerKSMLConfigTest {
         final var ksmlConfig = new KSMLConfig(); // field is initialized with a default instance
         final var existing = ksmlConfig.errorHandlingConfig();
 
-        assertNotNull(existing);
+        assertThat(existing).isNotNull();
         // A second call returns the same default instance (the non-null branch).
-        assertSame(existing, ksmlConfig.errorHandlingConfig());
+        assertThat(ksmlConfig.errorHandlingConfig()).isSameAs(existing);
     }
 
     @Test
@@ -224,8 +223,9 @@ class KSMLRunnerKSMLConfigTest {
         ksmlConfig.storageDirectory(blocker.resolve("child").toString());
         ksmlConfig.createStorageDirectory(true);
 
-        assertThrows(ConfigException.class, ksmlConfig::storageDirectory,
-                "creating a directory under a regular file should fail");
+        assertThatThrownBy(ksmlConfig::storageDirectory)
+                .as("creating a directory under a regular file should fail")
+                .isInstanceOf(ConfigException.class);
     }
 
     @Test
@@ -240,18 +240,18 @@ class KSMLRunnerKSMLConfigTest {
         ksmlConfig.definitions(defs);
 
         // The IOException while reading is caught and logged, so the entry is simply absent.
-        assertTrue(ksmlConfig.definitions().isEmpty(), "an unparseable definition file is skipped");
+        assertThat(ksmlConfig.definitions()).as("an unparseable definition file is skipped").isEmpty();
     }
 
     @Test
     @DisplayName("pythonContextConfig() falls back to a default when none is configured")
     void pythonContextConfigDefaults() {
         final var ksmlConfig = new KSMLConfig();
-        assertNotNull(ksmlConfig.pythonContextConfig(), "a default python context config should be provided");
+        assertThat(ksmlConfig.pythonContextConfig()).as("a default python context config should be provided").isNotNull();
 
         final var explicit = PythonContextConfig.builder().build();
         ksmlConfig.pythonContextConfig(explicit);
-        assertSame(explicit, ksmlConfig.pythonContextConfig(), "an explicit config should be returned as-is");
+        assertThat(ksmlConfig.pythonContextConfig()).as("an explicit config should be returned as-is").isSameAs(explicit);
     }
 
     @Test
@@ -261,9 +261,9 @@ class KSMLRunnerKSMLConfigTest {
         ksmlConfig.errorHandlingConfig(null);
         ksmlConfig.applicationServerConfig(null);
 
-        assertNotNull(ksmlConfig.errorHandlingConfig(), "a fresh error handling config should be returned");
+        assertThat(ksmlConfig.errorHandlingConfig()).as("a fresh error handling config should be returned").isNotNull();
         final var appServer = ksmlConfig.applicationServerConfig();
-        assertNotNull(appServer, "a fresh application server config should be returned");
-        assertFalse(appServer.enabled(), "the recreated application server should be disabled by default");
+        assertThat(appServer).as("a fresh application server config should be returned").isNotNull();
+        assertThat(appServer.enabled()).as("the recreated application server should be disabled by default").isFalse();
     }
 }

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/config/KSMLRunnerKSMLConfigTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/config/KSMLRunnerKSMLConfigTest.java
@@ -114,11 +114,11 @@ class KSMLRunnerKSMLConfigTest {
         notations.add("myAvro", NotationConfig.builder().type(NotationConfig.NotationType.CONFLUENT_AVRO).build());
         final var ksmlConfig = new KSMLConfig();
         ksmlConfig.notations(notations);
-
-        assertEquals(1, ksmlConfig.notations().size());
-        assertEquals(NotationConfig.NotationType.CONFLUENT_AVRO, ksmlConfig.notations().get("myAvro").type());
+        final var ksmlNotations = ksmlConfig.notations();
+        assertEquals(1, ksmlNotations.size());
+        assertEquals(NotationConfig.NotationType.CONFLUENT_AVRO, ksmlNotations.get("myAvro").type());
         assertThrows(UnsupportedOperationException.class,
-                () -> ksmlConfig.notations().clear(),
+                ksmlNotations::clear,
                 "the accessor must return a read-only view");
     }
 
@@ -129,11 +129,11 @@ class KSMLRunnerKSMLConfigTest {
         registries.add("primary", SchemaRegistryConfig.builder().build());
         final var ksmlConfig = new KSMLConfig();
         ksmlConfig.schemaRegistries(registries);
-
-        assertEquals(1, ksmlConfig.schemaRegistries().size());
-        assertTrue(ksmlConfig.schemaRegistries().containsKey("primary"));
+        final var ksmlSchemaRegistries = ksmlConfig.schemaRegistries();
+        assertEquals(1, ksmlSchemaRegistries.size());
+        assertTrue(ksmlSchemaRegistries.containsKey("primary"));
         assertThrows(UnsupportedOperationException.class,
-                () -> ksmlConfig.schemaRegistries().clear(),
+                ksmlSchemaRegistries::clear,
                 "the accessor must return a read-only view");
     }
 
@@ -169,6 +169,29 @@ class KSMLRunnerKSMLConfigTest {
     }
 
     @Test
+    @DisplayName("definitions() skips entries whose value is null")
+    void definitionsSkipNullEntries() {
+        final var defs = new KSMLConfig.KsmlDefinitionMap();
+        defs.add("nullEntry", null);
+        final var ksmlConfig = new KSMLConfig();
+        ksmlConfig.definitions(defs);
+
+        assertTrue(ksmlConfig.definitions().isEmpty(), "null definition entries must be skipped");
+    }
+
+    @Test
+    @DisplayName("A directory accessor throws when the configured path is a regular file")
+    void directoryAccessorRejectsNonDirectory(@TempDir Path tempDir) throws Exception {
+        final var file = tempDir.resolve("not-a-dir.txt");
+        Files.writeString(file, "content");
+        final var ksmlConfig = new KSMLConfig();
+        ksmlConfig.schemaDirectory(file.toString());
+
+        assertThrows(ConfigException.class, ksmlConfig::schemaDirectory,
+                "a path that is a regular file is not a valid directory");
+    }
+
+    @Test
     @DisplayName("definitions() throws when a referenced file does not exist")
     void definitionsThrowOnMissingFile() {
         final var defs = new KSMLConfig.KsmlDefinitionMap();
@@ -179,6 +202,45 @@ class KSMLRunnerKSMLConfigTest {
 
         assertThrows(ConfigException.class, ksmlConfig::definitions,
                 "a missing definition file should fail fast");
+    }
+
+    @Test
+    @DisplayName("errorHandlingConfig() returns the configured instance when present")
+    void errorHandlingConfigReturnsExistingInstance() {
+        final var ksmlConfig = new KSMLConfig(); // field is initialized with a default instance
+        final var existing = ksmlConfig.errorHandlingConfig();
+
+        assertNotNull(existing);
+        // A second call returns the same default instance (the non-null branch).
+        assertSame(existing, ksmlConfig.errorHandlingConfig());
+    }
+
+    @Test
+    @DisplayName("storageDirectory creation fails with a ConfigException when the parent is a file")
+    void storageDirectoryCreationFailsWhenParentIsAFile(@TempDir Path tempDir) throws Exception {
+        final var blocker = tempDir.resolve("blocker");
+        Files.writeString(blocker, "i am a file"); // a regular file where a directory parent is expected
+        final var ksmlConfig = new KSMLConfig();
+        ksmlConfig.storageDirectory(blocker.resolve("child").toString());
+        ksmlConfig.createStorageDirectory(true);
+
+        assertThrows(ConfigException.class, ksmlConfig::storageDirectory,
+                "creating a directory under a regular file should fail");
+    }
+
+    @Test
+    @DisplayName("definitions() skips a referenced file that cannot be parsed")
+    void definitionsSkipUnparseableFile(@TempDir Path tempDir) throws Exception {
+        final var badFile = tempDir.resolve("broken.yaml");
+        Files.writeString(badFile, "foo: [1, 2, 3"); // unterminated flow sequence -> parse error
+        final var defs = new KSMLConfig.KsmlDefinitionMap();
+        defs.add("broken", new KsmlFilePath("broken.yaml"));
+        final var ksmlConfig = new KSMLConfig();
+        ksmlConfig.configDirectory(tempDir.toString());
+        ksmlConfig.definitions(defs);
+
+        // The IOException while reading is caught and logged, so the entry is simply absent.
+        assertTrue(ksmlConfig.definitions().isEmpty(), "an unparseable definition file is skipped");
     }
 
     @Test

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/config/KafkaConfigTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/config/KafkaConfigTest.java
@@ -4,7 +4,7 @@ package io.axual.ksml.runner.config;
  * ========================LICENSE_START=================================
  * KSML Runner
  * %%
- * Copyright (C) 2021 - 2024 Axual B.V.
+ * Copyright (C) 2021 - 2026 Axual B.V.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/config/KafkaConfigTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/config/KafkaConfigTest.java
@@ -1,0 +1,117 @@
+package io.axual.ksml.runner.config;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Runner
+ * %%
+ * Copyright (C) 2021 - 2024 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import io.axual.ksml.client.resolving.ResolvingClientConfig;
+import io.axual.ksml.runner.config.KSMLRunnerConfig.KafkaConfig;
+import org.apache.kafka.streams.StreamsConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link KafkaConfig}, covering the {@code put} validation guards for the mandatory
+ * application id and bootstrap servers, and the effective-config resolution.
+ */
+class KafkaConfigTest {
+
+    @Test
+    @DisplayName("Putting the application id and bootstrap servers updates the typed fields")
+    void putUpdatesTypedFields() {
+        final var config = new KafkaConfig();
+
+        config.put(StreamsConfig.APPLICATION_ID_CONFIG, "my-app");
+        config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "broker:9092");
+
+        assertThat(config.applicationId()).isEqualTo("my-app");
+        assertThat(config.bootstrapServers()).isEqualTo("broker:9092");
+        assertThat(config).containsEntry(StreamsConfig.APPLICATION_ID_CONFIG, "my-app");
+    }
+
+    @Test
+    @DisplayName("An arbitrary config key is stored without affecting the typed fields")
+    void putArbitraryKeyIsStored() {
+        final var config = new KafkaConfig();
+
+        config.put("acks", "all");
+
+        assertThat(config).containsEntry("acks", "all");
+        assertThat(config.applicationId()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("A blank application id or bootstrap servers value is rejected")
+    void putRejectsBlankMandatoryValues() {
+        final var config = new KafkaConfig();
+
+        assertThatThrownBy(() -> config.put(StreamsConfig.APPLICATION_ID_CONFIG, " "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("applicationId");
+        assertThatThrownBy(() -> config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, ""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("bootstrapServers");
+    }
+
+    @Test
+    @DisplayName("A null application id or bootstrap servers value is rejected")
+    void putRejectsNullMandatoryValues() {
+        final var config = new KafkaConfig();
+
+        assertThatThrownBy(() -> config.put(StreamsConfig.APPLICATION_ID_CONFIG, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("applicationId");
+        assertThatThrownBy(() -> config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("bootstrapServers");
+    }
+
+    @Test
+    @DisplayName("Effective config is an unmodifiable copy of the entries")
+    void effectiveConfigIsUnmodifiableCopy() {
+        final var config = new KafkaConfig();
+        config.put(StreamsConfig.APPLICATION_ID_CONFIG, "my-app");
+        config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "broker:9092");
+
+        final var effective = config.getEffectiveConfig();
+
+        assertThat(effective)
+                .containsEntry(StreamsConfig.APPLICATION_ID_CONFIG, "my-app")
+                .containsEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "broker:9092");
+        assertThatThrownBy(() -> effective.put("x", "y")).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    @DisplayName("Deprecated resolving keys are replaced when the config requires resolving")
+    void effectiveConfigReplacesDeprecatedResolvingKeys() {
+        final var config = new KafkaConfig();
+        config.put(StreamsConfig.APPLICATION_ID_CONFIG, "my-app");
+        config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "broker:9092");
+        // The deprecated topic pattern key triggers the resolving-config replacement path.
+        config.put(ResolvingClientConfig.COMPAT_TOPIC_PATTERN_CONFIG, "{topic}");
+
+        final var effective = config.getEffectiveConfig();
+
+        // After replacement the canonical resolving key is present.
+        assertThat(effective).containsKey(ResolvingClientConfig.TOPIC_PATTERN_CONFIG);
+    }
+}

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/config/PrometheusConfigTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/config/PrometheusConfigTest.java
@@ -50,6 +50,17 @@ class PrometheusConfigTest {
     }
 
     @Test
+    @DisplayName("When enabled with null host/port, the defaults are substituted")
+    void enabledFallsBackToDefaultsForNullValues() {
+        final var config = new PrometheusConfig();
+        config.enabled(true);
+        config.host(null);
+        config.port(null);
+        assertEquals("0.0.0.0", config.getHost());
+        assertEquals(9999, config.getPort());
+    }
+
+    @Test
     @DisplayName("When enabled without a configFile, the internal default config is materialized")
     void enabledFallsBackToInternalDefaultConfigFile() {
         final var config = new PrometheusConfig();

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/config/PrometheusConfigTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/config/PrometheusConfigTest.java
@@ -4,7 +4,7 @@ package io.axual.ksml.runner.config;
  * ========================LICENSE_START=================================
  * KSML Runner
  * %%
- * Copyright (C) 2021 - 2024 Axual B.V.
+ * Copyright (C) 2021 - 2026 Axual B.V.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,9 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class PrometheusConfigTest {
 
@@ -35,9 +33,9 @@ class PrometheusConfigTest {
     @DisplayName("When disabled, host, port and config file are hidden (null)")
     void disabledHidesEverything() {
         final var config = new PrometheusConfig();      // enabled defaults to false
-        assertNull(config.getHost());
-        assertNull(config.getPort());
-        assertNull(config.getConfigFile());
+        assertThat(config.getHost()).isNull();
+        assertThat(config.getPort()).isNull();
+        assertThat(config.getConfigFile()).isNull();
     }
 
     @Test
@@ -45,8 +43,8 @@ class PrometheusConfigTest {
     void enabledExposesDefaults() {
         final var config = new PrometheusConfig();
         config.enabled(true);
-        assertEquals("0.0.0.0", config.getHost());
-        assertEquals(9999, config.getPort());
+        assertThat(config.getHost()).isEqualTo("0.0.0.0");
+        assertThat(config.getPort()).isEqualTo(9999);
     }
 
     @Test
@@ -56,8 +54,8 @@ class PrometheusConfigTest {
         config.enabled(true);
         config.host(null);
         config.port(null);
-        assertEquals("0.0.0.0", config.getHost());
-        assertEquals(9999, config.getPort());
+        assertThat(config.getHost()).isEqualTo("0.0.0.0");
+        assertThat(config.getPort()).isEqualTo(9999);
     }
 
     @Test
@@ -65,7 +63,7 @@ class PrometheusConfigTest {
     void enabledFallsBackToInternalDefaultConfigFile() {
         final var config = new PrometheusConfig();
         config.enabled(true);
-        assertNotNull(config.getConfigFile());          // lazily loaded from the classpath default
+        assertThat(config.getConfigFile()).isNotNull();          // lazily loaded from the classpath default
     }
 
     @Test
@@ -74,7 +72,7 @@ class PrometheusConfigTest {
         final var config = new PrometheusConfig();
         config.enabled(true);
         config.configFile("/tmp/custom-exporter.yaml");
-        assertEquals(new File("/tmp/custom-exporter.yaml"), config.getConfigFile());
+        assertThat(config.getConfigFile()).isEqualTo(new File("/tmp/custom-exporter.yaml"));
     }
 
     @Test
@@ -88,8 +86,8 @@ class PrometheusConfigTest {
 
         final var copy = new PrometheusConfig(original);
 
-        assertEquals("127.0.0.1", copy.getHost());
-        assertEquals(1234, copy.getPort());
-        assertEquals(new File("/tmp/x.yaml"), copy.getConfigFile());
+        assertThat(copy.getHost()).isEqualTo("127.0.0.1");
+        assertThat(copy.getPort()).isEqualTo(1234);
+        assertThat(copy.getConfigFile()).isEqualTo(new File("/tmp/x.yaml"));
     }
 }

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/config/internal/KsmlFileOrDefinitionSerializerTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/config/internal/KsmlFileOrDefinitionSerializerTest.java
@@ -4,7 +4,7 @@ package io.axual.ksml.runner.config.internal;
  * ========================LICENSE_START=================================
  * KSML Runner
  * %%
- * Copyright (C) 2021 - 2025 Axual B.V.
+ * Copyright (C) 2021 - 2026 Axual B.V.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/config/internal/KsmlFileOrDefinitionSerializerTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/config/internal/KsmlFileOrDefinitionSerializerTest.java
@@ -1,0 +1,78 @@
+package io.axual.ksml.runner.config.internal;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Runner
+ * %%
+ * Copyright (C) 2021 - 2025 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link KsmlFileOrDefinitionSerializer}, verifying that the sealed union is serialized as a
+ * JSON string for a file path and as a JSON object for an inline definition.
+ */
+class KsmlFileOrDefinitionSerializerTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("A file-path definition is serialized as a plain JSON string")
+    void serializesFilePathAsString() throws Exception {
+        final KsmlFileOrDefinition value = new KsmlFilePath("definitions/my-app.yaml");
+
+        final var json = mapper.writerFor(KsmlFileOrDefinition.class).writeValueAsString(value);
+
+        assertThat(json).isEqualTo("\"definitions/my-app.yaml\"");
+    }
+
+    @Test
+    @DisplayName("An inline definition is serialized as the embedded JSON object")
+    void serializesInlineDefinitionAsObject() throws Exception {
+        final var node = mapper.createObjectNode();
+        node.put("name", "my-pipeline");
+        final KsmlFileOrDefinition value = new KsmlInlineDefinition(node);
+
+        final var json = mapper.writerFor(KsmlFileOrDefinition.class).writeValueAsString(value);
+
+        // The object is written verbatim, so it round-trips back to the same tree.
+        assertThat(mapper.readTree(json)).isEqualTo(node);
+    }
+
+    @Test
+    @DisplayName("A string deserializes to a file path and an object to an inline definition")
+    void deserializesBothVariants() throws Exception {
+        assertThat(mapper.readValue("\"my/app.yaml\"", KsmlFileOrDefinition.class))
+                .isInstanceOf(KsmlFilePath.class);
+        assertThat(mapper.readValue("{\"name\":\"x\"}", KsmlFileOrDefinition.class))
+                .isInstanceOf(KsmlInlineDefinition.class);
+    }
+
+    @Test
+    @DisplayName("A JSON kind that is neither a string nor an object is rejected")
+    void deserializeRejectsUnsupportedKind() {
+        // A JSON array is neither a file path (string) nor an inline definition (object).
+        assertThatThrownBy(() -> mapper.readValue("[1, 2, 3]", KsmlFileOrDefinition.class))
+                .isInstanceOf(JsonMappingException.class);
+    }
+}

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/config/internal/KsmlFileOrDefinitionSubTypeResolverTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/config/internal/KsmlFileOrDefinitionSubTypeResolverTest.java
@@ -4,7 +4,7 @@ package io.axual.ksml.runner.config.internal;
  * ========================LICENSE_START=================================
  * KSML Runner
  * %%
- * Copyright (C) 2021 - 2025 Axual B.V.
+ * Copyright (C) 2021 - 2026 Axual B.V.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,31 +25,42 @@ import com.github.victools.jsonschema.generator.SchemaGenerationContext;
 import com.github.victools.jsonschema.generator.TypeContext;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link KsmlFileOrDefinitionSubTypeResolver}, verifying that the two concrete subtypes are
  * advertised for the {@link KsmlFileOrDefinition} union and that other types are left untouched.
  */
+@ExtendWith(MockitoExtension.class)
 class KsmlFileOrDefinitionSubTypeResolverTest {
 
     private final KsmlFileOrDefinitionSubTypeResolver resolver = new KsmlFileOrDefinitionSubTypeResolver();
 
+    @Mock
+    private ResolvedType declaredType;
+    @Mock
+    private TypeContext typeContext;
+    @Mock
+    private SchemaGenerationContext context;
+    @Mock
+    private ResolvedType filePathType;
+    @Mock
+    private ResolvedType inlineType;
+
     @Test
     @DisplayName("The union type resolves to both concrete subtypes")
     void resolvesBothSubtypesForUnion() {
-        final var declaredType = mock(ResolvedType.class);
-        when(declaredType.getErasedType()).thenReturn((Class) KsmlFileOrDefinition.class);
+        // doReturn avoids the unchecked-cast warning that when(...).thenReturn(...) triggers on Class<?>.
+        doReturn(KsmlFileOrDefinition.class).when(declaredType).getErasedType();
 
-        final var typeContext = mock(TypeContext.class);
-        final var context = mock(SchemaGenerationContext.class);
         when(context.getTypeContext()).thenReturn(typeContext);
 
-        final var filePathType = mock(ResolvedType.class);
-        final var inlineType = mock(ResolvedType.class);
         when(typeContext.resolveSubtype(declaredType, KsmlFilePath.class)).thenReturn(filePathType);
         when(typeContext.resolveSubtype(declaredType, KsmlInlineDefinition.class)).thenReturn(inlineType);
 
@@ -61,10 +72,9 @@ class KsmlFileOrDefinitionSubTypeResolverTest {
     @Test
     @DisplayName("Other declared types are not given any subtypes")
     void returnsNullForUnrelatedType() {
-        final var declaredType = mock(ResolvedType.class);
-        when(declaredType.getErasedType()).thenReturn((Class) String.class);
+        doReturn(String.class).when(declaredType).getErasedType();
 
         // Returning null signals "no special subtypes" to the schema generator.
-        assertThat(resolver.findSubtypes(declaredType, mock(SchemaGenerationContext.class))).isNull();
+        assertThat(resolver.findSubtypes(declaredType, context)).isNull();
     }
 }

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/config/internal/KsmlFileOrDefinitionSubTypeResolverTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/config/internal/KsmlFileOrDefinitionSubTypeResolverTest.java
@@ -1,0 +1,70 @@
+package io.axual.ksml.runner.config.internal;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Runner
+ * %%
+ * Copyright (C) 2021 - 2025 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.fasterxml.classmate.ResolvedType;
+import com.github.victools.jsonschema.generator.SchemaGenerationContext;
+import com.github.victools.jsonschema.generator.TypeContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link KsmlFileOrDefinitionSubTypeResolver}, verifying that the two concrete subtypes are
+ * advertised for the {@link KsmlFileOrDefinition} union and that other types are left untouched.
+ */
+class KsmlFileOrDefinitionSubTypeResolverTest {
+
+    private final KsmlFileOrDefinitionSubTypeResolver resolver = new KsmlFileOrDefinitionSubTypeResolver();
+
+    @Test
+    @DisplayName("The union type resolves to both concrete subtypes")
+    void resolvesBothSubtypesForUnion() {
+        final var declaredType = mock(ResolvedType.class);
+        when(declaredType.getErasedType()).thenReturn((Class) KsmlFileOrDefinition.class);
+
+        final var typeContext = mock(TypeContext.class);
+        final var context = mock(SchemaGenerationContext.class);
+        when(context.getTypeContext()).thenReturn(typeContext);
+
+        final var filePathType = mock(ResolvedType.class);
+        final var inlineType = mock(ResolvedType.class);
+        when(typeContext.resolveSubtype(declaredType, KsmlFilePath.class)).thenReturn(filePathType);
+        when(typeContext.resolveSubtype(declaredType, KsmlInlineDefinition.class)).thenReturn(inlineType);
+
+        final var subtypes = resolver.findSubtypes(declaredType, context);
+
+        assertThat(subtypes).containsExactly(filePathType, inlineType);
+    }
+
+    @Test
+    @DisplayName("Other declared types are not given any subtypes")
+    void returnsNullForUnrelatedType() {
+        final var declaredType = mock(ResolvedType.class);
+        when(declaredType.getErasedType()).thenReturn((Class) String.class);
+
+        // Returning null signals "no special subtypes" to the schema generator.
+        assertThat(resolver.findSubtypes(declaredType, mock(SchemaGenerationContext.class))).isNull();
+    }
+}

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/exception/RunnerExceptionsTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/exception/RunnerExceptionsTest.java
@@ -1,0 +1,108 @@
+package io.axual.ksml.runner.exception;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Runner
+ * %%
+ * Copyright (C) 2021 - 2024 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ConfigException} and {@link RunnerException}, focusing on the message composition
+ * (the {@code MESSAGE_DETAIL_FORMAT} key/value rendering and its null handling) and cause propagation
+ * rather than merely asserting that the exceptions can be thrown.
+ */
+class RunnerExceptionsTest {
+
+    @Test
+    @DisplayName("RunnerException keeps its message and cause")
+    void runnerExceptionWithCause() {
+        final var cause = new IllegalStateException("boom");
+        final var exception = new RunnerException("something failed", cause);
+
+        assertThat(exception.getMessage()).isEqualTo("something failed");
+        assertThat(exception.getCause()).isSameAs(cause);
+    }
+
+    @Test
+    @DisplayName("ConfigException is a RunnerException carrying the plain message")
+    void configExceptionPlainMessage() {
+        final var exception = new ConfigException("plain message");
+
+        assertThat(exception).isInstanceOf(RunnerException.class);
+        assertThat(exception.getMessage()).isEqualTo("plain message");
+    }
+
+    @Test
+    @DisplayName("ConfigException(message, cause) preserves both")
+    void configExceptionMessageAndCause() {
+        final var cause = new IllegalArgumentException("bad");
+        final var exception = new ConfigException("message", cause);
+
+        assertThat(exception.getMessage()).isEqualTo("message");
+        assertThat(exception.getCause()).isSameAs(cause);
+    }
+
+    @Test
+    @DisplayName("The (key, value) constructor renders the default message with the formatted detail")
+    void configExceptionKeyValueUsesDefaultMessage() {
+        final var exception = new ConfigException("myKey", "myValue");
+
+        assertThat(exception.getMessage())
+                .startsWith(ConfigException.DEFAULT_MESSAGE)
+                .contains("Configuration Key   : 'myKey'")
+                .contains("Configuration Value : 'myValue'");
+    }
+
+    @Test
+    @DisplayName("A null configuration value is rendered as the literal 'null'")
+    void configExceptionRendersNullValue() {
+        final var exception = new ConfigException("myKey", null, "custom message");
+
+        assertThat(exception.getMessage())
+                .startsWith("custom message")
+                .contains("Configuration Key   : 'myKey'")
+                .contains("Configuration Value : 'null'");
+    }
+
+    @Test
+    @DisplayName("The (key, value, message, cause) constructor formats the detail and keeps the cause")
+    void configExceptionKeyValueMessageAndCause() {
+        final var cause = new RuntimeException("root");
+        final var exception = new ConfigException("dir", "/bad/path", "Could not create the directory", cause);
+
+        assertThat(exception.getMessage())
+                .startsWith("Could not create the directory")
+                .contains("Configuration Key   : 'dir'")
+                .contains("Configuration Value : '/bad/path'");
+        assertThat(exception.getCause()).isSameAs(cause);
+    }
+
+    @Test
+    @DisplayName("The (key, value, message, cause) constructor renders a null value as 'null'")
+    void configExceptionKeyValueMessageAndCauseWithNullValue() {
+        final var cause = new RuntimeException("root");
+        final var exception = new ConfigException("dir", null, "Could not create the directory", cause);
+
+        assertThat(exception.getMessage()).contains("Configuration Value : 'null'");
+        assertThat(exception.getCause()).isSameAs(cause);
+    }
+}

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/exception/RunnerExceptionsTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/exception/RunnerExceptionsTest.java
@@ -4,7 +4,7 @@ package io.axual.ksml.runner.exception;
  * ========================LICENSE_START=================================
  * KSML Runner
  * %%
- * Copyright (C) 2021 - 2024 Axual B.V.
+ * Copyright (C) 2021 - 2026 Axual B.V.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,39 +33,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 class RunnerExceptionsTest {
 
     @Test
-    @DisplayName("RunnerException keeps its message and cause")
-    void runnerExceptionWithCause() {
-        final var cause = new IllegalStateException("boom");
-        final var exception = new RunnerException("something failed", cause);
-
-        assertThat(exception.getMessage()).isEqualTo("something failed");
-        assertThat(exception.getCause()).isSameAs(cause);
-    }
-
-    @Test
-    @DisplayName("ConfigException is a RunnerException carrying the plain message")
-    void configExceptionPlainMessage() {
-        final var exception = new ConfigException("plain message");
-
-        assertThat(exception).isInstanceOf(RunnerException.class);
-        assertThat(exception.getMessage()).isEqualTo("plain message");
-    }
-
-    @Test
-    @DisplayName("ConfigException(message, cause) preserves both")
-    void configExceptionMessageAndCause() {
-        final var cause = new IllegalArgumentException("bad");
-        final var exception = new ConfigException("message", cause);
-
-        assertThat(exception.getMessage()).isEqualTo("message");
-        assertThat(exception.getCause()).isSameAs(cause);
-    }
-
-    @Test
     @DisplayName("The (key, value) constructor renders the default message with the formatted detail")
     void configExceptionKeyValueUsesDefaultMessage() {
         final var exception = new ConfigException("myKey", "myValue");
 
+        assertThat(exception).isInstanceOf(RunnerException.class);
         assertThat(exception.getMessage())
                 .startsWith(ConfigException.DEFAULT_MESSAGE)
                 .contains("Configuration Key   : 'myKey'")

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/logging/KSMLLogbackConfiguratorTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/logging/KSMLLogbackConfiguratorTest.java
@@ -4,7 +4,7 @@ package io.axual.ksml.runner.logging;
  * ========================LICENSE_START=================================
  * KSML Runner
  * %%
- * Copyright (C) 2021 - 2024 Axual B.V.
+ * Copyright (C) 2021 - 2026 Axual B.V.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,13 +26,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junitpioneer.jupiter.SetSystemProperty;
 
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collection;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
 class KSMLLogbackConfiguratorTest {
@@ -54,8 +56,7 @@ class KSMLLogbackConfiguratorTest {
         configurator.setContext(spiedContext);
         configurator.configure(spiedContext);
         Collection<MockAppender> appenders = MockAppender.APPENDERS.get("testEnvToResource");
-        assertNotNull(appenders);
-        assertEquals(1, appenders.size());
+        assertThat(appenders).hasSize(1);
     }
 
     @Test
@@ -64,7 +65,7 @@ class KSMLLogbackConfiguratorTest {
     void configureWithEnvironmentVariableToResourceURL() {
         // Get value for environment variable
         URL resourceUrl = getClass().getClassLoader().getResource("logback-custom-testing.xml");
-        assertNotNull(resourceUrl);
+        assertThat(resourceUrl).isNotNull();
 
         // Run test
         KSMLLogbackConfigurator configurator = new KSMLLogbackConfigurator();
@@ -72,8 +73,7 @@ class KSMLLogbackConfiguratorTest {
         configurator.setContext(spiedContext);
         configurator.configure(spiedContext);
         Collection<MockAppender> appenders = MockAppender.APPENDERS.get("testEnvToResourceUrl");
-        assertNotNull(appenders);
-        assertEquals(1, appenders.size());
+        assertThat(appenders).hasSize(1);
     }
 
     @Test
@@ -82,7 +82,7 @@ class KSMLLogbackConfiguratorTest {
     void configureWithEnvironmentVariableToFile() {
         // Get value for environment variable
         URL resourceUrl = getClass().getClassLoader().getResource("logback-custom-testing.xml");
-        assertNotNull(resourceUrl);
+        assertThat(resourceUrl).isNotNull();
 
         // Run test
         KSMLLogbackConfigurator configurator = new KSMLLogbackConfigurator();
@@ -90,8 +90,7 @@ class KSMLLogbackConfiguratorTest {
         configurator.setContext(spiedContext);
         configurator.configure(spiedContext);
         Collection<MockAppender> appenders = MockAppender.APPENDERS.get("testEnvToFile");
-        assertNotNull(appenders);
-        assertEquals(1, appenders.size());
+        assertThat(appenders).hasSize(1);
     }
 
     @Test
@@ -107,13 +106,11 @@ class KSMLLogbackConfiguratorTest {
 
         // This id comes from the logback-test.xml, which should be loaded now and is hardcoded
         Collection<MockAppender> appenders = MockAppender.APPENDERS.get("fixed-from-standard-joran-lookup");
-        assertNotNull(appenders);
-        assertEquals(1, appenders.size());
+        assertThat(appenders).hasSize(1);
 
         // This id is set, but since the default logback-test.xml is used it should never be set
         appenders = MockAppender.APPENDERS.get("shouldNotAppear");
-        assertNotNull(appenders);
-        assertEquals(0, appenders.size());
+        assertThat(appenders).isEmpty();
     }
 
     @Test
@@ -126,8 +123,8 @@ class KSMLLogbackConfiguratorTest {
         configurator.configure(spiedContext);
 
         // Falls back to the default logback-test.xml.
-        assertEquals(1, MockAppender.APPENDERS.get("fixed-from-standard-joran-lookup").size());
-        assertEquals(0, MockAppender.APPENDERS.get("blankShouldNotAppear").size());
+        assertThat(MockAppender.APPENDERS.get("fixed-from-standard-joran-lookup")).hasSize(1);
+        assertThat(MockAppender.APPENDERS.get("blankShouldNotAppear")).isEmpty();
     }
 
     @Test
@@ -140,17 +137,17 @@ class KSMLLogbackConfiguratorTest {
         configurator.setContext(spiedContext);
         configurator.configure(spiedContext);
 
-        assertEquals(1, MockAppender.APPENDERS.get("fixed-from-standard-joran-lookup").size());
-        assertEquals(0, MockAppender.APPENDERS.get("missingShouldNotAppear").size());
+        assertThat(MockAppender.APPENDERS.get("fixed-from-standard-joran-lookup")).hasSize(1);
+        assertThat(MockAppender.APPENDERS.get("missingShouldNotAppear")).isEmpty();
     }
 
     @Test
     @DisplayName("A malformed configuration file is reported as a warning rather than thrown")
     @SetSystemProperty(key = "logback.test.id", value = "malformed")
     @SneakyThrows
-    void configureWithMalformedConfigFile(@org.junit.jupiter.api.io.TempDir java.nio.file.Path tempDir) {
+    void configureWithMalformedConfigFile(@TempDir Path tempDir) {
         final var malformed = tempDir.resolve("broken-logback.xml");
-        java.nio.file.Files.writeString(malformed, "<configuration><appender"); // not well-formed XML
+        Files.writeString(malformed, "<configuration><appender"); // not well-formed XML
 
         final var configurator = new KSMLLogbackConfigurator();
         configurator.environmentVariableLookup = _ -> malformed.toUri().toString();
@@ -160,7 +157,7 @@ class KSMLLogbackConfiguratorTest {
 
         final var hasWarning = spiedContext.getStatusManager().getCopyOfStatusList().stream()
                 .anyMatch(status -> status.getMessage().contains("Could not configure KSML logging"));
-        org.junit.jupiter.api.Assertions.assertTrue(hasWarning, "a warning status should be recorded for the malformed config");
+        assertThat(hasWarning).as("a warning status should be recorded for the malformed config").isTrue();
     }
 
 }

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/logging/KSMLLogbackConfiguratorTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/logging/KSMLLogbackConfiguratorTest.java
@@ -116,4 +116,51 @@ class KSMLLogbackConfiguratorTest {
         assertEquals(0, appenders.size());
     }
 
+    @Test
+    @DisplayName("A blank environment variable value falls back to the default configuration")
+    @SetSystemProperty(key = "logback.test.id", value = "blankShouldNotAppear")
+    void configureWithBlankEnvironmentVariable() {
+        final var configurator = new KSMLLogbackConfigurator();
+        configurator.environmentVariableLookup = _ -> "   "; // blank value is ignored
+        configurator.setContext(spiedContext);
+        configurator.configure(spiedContext);
+
+        // Falls back to the default logback-test.xml.
+        assertEquals(1, MockAppender.APPENDERS.get("fixed-from-standard-joran-lookup").size());
+        assertEquals(0, MockAppender.APPENDERS.get("blankShouldNotAppear").size());
+    }
+
+    @Test
+    @DisplayName("A non-existent config reference that is neither URL, resource nor file falls back to the default")
+    @SetSystemProperty(key = "logback.test.id", value = "missingShouldNotAppear")
+    void configureWithUnresolvableReference() {
+        final var configurator = new KSMLLogbackConfigurator();
+        // Not a valid URL, not a classpath resource and not an existing file -> nothing is resolved.
+        configurator.environmentVariableLookup = _ -> "/does/not/exist/logback-missing.xml";
+        configurator.setContext(spiedContext);
+        configurator.configure(spiedContext);
+
+        assertEquals(1, MockAppender.APPENDERS.get("fixed-from-standard-joran-lookup").size());
+        assertEquals(0, MockAppender.APPENDERS.get("missingShouldNotAppear").size());
+    }
+
+    @Test
+    @DisplayName("A malformed configuration file is reported as a warning rather than thrown")
+    @SetSystemProperty(key = "logback.test.id", value = "malformed")
+    @SneakyThrows
+    void configureWithMalformedConfigFile(@org.junit.jupiter.api.io.TempDir java.nio.file.Path tempDir) {
+        final var malformed = tempDir.resolve("broken-logback.xml");
+        java.nio.file.Files.writeString(malformed, "<configuration><appender"); // not well-formed XML
+
+        final var configurator = new KSMLLogbackConfigurator();
+        configurator.environmentVariableLookup = _ -> malformed.toUri().toString();
+        configurator.setContext(spiedContext);
+        // configureByResource throws a JoranException, which configure() catches and records as a warning.
+        configurator.configure(spiedContext);
+
+        final var hasWarning = spiedContext.getStatusManager().getCopyOfStatusList().stream()
+                .anyMatch(status -> status.getMessage().contains("Could not configure KSML logging"));
+        org.junit.jupiter.api.Assertions.assertTrue(hasWarning, "a warning status should be recorded for the malformed config");
+    }
+
 }

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/notation/NotationFactoriesTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/notation/NotationFactoriesTest.java
@@ -1,0 +1,81 @@
+package io.axual.ksml.runner.notation;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Runner
+ * %%
+ * Copyright (C) 2021 - 2024 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import io.axual.ksml.data.notation.binary.BinaryNotation;
+import io.axual.ksml.data.notation.json.JsonNotation;
+import io.axual.ksml.type.UserType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NotationFactoriesTest {
+
+    @Test
+    @DisplayName("JSON, binary and the default notation are always registered")
+    void registersMandatoryNotations() {
+        final var factories = new NotationFactories(Map.of());
+
+        // JSON and binary are mandatory in KSML and registered explicitly (not via ServiceLoader),
+        // and the default notation must always be available for untyped data.
+        assertThat(factories.notations())
+                .containsKey(JsonNotation.NOTATION_NAME)
+                .containsKey(BinaryNotation.NOTATION_NAME)
+                .containsKey(UserType.DEFAULT_NOTATION);
+    }
+
+    @Test
+    @DisplayName("The default notation is backed by the same binary notation instance")
+    void defaultNotationIsTheBinaryNotation() {
+        final var factories = new NotationFactories(Map.of());
+
+        final var binary = factories.notations().get(BinaryNotation.NOTATION_NAME).create(null);
+        final var defaultNotation = factories.notations().get(UserType.DEFAULT_NOTATION).create(null);
+
+        // Both keys resolve to the single binary notation instance created in the constructor.
+        assertThat(defaultNotation).isSameAs(binary);
+    }
+
+    @Test
+    @DisplayName("Each registered factory produces a usable notation instance")
+    void everyFactoryCreatesANotation() {
+        final var factories = new NotationFactories(Map.of());
+
+        assertThat(factories.notations()).isNotEmpty();
+        factories.notations().forEach((name, factory) ->
+                assertThat(factory.create(null))
+                        .as("notation created for '%s'", name)
+                        .isNotNull());
+    }
+
+    @Test
+    @DisplayName("Kafka configuration is accepted and does not affect the mandatory notations")
+    void acceptsKafkaConfiguration() {
+        final var factories = new NotationFactories(Map.of("bootstrap.servers", "localhost:9092"));
+
+        assertThat(factories.notations())
+                .containsKey(JsonNotation.NOTATION_NAME)
+                .containsKey(BinaryNotation.NOTATION_NAME);
+    }
+}

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/notation/NotationFactoriesTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/notation/NotationFactoriesTest.java
@@ -4,7 +4,7 @@ package io.axual.ksml.runner.notation;
  * ========================LICENSE_START=================================
  * KSML Runner
  * %%
- * Copyright (C) 2021 - 2024 Axual B.V.
+ * Copyright (C) 2021 - 2026 Axual B.V.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/producer/ExecutableProducerTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/producer/ExecutableProducerTest.java
@@ -188,16 +188,14 @@ class ExecutableProducerTest {
 
     private static ExecutableProducer executableProducerFor(DataObject generated) {
         final var tags = new MetricTags();
+        final var target = new ExecutableProducer.ProducerTarget(
+                "output-topic", STRING_TYPE, STRING_TYPE, passthroughSerializer(), passthroughSerializer());
         return new ExecutableProducer(
                 generatorReturning(generated),
                 onceStrategy(tags),
                 tags,
-                "output-topic",
-                STRING_TYPE,
-                STRING_TYPE,
                 null, // no partitioner
-                passthroughSerializer(),
-                passthroughSerializer());
+                target);
     }
 
     @Test

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/producer/ExecutableProducerTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/producer/ExecutableProducerTest.java
@@ -1,0 +1,238 @@
+package io.axual.ksml.runner.producer;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Runner
+ * %%
+ * Copyright (C) 2021 - 2024 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import io.axual.ksml.data.notation.binary.BinaryNotation;
+import io.axual.ksml.data.notation.json.JsonNotation;
+import io.axual.ksml.data.object.DataObject;
+import io.axual.ksml.data.object.DataList;
+import io.axual.ksml.data.object.DataString;
+import io.axual.ksml.data.object.DataTuple;
+import io.axual.ksml.definition.ParameterDefinition;
+import io.axual.ksml.definition.ProducerDefinition;
+import io.axual.ksml.execution.ExecutionContext;
+import io.axual.ksml.metric.MetricTags;
+import io.axual.ksml.store.StateStores;
+import io.axual.ksml.type.UserType;
+import io.axual.ksml.user.UserFunction;
+import io.axual.ksml.user.UserGenerator;
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the message-shaping logic of {@link ExecutableProducer} ({@code extractMessages} and
+ * {@code shapeMessage}), which is the pure, Python-free part of the producer. The end-to-end producing
+ * path (generator execution, serialization, Kafka send) is covered by {@code KafkaProducerRunnerTest}
+ * on GraalVM.
+ */
+class ExecutableProducerTest {
+
+    private static final UserType STRING_TYPE = new UserType(DataString.DATATYPE);
+
+    @BeforeEach
+    void registerNotations() {
+        // DataObjectConverter.convert resolves notations from the ExecutionContext, so the default
+        // notation must be registered for the type conversions inside shapeMessage to work.
+        final var jsonNotation = new JsonNotation();
+        ExecutionContext.INSTANCE.notationLibrary().register(JsonNotation.NOTATION_NAME, jsonNotation);
+        final var binaryNotation = new BinaryNotation(jsonNotation::serde);
+        ExecutionContext.INSTANCE.notationLibrary().register(UserType.DEFAULT_NOTATION, binaryNotation);
+    }
+
+    private static ProducerStrategy acceptingStrategy() {
+        final var strategy = mock(ProducerStrategy.class);
+        when(strategy.validateMessage(any(), any())).thenReturn(true);
+        return strategy;
+    }
+
+    @Test
+    @DisplayName("A valid (key, value) tuple is shaped into a single message")
+    void shapesSingleTuple() {
+        final var tuple = new DataTuple(new DataString("key-1"), new DataString("value-1"));
+
+        final var messages = ExecutableProducer.extractMessages(tuple, STRING_TYPE, STRING_TYPE, acceptingStrategy());
+
+        assertThat(messages).hasSize(1);
+        assertThat(messages.get(0).left()).isEqualTo(new DataString("key-1"));
+        assertThat(messages.get(0).right()).isEqualTo(new DataString("value-1"));
+    }
+
+    @Test
+    @DisplayName("A list of tuples yields one message per valid element and skips invalid ones")
+    void shapesListSkippingInvalidElements() {
+        final var list = new DataList(); // DataType.UNKNOWN accepts mixed element types
+        list.add(new DataTuple(new DataString("k1"), new DataString("v1")));
+        list.add(new DataString("not-a-tuple"));                              // skipped
+        list.add(new DataTuple(new DataString("k2"), new DataString("v2")));
+
+        final var messages = ExecutableProducer.extractMessages(list, STRING_TYPE, STRING_TYPE, acceptingStrategy());
+
+        assertThat(messages).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("A tuple that does not have exactly two elements produces no message")
+    void ignoresTupleWithWrongArity() {
+        final var tuple = new DataTuple(new DataString("only-one"));
+
+        final var messages = ExecutableProducer.extractMessages(tuple, STRING_TYPE, STRING_TYPE, acceptingStrategy());
+
+        assertThat(messages).isEmpty();
+    }
+
+    @Test
+    @DisplayName("A generated object that is neither a tuple nor a list yields no messages")
+    void ignoresUnsupportedGeneratedType() {
+        final var messages = ExecutableProducer.extractMessages(new DataString("scalar"), STRING_TYPE, STRING_TYPE, acceptingStrategy());
+
+        assertThat(messages).isEmpty();
+    }
+
+    @Test
+    @DisplayName("A list element that is a tuple with the wrong arity is skipped")
+    void skipsListElementWithWrongArity() {
+        final var list = new DataList();
+        list.add(new DataTuple(new DataString("k1"), new DataString("v1"))); // valid
+        list.add(new DataTuple(new DataString("only-one")));                 // wrong arity, skipped
+
+        final var messages = ExecutableProducer.extractMessages(list, STRING_TYPE, STRING_TYPE, acceptingStrategy());
+
+        assertThat(messages).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("Messages rejected by the strategy are not added to the result")
+    void rejectedMessagesAreNotCollected() {
+        final var rejectingStrategy = mock(ProducerStrategy.class);
+        when(rejectingStrategy.validateMessage(any(), any())).thenReturn(false);
+        final var tuple = new DataTuple(new DataString("k"), new DataString("v"));
+
+        // Through extractMessages a rejected (null) message must not be added.
+        assertThat(ExecutableProducer.extractMessages(tuple, STRING_TYPE, STRING_TYPE, rejectingStrategy)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("A message rejected by the producer strategy is skipped")
+    void skipsMessageRejectedByStrategy() {
+        final var rejectingStrategy = mock(ProducerStrategy.class);
+        when(rejectingStrategy.validateMessage(any(), any())).thenReturn(false);
+        final var tuple = new DataTuple(new DataString("k"), new DataString("v"));
+
+        assertThat(ExecutableProducer.shapeMessage(tuple, STRING_TYPE, STRING_TYPE, rejectingStrategy)).isNull();
+    }
+
+    @Test
+    @DisplayName("A validated tuple is converted to the configured key/value types")
+    void shapeMessageConvertsToTargetTypes() {
+        final var tuple = new DataTuple(new DataString("k"), new DataString("v"));
+
+        final var shaped = ExecutableProducer.shapeMessage(tuple, STRING_TYPE, STRING_TYPE, acceptingStrategy());
+
+        assertThat(shaped).isNotNull();
+        assertThat(shaped.left()).isEqualTo(new DataString("k"));
+        assertThat(shaped.right()).isEqualTo(new DataString("v"));
+    }
+
+    // ---- instance-level produce tests (stubbed generator, no Python/GraalVM) -------------------
+
+    /** A generator UserFunction whose {@code call} returns a fixed value, avoiding the Python runtime. */
+    private static UserFunction generatorReturning(DataObject result) {
+        // A generator must declare the tuple/list-of-tuples result type expected by UserGenerator.
+        final var generatorResultType = new UserType(UserGenerator.EXPECTED_RESULT_TYPE);
+        return new UserFunction("ns", "gen", new ParameterDefinition[0], generatorResultType, List.of()) {
+            @Override
+            public DataObject call(StateStores stores, DataObject... parameters) {
+                return result;
+            }
+        };
+    }
+
+    /** A "produce once" strategy (no interval/count/until), so no Python predicates are needed. */
+    private static ProducerStrategy onceStrategy(MetricTags tags) {
+        final var definition = new ProducerDefinition(null, null, null, null, null, null, null);
+        return new ProducerStrategy(null, "ns", "gen", tags, definition);
+    }
+
+    private static Serializer<Object> passthroughSerializer() {
+        return (topic, data) -> new byte[]{1, 2, 3};
+    }
+
+    private static ExecutableProducer executableProducerFor(DataObject generated) {
+        final var tags = new MetricTags();
+        return new ExecutableProducer(
+                generatorReturning(generated),
+                onceStrategy(tags),
+                tags,
+                "output-topic",
+                STRING_TYPE,
+                STRING_TYPE,
+                null, // no partitioner
+                passthroughSerializer(),
+                passthroughSerializer());
+    }
+
+    @Test
+    @DisplayName("produceMessages generates, serializes and sends one record for a single-shot producer")
+    void produceMessagesSendsRecord() {
+        final var producer = executableProducerFor(new DataTuple(new DataString("key"), new DataString("value")));
+        final var mockProducer = new MockProducer<>(true, null, new ByteArraySerializer(), new ByteArraySerializer());
+
+        producer.produceMessages(mockProducer);
+
+        assertThat(mockProducer.history()).hasSize(1);
+        assertThat(mockProducer.history().get(0).topic()).isEqualTo("output-topic");
+        // A single-shot producer should not ask to be rescheduled.
+        assertThat(producer.shouldReschedule()).isFalse();
+    }
+
+    @Test
+    @DisplayName("produceMessages sends nothing when the generator never yields a valid message")
+    void produceMessagesSkipsWhenNoValidMessage() {
+        // A scalar (non-tuple) generated value is never a valid message, so after the retries nothing is sent.
+        final var producer = executableProducerFor(new DataString("not-a-tuple"));
+        final var mockProducer = new MockProducer<>(true, null, new ByteArraySerializer(), new ByteArraySerializer());
+
+        producer.produceMessages(mockProducer);
+
+        assertThat(mockProducer.history()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("name and interval are exposed from the generator and strategy")
+    void exposesNameAndInterval() {
+        final var producer = executableProducerFor(new DataTuple(new DataString("k"), new DataString("v")));
+
+        assertThat(producer.name()).isEqualTo("gen");
+        // A single-shot producer has a zero interval.
+        assertThat(producer.interval()).isZero();
+    }
+}

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/producer/ExecutableProducerTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/producer/ExecutableProducerTest.java
@@ -4,7 +4,7 @@ package io.axual.ksml.runner.producer;
  * ========================LICENSE_START=================================
  * KSML Runner
  * %%
- * Copyright (C) 2021 - 2024 Axual B.V.
+ * Copyright (C) 2021 - 2026 Axual B.V.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -130,24 +130,16 @@ class ExecutableProducerTest {
     }
 
     @Test
-    @DisplayName("Messages rejected by the strategy are not added to the result")
-    void rejectedMessagesAreNotCollected() {
+    @DisplayName("A message rejected by the producer strategy is not collected")
+    void rejectedMessageIsNotCollected() {
         final var rejectingStrategy = mock(ProducerStrategy.class);
         when(rejectingStrategy.validateMessage(any(), any())).thenReturn(false);
         final var tuple = new DataTuple(new DataString("k"), new DataString("v"));
 
-        // Through extractMessages a rejected (null) message must not be added.
+        // extractMessages -> addShapedMessage -> shapeMessage returns null for a rejected tuple, so
+        // nothing is added to the result. This drives both the shapeMessage rejection path and the
+        // null-guard in addShapedMessage.
         assertThat(ExecutableProducer.extractMessages(tuple, STRING_TYPE, STRING_TYPE, rejectingStrategy)).isEmpty();
-    }
-
-    @Test
-    @DisplayName("A message rejected by the producer strategy is skipped")
-    void skipsMessageRejectedByStrategy() {
-        final var rejectingStrategy = mock(ProducerStrategy.class);
-        when(rejectingStrategy.validateMessage(any(), any())).thenReturn(false);
-        final var tuple = new DataTuple(new DataString("k"), new DataString("v"));
-
-        assertThat(ExecutableProducer.shapeMessage(tuple, STRING_TYPE, STRING_TYPE, rejectingStrategy)).isNull();
     }
 
     @Test
@@ -222,15 +214,5 @@ class ExecutableProducerTest {
         producer.produceMessages(mockProducer);
 
         assertThat(mockProducer.history()).isEmpty();
-    }
-
-    @Test
-    @DisplayName("name and interval are exposed from the generator and strategy")
-    void exposesNameAndInterval() {
-        final var producer = executableProducerFor(new DataTuple(new DataString("k"), new DataString("v")));
-
-        assertThat(producer.name()).isEqualTo("gen");
-        // A single-shot producer has a zero interval.
-        assertThat(producer.interval()).isZero();
     }
 }

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/producer/ExecutableProducerTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/producer/ExecutableProducerTest.java
@@ -22,6 +22,7 @@ package io.axual.ksml.runner.producer;
 
 import io.axual.ksml.data.notation.binary.BinaryNotation;
 import io.axual.ksml.data.notation.json.JsonNotation;
+import io.axual.ksml.data.object.DataInteger;
 import io.axual.ksml.data.object.DataObject;
 import io.axual.ksml.data.object.DataList;
 import io.axual.ksml.data.object.DataString;
@@ -34,7 +35,11 @@ import io.axual.ksml.store.StateStores;
 import io.axual.ksml.type.UserType;
 import io.axual.ksml.user.UserFunction;
 import io.axual.ksml.user.UserGenerator;
+import io.axual.ksml.user.UserStreamPartitioner;
 import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,8 +47,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -57,6 +64,7 @@ import static org.mockito.Mockito.when;
 class ExecutableProducerTest {
 
     private static final UserType STRING_TYPE = new UserType(DataString.DATATYPE);
+    private static final String TOPIC = "output-topic";
 
     @BeforeEach
     void registerNotations() {
@@ -168,6 +176,11 @@ class ExecutableProducerTest {
         };
     }
 
+    /** A valid (key, value) tuple used by the produce-path tests. */
+    private static DataTuple sampleTuple() {
+        return new DataTuple(new DataString("key"), new DataString("value"));
+    }
+
     /** A "produce once" strategy (no interval/count/until), so no Python predicates are needed. */
     private static ProducerStrategy onceStrategy(MetricTags tags) {
         final var definition = new ProducerDefinition(null, null, null, null, null, null, null);
@@ -179,27 +192,152 @@ class ExecutableProducerTest {
     }
 
     private static ExecutableProducer executableProducerFor(DataObject generated) {
+        return executableProducerFor(generated, null);
+    }
+
+    private static ExecutableProducer executableProducerFor(DataObject generated, UserFunction partitioner) {
         final var tags = new MetricTags();
         final var target = new ExecutableProducer.ProducerTarget(
-                "output-topic", STRING_TYPE, STRING_TYPE, passthroughSerializer(), passthroughSerializer());
+                TOPIC, STRING_TYPE, STRING_TYPE, passthroughSerializer(), passthroughSerializer());
         return new ExecutableProducer(
                 generatorReturning(generated),
                 onceStrategy(tags),
                 tags,
-                null, // no partitioner
+                partitioner,
                 target);
     }
 
+    /**
+     * A partitioner UserFunction that returns a fixed value, avoiding the Python runtime. The value is
+     * interpreted by {@link UserStreamPartitioner}: a {@link DataInteger} selects a single partition, a
+     * {@link DataList} of integers selects several, anything else selects none.
+     */
+    private static UserFunction partitionerReturning(DataObject result) {
+        final var resultType = new UserType(UserStreamPartitioner.EXPECTED_RESULT_TYPE);
+        final var params = new ParameterDefinition[]{
+                new ParameterDefinition("topic", DataString.DATATYPE),
+                new ParameterDefinition("key", DataString.DATATYPE),
+                new ParameterDefinition("value", DataString.DATATYPE),
+                new ParameterDefinition("numPartitions", DataInteger.DATATYPE)
+        };
+        return new UserFunction("ns", "partitioner", params, resultType, List.of()) {
+            @Override
+            public DataObject call(StateStores stores, DataObject... parameters) {
+                return result;
+            }
+        };
+    }
+
     @Test
-    @DisplayName("produceMessages generates, serializes and sends one record for a single-shot producer")
-    void produceMessagesSendsRecord() {
-        final var producer = executableProducerFor(new DataTuple(new DataString("key"), new DataString("value")));
+    @DisplayName("produceMessages sends one record to the single partition chosen by the partitioner")
+    void produceMessagesSendsToPartitionerSelectedPartition() {
+        final var producer = executableProducerFor(
+                sampleTuple(),
+                partitionerReturning(new DataInteger(3)));
         final var mockProducer = new MockProducer<>(true, null, new ByteArraySerializer(), new ByteArraySerializer());
 
         producer.produceMessages(mockProducer);
 
         assertThat(mockProducer.history()).hasSize(1);
-        assertThat(mockProducer.history().get(0).topic()).isEqualTo("output-topic");
+        assertThat(mockProducer.history().get(0).partition()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("produceMessages sends one record per partition for a multi-partition partitioner")
+    void produceMessagesSendsToEveryPartition() {
+        final var partitions = new DataList(DataInteger.DATATYPE);
+        partitions.add(new DataInteger(0));
+        partitions.add(new DataInteger(2));
+        final var producer = executableProducerFor(
+                sampleTuple(),
+                partitionerReturning(partitions));
+        final var mockProducer = new MockProducer<>(true, null, new ByteArraySerializer(), new ByteArraySerializer());
+
+        producer.produceMessages(mockProducer);
+
+        assertThat(mockProducer.history())
+                .hasSize(2)
+                .extracting(ProducerRecord::partition)
+                .containsExactlyInAnyOrder(0, 2);
+    }
+
+    @Test
+    @DisplayName("produceMessages sends nothing when the partitioner selects no partition")
+    void produceMessagesSendsNothingWhenNoPartitionSelected() {
+        final var producer = executableProducerFor(
+                sampleTuple(),
+                partitionerReturning(new DataString("not-a-partition")));
+        final var mockProducer = new MockProducer<>(true, null, new ByteArraySerializer(), new ByteArraySerializer());
+
+        producer.produceMessages(mockProducer);
+
+        assertThat(mockProducer.history()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("produceMessages wraps a failed send in an ExecutionException")
+    void produceMessagesWrapsSendFailure() {
+        final var executableProducer = executableProducerFor(new DataTuple(new DataString("k"), new DataString("v")));
+        final Producer<byte[], byte[]> producer = mock();
+        when(producer.send(any())).thenReturn(CompletableFuture.failedFuture(new RuntimeException("send failed")));
+
+        assertThatThrownBy(() -> executableProducer.produceMessages(producer))
+                .isInstanceOf(io.axual.ksml.exception.ExecutionException.class)
+                .hasMessageContaining("Could not produce to topic");
+    }
+
+    @Test
+    @DisplayName("produceMessages does not count a message whose metadata has no offset")
+    void produceMessagesDoesNotCountMessageWithoutOffset() {
+        final var tags = new MetricTags();
+        final var strategy = onceStrategy(tags);
+        final var target = new ExecutableProducer.ProducerTarget(
+                TOPIC, STRING_TYPE, STRING_TYPE, passthroughSerializer(), passthroughSerializer());
+        final var executableProducer = new ExecutableProducer(
+                generatorReturning(new DataTuple(new DataString("k"), new DataString("v"))),
+                strategy, tags, null, target);
+
+        final Producer<byte[], byte[]> producer = mock();
+        final var metadata = mock(RecordMetadata.class);
+        when(metadata.hasOffset()).thenReturn(false);
+        when(producer.send(any())).thenReturn(CompletableFuture.completedFuture(metadata));
+
+        executableProducer.produceMessages(producer);
+
+        // The metadata has no offset, so the message is logged as an error and not counted as produced.
+        assertThat(strategy.messagesProduced()).isZero();
+    }
+
+    @Test
+    @DisplayName("produceMessages does not count a message whose metadata is null")
+    void produceMessagesDoesNotCountNullMetadata() {
+        final var tags = new MetricTags();
+        final var strategy = onceStrategy(tags);
+        final var target = new ExecutableProducer.ProducerTarget(
+                TOPIC, STRING_TYPE, STRING_TYPE, passthroughSerializer(), passthroughSerializer());
+        final var executableProducer = new ExecutableProducer(
+                generatorReturning(new DataTuple(new DataString("k"), new DataString("v"))),
+                strategy, tags, null, target);
+
+        final Producer<byte[], byte[]> producer = mock();
+        when(producer.send(any())).thenReturn(CompletableFuture.completedFuture(null));
+
+        executableProducer.produceMessages(producer);
+
+        // Null metadata is treated as an error (logged), not counted, and must not throw.
+        assertThat(strategy.messagesProduced()).isZero();
+    }
+
+    @Test
+    @DisplayName("produceMessages generates, serializes and sends one record for a single-shot producer")
+    void produceMessagesSendsRecord() {
+        final var producer = executableProducerFor(sampleTuple());
+        final var mockProducer = new MockProducer<>(true, null, new ByteArraySerializer(), new ByteArraySerializer());
+
+        producer.produceMessages(mockProducer);
+
+        assertThat(mockProducer.history()).hasSize(1);
+        assertThat(mockProducer.history().get(0).topic()).isEqualTo(TOPIC);
         // A single-shot producer should not ask to be rescheduled.
         assertThat(producer.shouldReschedule()).isFalse();
     }

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/producer/ProducerStrategyTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/producer/ProducerStrategyTest.java
@@ -1,0 +1,145 @@
+package io.axual.ksml.runner.producer;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Runner
+ * %%
+ * Copyright (C) 2021 - 2024 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import io.axual.ksml.definition.ProducerDefinition;
+import io.axual.ksml.metric.MetricTags;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link ProducerStrategy}.
+ * <p>
+ * These tests deliberately use {@link ProducerDefinition}s without {@code condition} or {@code until}
+ * functions, so no Python/GraalVM context is required: the strategy resolves those optional predicates
+ * to {@code null}. The predicate-driven paths (custom condition/until functions) are exercised end-to-end
+ * by {@code KafkaProducerRunnerTest} on GraalVM.
+ */
+class ProducerStrategyTest {
+
+    private static final MetricTags TAGS = new MetricTags();
+
+    private static ProducerStrategy strategyFor(Long messageCount, Long batchSize, Duration interval) {
+        // generator, condition, until and target are unused by ProducerStrategy and left null on purpose.
+        final var definition = new ProducerDefinition(null, null, null, null, messageCount, batchSize, interval);
+        // context may be null because no condition/until functions are defined.
+        return new ProducerStrategy(null, "ns", "producer", TAGS, definition);
+    }
+
+    @Test
+    @DisplayName("With no interval, messageCount or until, the producer runs exactly once")
+    void runsOnceWhenNothingConfigured() {
+        final var strategy = strategyFor(null, null, null);
+
+        assertThat(strategy.interval()).isEqualTo(Duration.ZERO);
+        assertThat(strategy.batchSize()).isEqualTo(1);
+        // "once" producers must never reschedule, even before anything is produced.
+        assertThat(strategy.shouldReschedule()).isFalse();
+        // Without a condition every message is valid, and without an "until" we always continue.
+        assertThat(strategy.validateMessage(null, null)).isTrue();
+        assertThat(strategy.continueAfterMessage(null, null)).isTrue();
+    }
+
+    @Test
+    @DisplayName("A fixed messageCount reschedules until that many messages have been produced")
+    void reschedulesUntilMessageCountReached() {
+        final var strategy = strategyFor(3L, null, null);
+
+        assertThat(strategy.shouldReschedule()).isTrue();
+        assertThat(strategy.batchSize()).isEqualTo(1); // min(default batch 1, remaining 3)
+
+        strategy.successfullyProducedOneMessage();
+        strategy.successfullyProducedOneMessage();
+        assertThat(strategy.messagesProduced()).isEqualTo(2);
+        assertThat(strategy.shouldReschedule()).isTrue();
+
+        strategy.successfullyProducedOneMessage();
+        assertThat(strategy.messagesProduced()).isEqualTo(3);
+        // All requested messages produced, so no further runs.
+        assertThat(strategy.shouldReschedule()).isFalse();
+    }
+
+    @Test
+    @DisplayName("An interval without a messageCount produces indefinitely")
+    void reschedulesForeverWhenOnlyIntervalConfigured() {
+        final var strategy = strategyFor(null, null, Duration.ofMillis(250));
+
+        assertThat(strategy.interval()).isEqualTo(Duration.ofMillis(250));
+        assertThat(strategy.shouldReschedule()).isTrue();
+
+        // Producing many messages must not exhaust an infinite producer.
+        for (int i = 0; i < 100; i++) {
+            strategy.successfullyProducedOneMessage();
+        }
+        assertThat(strategy.shouldReschedule()).isTrue();
+    }
+
+    @ParameterizedTest(name = "configured batchSize {0} -> effective {1}")
+    @DisplayName("Batch size is clamped to the supported 1..1000 range")
+    @CsvSource({
+            "0,    1",     // below the minimum falls back to the default of 1
+            "1,    1",
+            "500,  500",
+            "1000, 1000",
+            "2000, 1"      // above the maximum falls back to the default of 1
+    })
+    void clampsBatchSizeToValidRange(long configured, long expected) {
+        // An interval (and no messageCount) makes the producer infinite, so batchSize() returns
+        // the stored batch size verbatim without the "remaining messages" clamping.
+        final var strategy = strategyFor(null, configured, Duration.ofMillis(10));
+        assertThat(strategy.batchSize()).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("Batch size never exceeds the number of messages still to be produced")
+    void batchSizeNeverExceedsRemainingMessages() {
+        final var strategy = strategyFor(2L, 10L, Duration.ofMillis(10));
+
+        assertThat(strategy.batchSize()).isEqualTo(2); // min(10, 2 remaining)
+
+        strategy.successfullyProducedOneMessage();
+        assertThat(strategy.batchSize()).isEqualTo(1); // min(10, 1 remaining)
+    }
+
+    @Test
+    @DisplayName("A messageCount below 1 is floored to a single message")
+    void messageCountIsFlooredToOne() {
+        // interval present so this is not a "once" producer; messageCount 0 is floored to 1.
+        final var strategy = strategyFor(0L, null, Duration.ofMillis(10));
+
+        assertThat(strategy.shouldReschedule()).isTrue();
+        strategy.successfullyProducedOneMessage();
+        assertThat(strategy.shouldReschedule()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Interval defaults to zero when only a messageCount is configured")
+    void intervalDefaultsToZeroWhenOnlyCountConfigured() {
+        final var strategy = strategyFor(5L, null, null);
+        assertThat(strategy.interval()).isEqualTo(Duration.ZERO);
+    }
+}

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/producer/ProducerStrategyTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/producer/ProducerStrategyTest.java
@@ -4,7 +4,7 @@ package io.axual.ksml.runner.producer;
  * ========================LICENSE_START=================================
  * KSML Runner
  * %%
- * Copyright (C) 2021 - 2024 Axual B.V.
+ * Copyright (C) 2021 - 2026 Axual B.V.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/prometheus/PrometheusExportTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/prometheus/PrometheusExportTest.java
@@ -68,7 +68,7 @@ class PrometheusExportTest {
         config.port(0); // bind to an ephemeral port so the test never clashes with a fixed port
 
         final var export = new PrometheusExport(config);
-        try {
+        try (export; final var httpClient = HttpClient.newHttpClient()) {
             export.start();
 
             final var server = httpServerOf(export);
@@ -77,13 +77,11 @@ class PrometheusExportTest {
             assertThat(boundPort).isPositive();
 
             // The exporter actually serves Prometheus metrics over HTTP.
-            final var response = HttpClient.newHttpClient().send(
+            final var response = httpClient.send(
                     HttpRequest.newBuilder(URI.create("http://localhost:" + boundPort + "/metrics")).build(),
                     HttpResponse.BodyHandlers.ofString());
             assertThat(response.statusCode()).isEqualTo(200);
             assertThat(response.body()).isNotEmpty();
-        } finally {
-            export.close();
         }
 
         // close() clears the server reference, and a second close() is a harmless no-op.

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/prometheus/PrometheusExportTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/prometheus/PrometheusExportTest.java
@@ -4,7 +4,7 @@ package io.axual.ksml.runner.prometheus;
  * ========================LICENSE_START=================================
  * KSML Runner
  * %%
- * Copyright (C) 2021 - 2024 Axual B.V.
+ * Copyright (C) 2021 - 2026 Axual B.V.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/prometheus/PrometheusExportTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/prometheus/PrometheusExportTest.java
@@ -1,0 +1,107 @@
+package io.axual.ksml.runner.prometheus;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Runner
+ * %%
+ * Copyright (C) 2021 - 2024 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import io.axual.ksml.runner.config.PrometheusConfig;
+import io.prometheus.metrics.exporter.httpserver.HTTPServer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class PrometheusExportTest {
+
+    private static HTTPServer httpServerOf(PrometheusExport export) throws Exception {
+        final Field field = PrometheusExport.class.getDeclaredField("httpServer");
+        field.setAccessible(true);
+        return (HTTPServer) field.get(export);
+    }
+
+    @Test
+    @DisplayName("When disabled, start() does not open an HTTP server")
+    void disabledDoesNotStartServer() throws Exception {
+        final var config = new PrometheusConfig(); // enabled defaults to false
+        try (final var export = new PrometheusExport(config)) {
+            assertThatCode(export::start).doesNotThrowAnyException();
+            assertThat(httpServerOf(export)).as("no server when disabled").isNull();
+        }
+    }
+
+    @Test
+    @DisplayName("stop() and close() are safe to call when the server was never started")
+    void stopIsIdempotentWhenNeverStarted() {
+        final var export = new PrometheusExport(new PrometheusConfig());
+        assertThatCode(export::stop).doesNotThrowAnyException();
+        assertThatCode(export::close).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("When enabled, start() exposes a working metrics endpoint that close() shuts down")
+    void enabledStartsAndServesMetrics() throws Exception {
+        final var config = new PrometheusConfig();
+        config.enabled(true);
+        config.port(0); // bind to an ephemeral port so the test never clashes with a fixed port
+
+        final var export = new PrometheusExport(config);
+        try {
+            export.start();
+
+            final var server = httpServerOf(export);
+            assertThat(server).as("an HTTP server is created when enabled").isNotNull();
+            final int boundPort = server.getPort();
+            assertThat(boundPort).isPositive();
+
+            // The exporter actually serves Prometheus metrics over HTTP.
+            final var response = HttpClient.newHttpClient().send(
+                    HttpRequest.newBuilder(URI.create("http://localhost:" + boundPort + "/metrics")).build(),
+                    HttpResponse.BodyHandlers.ofString());
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.body()).isNotEmpty();
+        } finally {
+            export.close();
+        }
+
+        // close() clears the server reference, and a second close() is a harmless no-op.
+        assertThat(httpServerOf(export)).isNull();
+        assertThatCode(export::close).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("The configuration is defensively copied so later mutations have no effect")
+    void configurationIsDefensivelyCopied() throws Exception {
+        final var config = new PrometheusConfig();
+        config.enabled(false);
+
+        try (final var export = new PrometheusExport(config)) {
+            // Enabling the original config after construction must not enable the export.
+            config.enabled(true);
+            export.start();
+            assertThat(httpServerOf(export)).as("export keeps its own disabled copy").isNull();
+        }
+    }
+}

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/streams/KSMLClientSupplierTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/streams/KSMLClientSupplierTest.java
@@ -4,7 +4,7 @@ package io.axual.ksml.runner.streams;
  * ========================LICENSE_START=================================
  * KSML Runner
  * %%
- * Copyright (C) 2021 - 2024 Axual B.V.
+ * Copyright (C) 2021 - 2026 Axual B.V.
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -69,7 +68,6 @@ class KSMLClientSupplierTest {
             assertThat(config)
                     .containsEntry(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getCanonicalName())
                     .containsEntry(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getCanonicalName());
-            producer.close(Duration.ZERO);
         }
     }
 
@@ -88,16 +86,22 @@ class KSMLClientSupplierTest {
     @Test
     @DisplayName("getRestoreConsumer and getGlobalConsumer delegate to getConsumer")
     void restoreAndGlobalConsumersDelegateToGetConsumer() {
+        // Both delegate to getConsumer, so each must return a resolving consumer and have both
+        // byte-array deserializers injected into its config (the side effect getConsumer performs).
         final var restoreConfig = baseConfig();
         try (var restore = SUPPLIER.getRestoreConsumer(restoreConfig)) {
             assertThat(restore).isInstanceOf(ResolvingConsumer.class);
-            assertThat(restoreConfig).containsKey(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG);
+            assertThat(restoreConfig)
+                    .containsEntry(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getCanonicalName())
+                    .containsEntry(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getCanonicalName());
         }
 
         final var globalConfig = baseConfig();
         try (var global = SUPPLIER.getGlobalConsumer(globalConfig)) {
             assertThat(global).isInstanceOf(ResolvingConsumer.class);
-            assertThat(globalConfig).containsKey(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG);
+            assertThat(globalConfig)
+                    .containsEntry(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getCanonicalName())
+                    .containsEntry(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getCanonicalName());
         }
     }
 }

--- a/ksml-runner/src/test/java/io/axual/ksml/runner/streams/KSMLClientSupplierTest.java
+++ b/ksml-runner/src/test/java/io/axual/ksml/runner/streams/KSMLClientSupplierTest.java
@@ -1,0 +1,103 @@
+package io.axual.ksml.runner.streams;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Runner
+ * %%
+ * Copyright (C) 2021 - 2024 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import io.axual.ksml.client.admin.ResolvingAdmin;
+import io.axual.ksml.client.consumer.ResolvingConsumer;
+import io.axual.ksml.client.producer.ResolvingProducer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link KSMLClientSupplier}. Kafka clients connect lazily, so these construct real
+ * (unconnected) clients against a dummy broker address and close them immediately. The behaviour under
+ * test is the (de)serializer injection and that each factory returns the resolving client variant.
+ */
+class KSMLClientSupplierTest {
+
+    private static final KSMLClientSupplier SUPPLIER = new KSMLClientSupplier();
+
+    private static Map<String, Object> baseConfig() {
+        final var config = new HashMap<String, Object>();
+        config.put("bootstrap.servers", "localhost:9092");
+        return config;
+    }
+
+    @Test
+    @DisplayName("getAdmin returns a resolving admin client")
+    void getAdminReturnsResolvingAdmin() {
+        final var config = baseConfig();
+        try (var admin = SUPPLIER.getAdmin(config)) {
+            assertThat(admin).isInstanceOf(ResolvingAdmin.class);
+        }
+    }
+
+    @Test
+    @DisplayName("getProducer injects the byte-array serializers and returns a resolving producer")
+    void getProducerInjectsSerializers() {
+        final var config = baseConfig();
+        try (var producer = SUPPLIER.getProducer(config)) {
+            assertThat(producer).isInstanceOf(ResolvingProducer.class);
+            assertThat(config)
+                    .containsEntry(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getCanonicalName())
+                    .containsEntry(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getCanonicalName());
+            producer.close(Duration.ZERO);
+        }
+    }
+
+    @Test
+    @DisplayName("getConsumer injects the byte-array deserializers and returns a resolving consumer")
+    void getConsumerInjectsDeserializers() {
+        final var config = baseConfig();
+        try (var consumer = SUPPLIER.getConsumer(config)) {
+            assertThat(consumer).isInstanceOf(ResolvingConsumer.class);
+            assertThat(config)
+                    .containsEntry(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getCanonicalName())
+                    .containsEntry(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getCanonicalName());
+        }
+    }
+
+    @Test
+    @DisplayName("getRestoreConsumer and getGlobalConsumer delegate to getConsumer")
+    void restoreAndGlobalConsumersDelegateToGetConsumer() {
+        final var restoreConfig = baseConfig();
+        try (var restore = SUPPLIER.getRestoreConsumer(restoreConfig)) {
+            assertThat(restore).isInstanceOf(ResolvingConsumer.class);
+            assertThat(restoreConfig).containsKey(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG);
+        }
+
+        final var globalConfig = baseConfig();
+        try (var global = SUPPLIER.getGlobalConsumer(globalConfig)) {
+            assertThat(global).isInstanceOf(ResolvingConsumer.class);
+            assertThat(globalConfig).containsKey(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG);
+        }
+    }
+}

--- a/ksml-runner/src/test/resources/load-definition-test.yaml
+++ b/ksml-runner/src/test/resources/load-definition-test.yaml
@@ -1,0 +1,6 @@
+# Minimal KSML definition used by KSMLConfig file-loading tests.
+streams:
+  some_stream:
+    topic: some_topic
+    keyType: string
+    valueType: string


### PR DESCRIPTION
Increase ksml-runner test coverage + reduce complexity

Adds unit tests across the ksml-runner package and refactors three classes to make that logic testable and to lower cognitive complexity — with no change to runtime behavior.

Production (refactoring only):
- KSMLRunner — split the monolithic main() into small, testable static helpers (notation registration, definition parsing/splitting, runner creation, orchestration, error handling).
- ExecutableProducer — introduced a ProducerTarget parameter object, extracted the message-shaping logic into pure static methods, and broke produceMessages/generateBatch into helpers to satisfy Sonar complexity (S3776) and single-jump (S135) rules.
- KafkaProducerRunner — split run() into a registration phase and the produce loop.

Tests:
- New/expanded unit tests for the runner, producer, config, notation, exception, logging and streams packages (AssertJ throughout, following project conventions).

Build:
- Fixed the ksml-runner Surefire config so the JaCoCo agent attaches, so coverage is now reported for this module.