### PR TITLE
Add unit test to ksml-data module

### DIFF
--- a/ksml-data/src/test/java/io/axual/ksml/data/compare/EqualityFlagsTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/compare/EqualityFlagsTest.java
@@ -1,0 +1,92 @@
+package io.axual.ksml.data.compare;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Data Library
+ * %%
+ * Copyright (C) 2021 - 2026 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import io.axual.ksml.data.object.DataObjectFlag;
+import io.axual.ksml.data.schema.DataSchemaFlag;
+import io.axual.ksml.data.type.DataTypeFlag;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EqualityFlagsTest {
+
+    @Test
+    @DisplayName("An empty instance has no flags set")
+    void emptyHasNothingSet() {
+        final var flags = new EqualityFlags();
+
+        assertThat(flags.isSet(DataObjectFlag.IGNORE_DATA_TUPLE_TYPE)).isFalse();
+        assertThat(flags.getAll()).isEmpty();
+        assertThat(flags.isSet(null)).isFalse();
+        assertThat(EqualityFlags.EMPTY.getAll()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Varargs constructor routes each flag to its category and isSet reflects it")
+    void varargsConstructorRoutesFlags() {
+        final var flags = new EqualityFlags(
+                DataObjectFlag.IGNORE_DATA_TUPLE_TYPE,
+                DataTypeFlag.IGNORE_UNION_TYPE_MEMBER_NAME,
+                DataSchemaFlag.IGNORE_UNION_SCHEMA_MEMBER_NAME);
+
+        assertThat(flags.isSet(DataObjectFlag.IGNORE_DATA_TUPLE_TYPE)).isTrue();
+        assertThat(flags.isSet(DataTypeFlag.IGNORE_UNION_TYPE_MEMBER_NAME)).isTrue();
+        assertThat(flags.isSet(DataSchemaFlag.IGNORE_UNION_SCHEMA_MEMBER_NAME)).isTrue();
+        assertThat(flags.isSet(DataObjectFlag.IGNORE_DATA_MAP_TYPE)).isFalse();
+        assertThat(flags.getAll()).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("Set constructor initialises from the provided flags")
+    void setConstructor() {
+        final var flags = new EqualityFlags(Set.of(DataObjectFlag.IGNORE_DATA_TUPLE_TYPE));
+
+        assertThat(flags.isSet(DataObjectFlag.IGNORE_DATA_TUPLE_TYPE)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Copy constructor keeps existing flags and adds new ones")
+    void copyConstructorAddsFlags() {
+        final var base = new EqualityFlags(DataObjectFlag.IGNORE_DATA_TUPLE_TYPE);
+
+        final var extended = new EqualityFlags(base, DataTypeFlag.IGNORE_UNION_TYPE_MEMBER_TAG);
+
+        assertThat(extended.isSet(DataObjectFlag.IGNORE_DATA_TUPLE_TYPE)).isTrue();
+        assertThat(extended.isSet(DataTypeFlag.IGNORE_UNION_TYPE_MEMBER_TAG)).isTrue();
+    }
+
+    @Test
+    @DisplayName("ifSetThenAdd only extends the flags when the queried flag is set")
+    void ifSetThenAdd() {
+        final var base = new EqualityFlags(DataObjectFlag.IGNORE_DATA_TUPLE_TYPE);
+
+        final var added = base.ifSetThenAdd(DataObjectFlag.IGNORE_DATA_TUPLE_TYPE, DataTypeFlag.IGNORE_UNION_TYPE_MEMBER_TAG);
+        assertThat(added.isSet(DataTypeFlag.IGNORE_UNION_TYPE_MEMBER_TAG)).isTrue();
+
+        // When the queried flag is not set, the same instance is returned unchanged.
+        final var unchanged = base.ifSetThenAdd(DataObjectFlag.IGNORE_DATA_MAP_TYPE, DataTypeFlag.IGNORE_UNION_TYPE_MEMBER_TAG);
+        assertThat(unchanged).isSameAs(base);
+    }
+}

--- a/ksml-data/src/test/java/io/axual/ksml/data/compare/EqualityTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/compare/EqualityTest.java
@@ -71,7 +71,6 @@ class EqualityTest {
     void toStringRendersChain() {
         final var chained = Equality.notEqual("outer", Equality.notEqual("inner"));
 
-        assertThat(chained.toString()).contains("outer");
-        assertThat(chained.toString()).contains("caused by:").contains("inner");
+        assertThat(chained).asString().contains("outer").contains("caused by:").contains("inner");
     }
 }

--- a/ksml-data/src/test/java/io/axual/ksml/data/compare/EqualityTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/compare/EqualityTest.java
@@ -1,0 +1,77 @@
+package io.axual.ksml.data.compare;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Data Library
+ * %%
+ * Copyright (C) 2021 - 2026 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class EqualityTest {
+
+    @Test
+    @DisplayName("equal() is the OK state: equal, not-not-equal, no message")
+    void equalState() {
+        final var equality = Equality.equal();
+
+        assertThat(equality.isEqual()).isTrue();
+        assertThat(equality.isNotEqual()).isFalse();
+        assertThat(equality.message()).isNull();
+        assertThat(equality.cause()).isNull();
+    }
+
+    @Test
+    @DisplayName("notEqual(message) carries the message and no cause")
+    void notEqualWithMessage() {
+        final var equality = Equality.notEqual("they differ");
+
+        assertThat(equality.isEqual()).isFalse();
+        assertThat(equality.isNotEqual()).isTrue();
+        assertThat(equality.message()).isEqualTo("they differ");
+        assertThat(equality.cause()).isNull();
+    }
+
+    @Test
+    @DisplayName("notEqual stores a non-equal cause but drops an OK cause")
+    void notEqualCauseHandling() {
+        final var realCause = Equality.notEqual("inner reason");
+
+        assertThat(Equality.notEqual("outer", realCause).cause()).isSameAs(realCause);
+        // An OK cause is meaningless for an inequality, so it is dropped.
+        assertThat(Equality.notEqual("outer", Equality.equal()).cause()).isNull();
+    }
+
+    @Test
+    @DisplayName("notEqual(null) is rejected")
+    void notEqualRejectsNullMessage() {
+        assertThatThrownBy(() -> Equality.notEqual(null)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("toString renders the message and chains causes with 'caused by:'")
+    void toStringRendersChain() {
+        final var chained = Equality.notEqual("outer", Equality.notEqual("inner"));
+
+        assertThat(chained.toString()).contains("outer");
+        assertThat(chained.toString()).contains("caused by:").contains("inner");
+    }
+}

--- a/ksml-data/src/test/java/io/axual/ksml/data/exception/DataExceptionTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/exception/DataExceptionTest.java
@@ -33,22 +33,22 @@ class DataExceptionTest {
     @Test
     @DisplayName("Message and cause constructors retain their inputs")
     void messageAndCause() {
-        assertThat(new DataException("boom").getMessage()).contains("boom");
+        assertThat(new DataException("boom")).hasMessageContaining("boom");
 
         final var cause = new IllegalStateException("root");
         final var exception = new DataException("boom", cause);
-        assertThat(exception.getMessage()).contains("boom");
+        assertThat(exception).hasMessageContaining("boom");
         assertThat(exception.getCause()).isSameAs(cause);
     }
 
     @Test
     @DisplayName("conversionFailed factories describe the source and target types")
     void conversionFailedFactories() {
-        assertThat(DataException.conversionFailed(DataInteger.DATATYPE, DataLong.DATATYPE).getMessage())
-                .isNotBlank();
-        assertThat(DataException.conversionFailed(DataInteger.DATATYPE, DataLong.DATATYPE, Assignable.notAssignable("reason")).getMessage())
-                .contains("reason");
-        assertThat(DataException.conversionFailed("fromType", "toType").getMessage())
-                .contains("fromType").contains("toType");
+        assertThat(DataException.conversionFailed(DataInteger.DATATYPE, DataLong.DATATYPE))
+                .message().isNotBlank();
+        assertThat(DataException.conversionFailed(DataInteger.DATATYPE, DataLong.DATATYPE, Assignable.notAssignable("reason")))
+                .hasMessageContaining("reason");
+        assertThat(DataException.conversionFailed("fromType", "toType"))
+                .hasMessageContaining("fromType").hasMessageContaining("toType");
     }
 }

--- a/ksml-data/src/test/java/io/axual/ksml/data/exception/DataExceptionTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/exception/DataExceptionTest.java
@@ -1,0 +1,54 @@
+package io.axual.ksml.data.exception;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Data Library
+ * %%
+ * Copyright (C) 2021 - 2026 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import io.axual.ksml.data.compare.Assignable;
+import io.axual.ksml.data.object.DataInteger;
+import io.axual.ksml.data.object.DataLong;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DataExceptionTest {
+
+    @Test
+    @DisplayName("Message and cause constructors retain their inputs")
+    void messageAndCause() {
+        assertThat(new DataException("boom").getMessage()).contains("boom");
+
+        final var cause = new IllegalStateException("root");
+        final var exception = new DataException("boom", cause);
+        assertThat(exception.getMessage()).contains("boom");
+        assertThat(exception.getCause()).isSameAs(cause);
+    }
+
+    @Test
+    @DisplayName("conversionFailed factories describe the source and target types")
+    void conversionFailedFactories() {
+        assertThat(DataException.conversionFailed(DataInteger.DATATYPE, DataLong.DATATYPE).getMessage())
+                .isNotBlank();
+        assertThat(DataException.conversionFailed(DataInteger.DATATYPE, DataLong.DATATYPE, Assignable.notAssignable("reason")).getMessage())
+                .contains("reason");
+        assertThat(DataException.conversionFailed("fromType", "toType").getMessage())
+                .contains("fromType").contains("toType");
+    }
+}

--- a/ksml-data/src/test/java/io/axual/ksml/data/notation/NotationProviderTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/notation/NotationProviderTest.java
@@ -44,4 +44,49 @@ class NotationProviderTest {
         assertThat(provider.vendorName()).isNull();
         assertThat(provider.notationName()).isEqualTo("avro");
     }
+
+    @Test
+    @DisplayName("name() combines vendor and notation, uses notation alone when no vendor, and is null without a notation name")
+    void nameCombining() {
+        final var vendored = new NotationProvider() {
+            @Override
+            public String notationName() {
+                return "avro";
+            }
+
+            @Override
+            public String vendorName() {
+                return "confluent";
+            }
+
+            @Override
+            public Notation createNotation(NotationContext notationContext) {
+                return null;
+            }
+        };
+        assertThat(vendored.name()).isEqualTo("confluent_avro");
+
+        final var plain = new NotationProvider() {
+            @Override
+            public String notationName() {
+                return "json";
+            }
+
+            @Override
+            public Notation createNotation(NotationContext notationContext) {
+                return null;
+            }
+        };
+        assertThat(plain.name()).isEqualTo("json");
+
+        final var anonymous = new NotationProvider() {
+            @Override
+            public Notation createNotation(NotationContext notationContext) {
+                return null;
+            }
+        };
+        assertThat(anonymous.name()).isNull();
+        // The no-arg createNotation() default delegates to createNotation(null)
+        assertThat(anonymous.createNotation()).isNull();
+    }
 }

--- a/ksml-data/src/test/java/io/axual/ksml/data/notation/NotationProviderTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/notation/NotationProviderTest.java
@@ -56,7 +56,7 @@ class NotationProviderTest {
 
             @Override
             public String vendorName() {
-                return "confluent";
+                return "axual";
             }
 
             @Override
@@ -64,7 +64,7 @@ class NotationProviderTest {
                 return null;
             }
         };
-        assertThat(vendored.name()).isEqualTo("confluent_avro");
+        assertThat(vendored.name()).isEqualTo("axual_avro");
 
         final var plain = new NotationProvider() {
             @Override
@@ -73,10 +73,16 @@ class NotationProviderTest {
             }
 
             @Override
+            public String vendorName() {
+                return null; // explicit: no vendor
+            }
+
+            @Override
             public Notation createNotation(NotationContext notationContext) {
                 return null;
             }
         };
+        assertThat(plain.vendorName()).isNull(); // documents the assumption name() relies on
         assertThat(plain.name()).isEqualTo("json");
 
         final var anonymous = new NotationProvider() {

--- a/ksml-data/src/test/java/io/axual/ksml/data/notation/NotationStub.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/notation/NotationStub.java
@@ -1,0 +1,75 @@
+package io.axual.ksml.data.notation;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Data Library
+ * %%
+ * Copyright (C) 2021 - 2026 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import io.axual.ksml.data.type.DataType;
+import org.apache.kafka.common.serialization.Serde;
+
+/**
+ * Minimal configurable {@link Notation} stub for tests. Only the name, filename extension and
+ * converter vary between usages; every other method returns {@code null}.
+ */
+public class NotationStub implements Notation {
+    private final String name;
+    private final String filenameExtension;
+    private final Converter converter;
+
+    public NotationStub(String name, String filenameExtension, Converter converter) {
+        this.name = name;
+        this.filenameExtension = filenameExtension;
+        this.converter = converter;
+    }
+
+    @Override
+    public SchemaUsage schemaUsage() {
+        return null;
+    }
+
+    @Override
+    public DataType defaultType() {
+        return null;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public String filenameExtension() {
+        return filenameExtension;
+    }
+
+    @Override
+    public Serde<Object> serde(DataType type, boolean isKey) {
+        return null;
+    }
+
+    @Override
+    public Converter converter() {
+        return converter;
+    }
+
+    @Override
+    public SchemaParser schemaParser() {
+        return null;
+    }
+}

--- a/ksml-data/src/test/java/io/axual/ksml/data/notation/NotationTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/notation/NotationTest.java
@@ -1,0 +1,80 @@
+package io.axual.ksml.data.notation;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Data Library
+ * %%
+ * Copyright (C) 2021 - 2026 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import io.axual.ksml.data.type.DataType;
+import org.apache.kafka.common.serialization.Serde;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NotationTest {
+
+    /** A minimal Notation implementation so the interface's default methods can be exercised. */
+    private static Notation minimalNotation() {
+        return new Notation() {
+            @Override
+            public Notation.SchemaUsage schemaUsage() {
+                return null;
+            }
+
+            @Override
+            public DataType defaultType() {
+                return null;
+            }
+
+            @Override
+            public String name() {
+                return "test";
+            }
+
+            @Override
+            public String filenameExtension() {
+                return ".test";
+            }
+
+            @Override
+            public Serde<Object> serde(DataType type, boolean isKey) {
+                return null;
+            }
+
+            @Override
+            public Notation.Converter converter() {
+                return null;
+            }
+
+            @Override
+            public Notation.SchemaParser schemaParser() {
+                return null;
+            }
+        };
+    }
+
+    @Test
+    @DisplayName("Remote-schema support defaults to false and fetchRemoteSchema defaults to null")
+    void remoteSchemaDefaults() {
+        final var notation = minimalNotation();
+
+        assertThat(notation.supportsRemoteSchema()).isFalse();
+        assertThat(notation.fetchRemoteSchema("topic", false)).isNull();
+    }
+}

--- a/ksml-data/src/test/java/io/axual/ksml/data/notation/NotationTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/notation/NotationTest.java
@@ -20,8 +20,6 @@ package io.axual.ksml.data.notation;
  * =========================LICENSE_END==================================
  */
 
-import io.axual.ksml.data.type.DataType;
-import org.apache.kafka.common.serialization.Serde;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -31,42 +29,7 @@ class NotationTest {
 
     /** A minimal Notation implementation so the interface's default methods can be exercised. */
     private static Notation minimalNotation() {
-        return new Notation() {
-            @Override
-            public Notation.SchemaUsage schemaUsage() {
-                return null;
-            }
-
-            @Override
-            public DataType defaultType() {
-                return null;
-            }
-
-            @Override
-            public String name() {
-                return "test";
-            }
-
-            @Override
-            public String filenameExtension() {
-                return ".test";
-            }
-
-            @Override
-            public Serde<Object> serde(DataType type, boolean isKey) {
-                return null;
-            }
-
-            @Override
-            public Notation.Converter converter() {
-                return null;
-            }
-
-            @Override
-            public Notation.SchemaParser schemaParser() {
-                return null;
-            }
-        };
+        return new NotationStub("test", ".test", null);
     }
 
     @Test

--- a/ksml-data/src/test/java/io/axual/ksml/data/schema/DataSchemaConstantsTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/schema/DataSchemaConstantsTest.java
@@ -23,8 +23,6 @@ package io.axual.ksml.data.schema;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Constructor;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 class DataSchemaConstantsTest {
@@ -42,15 +40,9 @@ class DataSchemaConstantsTest {
     @Test
     @DisplayName("Constants carry their documented values")
     void constants() {
-        assertThat(DataSchemaConstants.NO_TAG).isEqualTo(-1);
-        assertThat(DataSchemaConstants.DATA_SCHEMA_KSML_NAMESPACE).isEqualTo("io.axual.ksml.data");
-    }
-
-    @Test
-    @DisplayName("The utility class cannot meaningfully be instantiated (private constructor)")
-    void privateConstructor() throws Exception {
-        final Constructor<DataSchemaConstants> constructor = DataSchemaConstants.class.getDeclaredConstructor();
-        constructor.setAccessible(true);
-        assertThat(constructor.newInstance()).isNotNull();
+        final int noTag = DataSchemaConstants.NO_TAG;
+        final String namespace = DataSchemaConstants.DATA_SCHEMA_KSML_NAMESPACE;
+        assertThat(noTag).isEqualTo(-1);
+        assertThat(namespace).isEqualTo("io.axual.ksml.data");
     }
 }

--- a/ksml-data/src/test/java/io/axual/ksml/data/schema/DataSchemaConstantsTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/schema/DataSchemaConstantsTest.java
@@ -36,13 +36,4 @@ class DataSchemaConstantsTest {
         assertThat(DataSchemaConstants.isType(DataSchemaConstants.STRUCT_TYPE)).isTrue();
         assertThat(DataSchemaConstants.isType("not-a-type")).isFalse();
     }
-
-    @Test
-    @DisplayName("Constants carry their documented values")
-    void constants() {
-        final var noTag = DataSchemaConstants.NO_TAG;
-        final var namespace = DataSchemaConstants.DATA_SCHEMA_KSML_NAMESPACE;
-        assertThat(noTag).isEqualTo(-1);
-        assertThat(namespace).isEqualTo("io.axual.ksml.data");
-    }
 }

--- a/ksml-data/src/test/java/io/axual/ksml/data/schema/DataSchemaConstantsTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/schema/DataSchemaConstantsTest.java
@@ -1,0 +1,56 @@
+package io.axual.ksml.data.schema;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Data Library
+ * %%
+ * Copyright (C) 2021 - 2026 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DataSchemaConstantsTest {
+
+    @Test
+    @DisplayName("isType recognises every known schema type name and rejects unknown ones")
+    void isType() {
+        assertThat(DataSchemaConstants.isType(DataSchemaConstants.STRING_TYPE)).isTrue();
+        assertThat(DataSchemaConstants.isType(DataSchemaConstants.INTEGER_TYPE)).isTrue();
+        assertThat(DataSchemaConstants.isType(DataSchemaConstants.UNION_TYPE)).isTrue();
+        assertThat(DataSchemaConstants.isType(DataSchemaConstants.STRUCT_TYPE)).isTrue();
+        assertThat(DataSchemaConstants.isType("not-a-type")).isFalse();
+    }
+
+    @Test
+    @DisplayName("Constants carry their documented values")
+    void constants() {
+        assertThat(DataSchemaConstants.NO_TAG).isEqualTo(-1);
+        assertThat(DataSchemaConstants.DATA_SCHEMA_KSML_NAMESPACE).isEqualTo("io.axual.ksml.data");
+    }
+
+    @Test
+    @DisplayName("The utility class cannot meaningfully be instantiated (private constructor)")
+    void privateConstructor() throws Exception {
+        final Constructor<DataSchemaConstants> constructor = DataSchemaConstants.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        assertThat(constructor.newInstance()).isNotNull();
+    }
+}

--- a/ksml-data/src/test/java/io/axual/ksml/data/schema/DataSchemaConstantsTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/schema/DataSchemaConstantsTest.java
@@ -40,8 +40,8 @@ class DataSchemaConstantsTest {
     @Test
     @DisplayName("Constants carry their documented values")
     void constants() {
-        final int noTag = DataSchemaConstants.NO_TAG;
-        final String namespace = DataSchemaConstants.DATA_SCHEMA_KSML_NAMESPACE;
+        final var noTag = DataSchemaConstants.NO_TAG;
+        final var namespace = DataSchemaConstants.DATA_SCHEMA_KSML_NAMESPACE;
         assertThat(noTag).isEqualTo(-1);
         assertThat(namespace).isEqualTo("io.axual.ksml.data");
     }

--- a/ksml-data/src/test/java/io/axual/ksml/data/schema/EnumSchemaTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/schema/EnumSchemaTest.java
@@ -20,6 +20,7 @@ package io.axual.ksml.data.schema;
  * =========================LICENSE_END==================================
  */
 
+import io.axual.ksml.data.compare.EqualityFlags;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -46,5 +47,39 @@ class EnumSchemaTest {
 
         // No overlap: should be false
         assertThat(colors.isAssignableFrom(blueOnly).isAssignable()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Symbol exposes name/doc/tag; the name-only constructor defaults doc and tag")
+    void symbolAccessors() {
+        final var full = new EnumSchema.Symbol("RED", "the colour red", 3);
+        assertThat(full.name()).isEqualTo("RED");
+        assertThat(full.doc()).isEqualTo("the colour red");
+        assertThat(full.tag()).isEqualTo(3);
+
+        final var nameOnly = new EnumSchema.Symbol("GREEN");
+        assertThat(nameOnly.name()).isEqualTo("GREEN");
+        assertThat(nameOnly.doc()).isNull();
+    }
+
+    @Test
+    @DisplayName("symbols() returns the configured symbols")
+    void symbolsAccessor() {
+        final var colors = new EnumSchema("ns", "Color", "doc", List.of(new EnumSchema.Symbol("RED"), new EnumSchema.Symbol("GREEN")));
+
+        assertThat(colors.symbols()).hasSize(2);
+        assertThat(colors.symbols().get(0).name()).isEqualTo("RED");
+    }
+
+    @Test
+    @DisplayName("Deep equals treats enums with the same symbols as equal and differing symbols as not equal")
+    void deepEquals() {
+        final var colors = new EnumSchema("ns", "Color", "doc", List.of(new EnumSchema.Symbol("RED")));
+        final var sameColors = new EnumSchema("ns", "Color", "doc", List.of(new EnumSchema.Symbol("RED")));
+        final var otherColors = new EnumSchema("ns", "Color", "doc", List.of(new EnumSchema.Symbol("BLUE")));
+
+        assertThat(colors.equals(sameColors, EqualityFlags.EMPTY).isEqual()).isTrue();
+        assertThat(colors.equals(otherColors, EqualityFlags.EMPTY).isNotEqual()).isTrue();
+        assertThat(colors.equals(DataSchema.STRING_SCHEMA, EqualityFlags.EMPTY).isNotEqual()).isTrue();
     }
 }

--- a/ksml-data/src/test/java/io/axual/ksml/data/schema/EnumSchemaTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/schema/EnumSchemaTest.java
@@ -67,8 +67,9 @@ class EnumSchemaTest {
     void symbolsAccessor() {
         final var colors = new EnumSchema("ns", "Color", "doc", List.of(new EnumSchema.Symbol("RED"), new EnumSchema.Symbol("GREEN")));
 
-        assertThat(colors.symbols()).hasSize(2);
-        assertThat(colors.symbols().get(0).name()).isEqualTo("RED");
+        final var symbols = colors.symbols();
+        assertThat(symbols).hasSize(2);
+        assertThat(symbols.get(0).name()).isEqualTo("RED");
     }
 
     @Test

--- a/ksml-data/src/test/java/io/axual/ksml/data/schema/FixedSchemaTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/schema/FixedSchemaTest.java
@@ -20,6 +20,7 @@ package io.axual.ksml.data.schema;
  * =========================LICENSE_END==================================
  */
 
+import io.axual.ksml.data.compare.EqualityFlags;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -58,5 +59,15 @@ class FixedSchemaTest {
 
         // null not assignable
         assertThat(eight.isAssignableFrom(null).isAssignable()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Deep equals compares type and size")
+    void deepEquals() {
+        final var eight = new FixedSchema("ns", "F", "", 8);
+
+        assertThat(eight.equals(new FixedSchema("ns", "F", "", 8), EqualityFlags.EMPTY).isEqual()).isTrue();
+        assertThat(eight.equals(new FixedSchema("ns", "F", "", 4), EqualityFlags.EMPTY).isNotEqual()).isTrue();
+        assertThat(eight.equals(DataSchema.STRING_SCHEMA, EqualityFlags.EMPTY).isNotEqual()).isTrue();
     }
 }

--- a/ksml-data/src/test/java/io/axual/ksml/data/schema/ListSchemaTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/schema/ListSchemaTest.java
@@ -20,6 +20,7 @@ package io.axual.ksml.data.schema;
  * =========================LICENSE_END==================================
  */
 
+import io.axual.ksml.data.compare.EqualityFlags;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -70,5 +71,15 @@ class ListSchemaTest {
         assertThat(listOfInt.isAssignableFrom(DataSchema.STRING_SCHEMA).isAssignable()).isFalse();
         // Null not assignable
         assertThat(listOfInt.isAssignableFrom(null).isAssignable()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Deep equals compares the value schema")
+    void deepEquals() {
+        final var listOfInt = new ListSchema(DataSchema.INTEGER_SCHEMA);
+
+        assertThat(listOfInt.equals(new ListSchema(DataSchema.INTEGER_SCHEMA), EqualityFlags.EMPTY).isEqual()).isTrue();
+        assertThat(listOfInt.equals(new ListSchema(DataSchema.STRING_SCHEMA), EqualityFlags.EMPTY).isNotEqual()).isTrue();
+        assertThat(listOfInt.equals(DataSchema.STRING_SCHEMA, EqualityFlags.EMPTY).isNotEqual()).isTrue();
     }
 }

--- a/ksml-data/src/test/java/io/axual/ksml/data/schema/MapSchemaTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/schema/MapSchemaTest.java
@@ -20,6 +20,7 @@ package io.axual.ksml.data.schema;
  * =========================LICENSE_END==================================
  */
 
+import io.axual.ksml.data.compare.EqualityFlags;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -66,5 +67,15 @@ class MapSchemaTest {
         assertThat(mapOfInt.isAssignableFrom(DataSchema.STRING_SCHEMA).isAssignable()).isFalse();
         // Null not assignable
         assertThat(mapOfInt.isAssignableFrom(null).isAssignable()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Deep equals compares the value schema")
+    void deepEquals() {
+        final var mapOfInt = new MapSchema(DataSchema.INTEGER_SCHEMA);
+
+        assertThat(mapOfInt.equals(new MapSchema(DataSchema.INTEGER_SCHEMA), EqualityFlags.EMPTY).isEqual()).isTrue();
+        assertThat(mapOfInt.equals(new MapSchema(DataSchema.STRING_SCHEMA), EqualityFlags.EMPTY).isNotEqual()).isTrue();
+        assertThat(mapOfInt.equals(DataSchema.STRING_SCHEMA, EqualityFlags.EMPTY).isNotEqual()).isTrue();
     }
 }

--- a/ksml-data/src/test/java/io/axual/ksml/data/schema/StructFieldTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/schema/StructFieldTest.java
@@ -20,6 +20,7 @@ package io.axual.ksml.data.schema;
  * =========================LICENSE_END==================================
  */
 
+import io.axual.ksml.data.compare.EqualityFlags;
 import io.axual.ksml.data.object.DataNull;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
@@ -98,5 +99,17 @@ class StructSchemaFieldTest {
         assertThat(target.isAssignableFrom(otherFloat).isAssignable()).isFalse();
         // null is not assignable
         assertThat(target.isAssignableFrom(null).isAssignable()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Deep equals compares the field attributes (name, schema, tag, ...)")
+    void deepEquals() {
+        final var base = new StructSchema.Field("id", DataSchema.INTEGER_SCHEMA, "doc", 1);
+
+        assertThat(base.equals(new StructSchema.Field("id", DataSchema.INTEGER_SCHEMA, "doc", 1), EqualityFlags.EMPTY).isEqual()).isTrue();
+        assertThat(base.equals(new StructSchema.Field("other", DataSchema.INTEGER_SCHEMA, "doc", 1), EqualityFlags.EMPTY).isNotEqual()).isTrue();
+        assertThat(base.equals(new StructSchema.Field("id", DataSchema.STRING_SCHEMA, "doc", 1), EqualityFlags.EMPTY).isNotEqual()).isTrue();
+        assertThat(base.equals(null, EqualityFlags.EMPTY).isNotEqual()).isTrue();
+        assertThat(base.equals("not-a-field", EqualityFlags.EMPTY).isNotEqual()).isTrue();
     }
 }

--- a/ksml-data/src/test/java/io/axual/ksml/data/schema/StructSchemaTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/schema/StructSchemaTest.java
@@ -20,6 +20,7 @@ package io.axual.ksml.data.schema;
  * =========================LICENSE_END==================================
  */
 
+import io.axual.ksml.data.compare.EqualityFlags;
 import io.axual.ksml.data.object.DataString;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -335,5 +336,29 @@ class StructSchemaTest {
 
         assertThat(schema2.additionalFieldsAllowed()).isTrue();
         assertThat(schema2.additionalFieldsSchema()).isEqualTo(DataSchema.ANY_SCHEMA);
+    }
+
+    @Test
+    @DisplayName("field(name) returns the matching field and null when absent; field(index) returns by position")
+    void fieldLookup() {
+        final var schema = new StructSchema("ns", "Person", null, List.of(requiredInt("id"), optionalStringWithDefault("name")));
+
+        assertThat(schema.field("id")).isNotNull();
+        assertThat(schema.field("id").name()).isEqualTo("id");
+        assertThat(schema.field("missing")).isNull();
+        assertThat(schema.field(1).name()).isEqualTo("name");
+    }
+
+    @Test
+    @DisplayName("Deep equals(Object, EqualityFlags): equal fields are equal; differing fields, null and foreign types are not")
+    void deepEquals() {
+        final var base = new StructSchema("ns", "Person", null, List.of(requiredInt("id")));
+        final var same = new StructSchema("ns", "Person", null, List.of(requiredInt("id")));
+        final var different = new StructSchema("ns", "Person", null, List.of(requiredInt("other")));
+
+        assertThat(base.equals(same, EqualityFlags.EMPTY).isEqual()).isTrue();
+        assertThat(base.equals(different, EqualityFlags.EMPTY).isNotEqual()).isTrue();
+        assertThat(base.equals(null, EqualityFlags.EMPTY).isNotEqual()).isTrue();
+        assertThat(base.equals(DataSchema.STRING_SCHEMA, EqualityFlags.EMPTY).isNotEqual()).isTrue();
     }
 }

--- a/ksml-data/src/test/java/io/axual/ksml/data/schema/StructSchemaTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/schema/StructSchemaTest.java
@@ -343,8 +343,9 @@ class StructSchemaTest {
     void fieldLookup() {
         final var schema = new StructSchema("ns", "Person", null, List.of(requiredInt("id"), optionalStringWithDefault("name")));
 
-        assertThat(schema.field("id")).isNotNull();
-        assertThat(schema.field("id").name()).isEqualTo("id");
+        final var idField = schema.field("id");
+        assertThat(idField).isNotNull();
+        assertThat(idField.name()).isEqualTo("id");
         assertThat(schema.field("missing")).isNull();
         assertThat(schema.field(1).name()).isEqualTo("name");
     }

--- a/ksml-data/src/test/java/io/axual/ksml/data/schema/UnionSchemaMemberTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/schema/UnionSchemaMemberTest.java
@@ -1,0 +1,76 @@
+package io.axual.ksml.data.schema;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Data Library
+ * %%
+ * Copyright (C) 2021 - 2026 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import io.axual.ksml.data.compare.EqualityFlags;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UnionSchemaMemberTest {
+
+    private static final int NO_TAG = -1;
+
+    @Test
+    @DisplayName("The convenience constructor defaults name/doc to null and tag to NO_TAG")
+    void convenienceConstructorDefaults() {
+        final var member = new UnionSchema.Member(DataSchema.INTEGER_SCHEMA);
+
+        assertThat(member.name()).isNull();
+        assertThat(member.doc()).isNull();
+        assertThat(member.tag()).isEqualTo(NO_TAG);
+        assertThat(member.schema()).isEqualTo(DataSchema.INTEGER_SCHEMA);
+    }
+
+    @Test
+    @DisplayName("The full constructor exposes all fields")
+    void fullConstructor() {
+        final var member = new UnionSchema.Member("name", DataSchema.INTEGER_SCHEMA, "doc", 7);
+
+        assertThat(member.name()).isEqualTo("name");
+        assertThat(member.schema()).isEqualTo(DataSchema.INTEGER_SCHEMA);
+        assertThat(member.doc()).isEqualTo("doc");
+        assertThat(member.tag()).isEqualTo(7);
+    }
+
+    @Test
+    @DisplayName("Deep equals: equal members are equal; identity short-circuits; null/foreign types are not equal")
+    void deepEqualsBasics() {
+        final var member = new UnionSchema.Member("n", DataSchema.INTEGER_SCHEMA, "d", 1);
+
+        assertThat(member.equals(member, EqualityFlags.EMPTY).isEqual()).isTrue();
+        assertThat(member.equals(new UnionSchema.Member("n", DataSchema.INTEGER_SCHEMA, "d", 1), EqualityFlags.EMPTY).isEqual()).isTrue();
+        assertThat(member.equals(null, EqualityFlags.EMPTY).isNotEqual()).isTrue();
+        assertThat(member.equals("not-a-member", EqualityFlags.EMPTY).isNotEqual()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Deep equals: a difference in any field makes members not equal")
+    void deepEqualsPerField() {
+        final var base = new UnionSchema.Member("n", DataSchema.INTEGER_SCHEMA, "d", 1);
+
+        assertThat(base.equals(new UnionSchema.Member("other", DataSchema.INTEGER_SCHEMA, "d", 1), EqualityFlags.EMPTY).isNotEqual()).isTrue();
+        assertThat(base.equals(new UnionSchema.Member("n", DataSchema.LONG_SCHEMA, "d", 1), EqualityFlags.EMPTY).isNotEqual()).isTrue();
+        assertThat(base.equals(new UnionSchema.Member("n", DataSchema.INTEGER_SCHEMA, "other", 1), EqualityFlags.EMPTY).isNotEqual()).isTrue();
+        assertThat(base.equals(new UnionSchema.Member("n", DataSchema.INTEGER_SCHEMA, "d", 99), EqualityFlags.EMPTY).isNotEqual()).isTrue();
+    }
+}

--- a/ksml-data/src/test/java/io/axual/ksml/data/schema/UnionSchemaTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/schema/UnionSchemaTest.java
@@ -20,6 +20,7 @@ package io.axual.ksml.data.schema;
  * =========================LICENSE_END==================================
  */
 
+import io.axual.ksml.data.compare.EqualityFlags;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -76,5 +77,18 @@ class UnionSchemaTest {
                 new UnionSchema.Member("s", DataSchema.STRING_SCHEMA, "String", 2)
         );
         assertThat(union.isAssignableFrom(anonymous).isAssignable()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Deep equals compares the union members")
+    void deepEquals() {
+        final var union = new UnionSchema(new UnionSchema.Member("i", DataSchema.INTEGER_SCHEMA, "Integer", 1));
+        final var same = new UnionSchema(new UnionSchema.Member("i", DataSchema.INTEGER_SCHEMA, "Integer", 1));
+        final var different = new UnionSchema(new UnionSchema.Member("s", DataSchema.STRING_SCHEMA, "String", 1));
+
+        assertThat(union.equals(same, EqualityFlags.EMPTY).isEqual()).isTrue();
+        assertThat(union.equals(different, EqualityFlags.EMPTY).isNotEqual()).isTrue();
+        assertThat(union.equals(null, EqualityFlags.EMPTY).isNotEqual()).isTrue();
+        assertThat(union.equals(DataSchema.STRING_SCHEMA, EqualityFlags.EMPTY).isNotEqual()).isTrue();
     }
 }

--- a/ksml-data/src/test/java/io/axual/ksml/data/type/EnumTypeTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/type/EnumTypeTest.java
@@ -20,6 +20,7 @@ package io.axual.ksml.data.type;
  * =========================LICENSE_END==================================
  */
 
+import io.axual.ksml.data.compare.EqualityFlags;
 import io.axual.ksml.data.object.DataNull;
 import io.axual.ksml.data.object.DataString;
 import io.axual.ksml.data.schema.EnumSchema;
@@ -70,5 +71,19 @@ class EnumTypeTest {
         softly.assertThat(ds.toString()).isEqualTo("hello");
         softly.assertThat(type.isAssignableFrom(ds).isAssignable()).isTrue();
         softly.assertAll();
+    }
+
+    @Test
+    @DisplayName("Deep equals: equal to an enum with the same symbols, not to a different one, null or a foreign type")
+    void deepEquals() {
+        final var type = new EnumType(new EnumSchema(List.of(new EnumSchema.Symbol("A"))));
+        final var same = new EnumType(new EnumSchema(List.of(new EnumSchema.Symbol("A"))));
+        final var other = new EnumType(new EnumSchema(List.of(new EnumSchema.Symbol("B"))));
+
+        assertThat(type.equals(type, EqualityFlags.EMPTY).isEqual()).isTrue();
+        assertThat(type.equals(same, EqualityFlags.EMPTY).isEqual()).isTrue();
+        assertThat(type.equals(other, EqualityFlags.EMPTY).isNotEqual()).isTrue();
+        assertThat(type.equals(null, EqualityFlags.EMPTY).isNotEqual()).isTrue();
+        assertThat(type.equals("not-an-enum", EqualityFlags.EMPTY).isNotEqual()).isTrue();
     }
 }

--- a/ksml-data/src/test/java/io/axual/ksml/data/type/StructTypeTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/type/StructTypeTest.java
@@ -21,6 +21,7 @@ package io.axual.ksml.data.type;
  */
 
 import io.axual.ksml.data.object.DataNull;
+import io.axual.ksml.data.object.DataString;
 import io.axual.ksml.data.schema.DataSchema;
 import io.axual.ksml.data.schema.DataSchemaConstants;
 import io.axual.ksml.data.schema.StructSchema;
@@ -113,5 +114,25 @@ class StructTypeTest {
         softly.assertThat(s1).isEqualTo(s2);
         softly.assertThat(s1.hashCode()).isEqualTo(s1.hashCode());
         softly.assertAll();
+    }
+
+    @Test
+    @DisplayName("fieldType resolves field types with fallbacks, DataNull is assignable, and CompareFilter keeps tags by default")
+    void fieldTypeFallbacksAndExtras() {
+        final var schema = new StructSchema("ns", "S", null, List.of(new StructSchema.Field("id", DataSchema.INTEGER_SCHEMA, null, 0)));
+        final var type = new StructType(schema);
+
+        // Existing field -> its mapped type (neither fallback)
+        assertThat(type.fieldType("id", DataString.DATATYPE, DataString.DATATYPE)).isNotNull();
+        // Missing field -> the "no such field" fallback
+        assertThat(type.fieldType("missing", DataType.UNKNOWN, DataString.DATATYPE)).isEqualTo(DataString.DATATYPE);
+        // Schemaless struct -> the "no schema" fallback
+        assertThat(new StructType().fieldType("x", DataString.DATATYPE, DataType.UNKNOWN)).isEqualTo(DataString.DATATYPE);
+
+        // A struct type is assignable from DataNull
+        assertThat(type.isAssignableFrom(DataNull.DATATYPE).isAssignable()).isTrue();
+
+        // CompareFilter's default keeps tags (ignoreTags == false)
+        assertThat(new StructType.CompareFilter() {}.ignoreTags()).isFalse();
     }
 }

--- a/ksml-data/src/test/java/io/axual/ksml/data/type/StructTypeTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/type/StructTypeTest.java
@@ -117,22 +117,27 @@ class StructTypeTest {
     }
 
     @Test
-    @DisplayName("fieldType resolves field types with fallbacks, DataNull is assignable, and CompareFilter keeps tags by default")
-    void fieldTypeFallbacksAndExtras() {
+    @DisplayName("fieldType: an existing field resolves to its mapped type; missing and schemaless fall back correctly")
+    void fieldTypeFallbacks() {
         final var schema = new StructSchema("ns", "S", null, List.of(new StructSchema.Field("id", DataSchema.INTEGER_SCHEMA, null, 0)));
         final var type = new StructType(schema);
 
-        // Existing field -> its mapped type (neither fallback)
-        assertThat(type.fieldType("id", DataString.DATATYPE, DataString.DATATYPE)).isNotNull();
-        // Missing field -> the "no such field" fallback
+        assertThat(type.fieldType("id", DataString.DATATYPE, DataString.DATATYPE)).isEqualTo(io.axual.ksml.data.object.DataInteger.DATATYPE);
         assertThat(type.fieldType("missing", DataType.UNKNOWN, DataString.DATATYPE)).isEqualTo(DataString.DATATYPE);
-        // Schemaless struct -> the "no schema" fallback
         assertThat(new StructType().fieldType("x", DataString.DATATYPE, DataType.UNKNOWN)).isEqualTo(DataString.DATATYPE);
+    }
 
-        // A struct type is assignable from DataNull
+    @Test
+    @DisplayName("A StructType is assignable from DataNull")
+    void isAssignableFromDataNull() {
+        final var type = new StructType(new StructSchema("ns", "S", null, List.of()));
+
         assertThat(type.isAssignableFrom(DataNull.DATATYPE).isAssignable()).isTrue();
+    }
 
-        // CompareFilter's default keeps tags (ignoreTags == false)
+    @Test
+    @DisplayName("CompareFilter.ignoreTags() defaults to false")
+    void compareFilterIgnoreTagsDefaultsFalse() {
         assertThat(new StructType.CompareFilter() {}.ignoreTags()).isFalse();
     }
 }

--- a/ksml-data/src/test/java/io/axual/ksml/data/type/StructTypeTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/type/StructTypeTest.java
@@ -20,6 +20,7 @@ package io.axual.ksml.data.type;
  * =========================LICENSE_END==================================
  */
 
+import io.axual.ksml.data.object.DataInteger;
 import io.axual.ksml.data.object.DataNull;
 import io.axual.ksml.data.object.DataString;
 import io.axual.ksml.data.schema.DataSchema;
@@ -43,7 +44,7 @@ class StructTypeTest {
                 .returns(java.util.Map.class, StructType::containerClass)
                 .returns("Struct", StructType::toString)
                 .returns("Struct", StructType::name);
-        assertThat(t.keyType()).isEqualTo(io.axual.ksml.data.object.DataString.DATATYPE);
+        assertThat(t.keyType()).isEqualTo(DataString.DATATYPE);
         assertThat(t.valueType()).isEqualTo(DataType.UNKNOWN);
     }
 
@@ -71,8 +72,8 @@ class StructTypeTest {
         var schema = new StructSchema("ns", "S", null, List.of(f1, f2));
         var typed = new StructType(schema);
         // Existing field maps to correct DataType
-        assertThat(typed.fieldType("s", DataType.UNKNOWN, DataType.UNKNOWN)).isEqualTo(io.axual.ksml.data.object.DataString.DATATYPE);
-        assertThat(typed.fieldType("i", DataType.UNKNOWN, DataType.UNKNOWN)).isEqualTo(io.axual.ksml.data.object.DataInteger.DATATYPE);
+        assertThat(typed.fieldType("s", DataType.UNKNOWN, DataType.UNKNOWN)).isEqualTo(DataString.DATATYPE);
+        assertThat(typed.fieldType("i", DataType.UNKNOWN, DataType.UNKNOWN)).isEqualTo(DataInteger.DATATYPE);
         // Missing field returns incaseNoSuchField
         assertThat(typed.fieldType("missing", DataType.UNKNOWN, DataType.UNKNOWN)).isEqualTo(DataType.UNKNOWN);
     }
@@ -122,7 +123,7 @@ class StructTypeTest {
         final var schema = new StructSchema("ns", "S", null, List.of(new StructSchema.Field("id", DataSchema.INTEGER_SCHEMA, null, 0)));
         final var type = new StructType(schema);
 
-        assertThat(type.fieldType("id", DataString.DATATYPE, DataString.DATATYPE)).isEqualTo(io.axual.ksml.data.object.DataInteger.DATATYPE);
+        assertThat(type.fieldType("id", DataString.DATATYPE, DataString.DATATYPE)).isEqualTo(DataInteger.DATATYPE);
         assertThat(type.fieldType("missing", DataType.UNKNOWN, DataString.DATATYPE)).isEqualTo(DataString.DATATYPE);
         assertThat(new StructType().fieldType("x", DataString.DATATYPE, DataType.UNKNOWN)).isEqualTo(DataString.DATATYPE);
     }

--- a/ksml-data/src/test/java/io/axual/ksml/data/type/UnionTypeMemberTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/type/UnionTypeMemberTest.java
@@ -1,0 +1,78 @@
+package io.axual.ksml.data.type;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Data Library
+ * %%
+ * Copyright (C) 2021 - 2026 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import io.axual.ksml.data.compare.EqualityFlags;
+import io.axual.ksml.data.object.DataInteger;
+import io.axual.ksml.data.object.DataLong;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UnionTypeMemberTest {
+
+    private static final int NO_TAG = -1;
+
+    @Test
+    @DisplayName("The convenience constructor defaults name/doc to null and tag to NO_TAG")
+    void convenienceConstructorDefaults() {
+        final var member = new UnionType.Member(DataInteger.DATATYPE);
+
+        assertThat(member.name()).isNull();
+        assertThat(member.doc()).isNull();
+        assertThat(member.tag()).isEqualTo(NO_TAG);
+        assertThat(member.type()).isEqualTo(DataInteger.DATATYPE);
+    }
+
+    @Test
+    @DisplayName("The full constructor exposes all fields")
+    void fullConstructor() {
+        final var member = new UnionType.Member("name", DataInteger.DATATYPE, "doc", 7);
+
+        assertThat(member.name()).isEqualTo("name");
+        assertThat(member.type()).isEqualTo(DataInteger.DATATYPE);
+        assertThat(member.doc()).isEqualTo("doc");
+        assertThat(member.tag()).isEqualTo(7);
+    }
+
+    @Test
+    @DisplayName("Deep equals: equal members are equal; identity short-circuits; null/foreign types are not equal")
+    void deepEqualsBasics() {
+        final var member = new UnionType.Member("n", DataInteger.DATATYPE, "d", 1);
+
+        assertThat(member.equals(member, EqualityFlags.EMPTY).isEqual()).isTrue();
+        assertThat(member.equals(new UnionType.Member("n", DataInteger.DATATYPE, "d", 1), EqualityFlags.EMPTY).isEqual()).isTrue();
+        assertThat(member.equals(null, EqualityFlags.EMPTY).isNotEqual()).isTrue();
+        assertThat(member.equals("not-a-member", EqualityFlags.EMPTY).isNotEqual()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Deep equals: a difference in any field makes members not equal")
+    void deepEqualsPerField() {
+        final var base = new UnionType.Member("n", DataInteger.DATATYPE, "d", 1);
+
+        assertThat(base.equals(new UnionType.Member("other", DataInteger.DATATYPE, "d", 1), EqualityFlags.EMPTY).isNotEqual()).isTrue();
+        assertThat(base.equals(new UnionType.Member("n", DataLong.DATATYPE, "d", 1), EqualityFlags.EMPTY).isNotEqual()).isTrue();
+        assertThat(base.equals(new UnionType.Member("n", DataInteger.DATATYPE, "other", 1), EqualityFlags.EMPTY).isNotEqual()).isTrue();
+        assertThat(base.equals(new UnionType.Member("n", DataInteger.DATATYPE, "d", 99), EqualityFlags.EMPTY).isNotEqual()).isTrue();
+    }
+}

--- a/ksml-data/src/test/java/io/axual/ksml/data/type/UnionTypeTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/type/UnionTypeTest.java
@@ -46,9 +46,10 @@ class UnionTypeTest {
         assertThat(u.subTypeCount()).isEqualTo(2);
         assertThat(u.subType(0)).isEqualTo(intType);
         assertThat(u.subType(1)).isEqualTo(strType);
-        assertThat(u.members()).containsExactly(m1, m2);
-        assertThat(u.members()[0].tag()).isEqualTo(10);
-        assertThat(u.members()[1].tag()).isEqualTo(20);
+        final var members = u.members();
+        assertThat(members).containsExactly(m1, m2);
+        assertThat(members[0].tag()).isEqualTo(10);
+        assertThat(members[1].tag()).isEqualTo(20);
     }
 
     @Test

--- a/ksml-data/src/test/java/io/axual/ksml/data/type/UnionTypeTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/type/UnionTypeTest.java
@@ -20,6 +20,7 @@ package io.axual.ksml.data.type;
  * =========================LICENSE_END==================================
  */
 
+import io.axual.ksml.data.compare.EqualityFlags;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -108,5 +109,21 @@ class UnionTypeTest {
         softly.assertThat(a.hashCode()).isEqualTo(a.hashCode());
         softly.assertThat(aDifferentTags.hashCode()).isEqualTo(aDifferentTags.hashCode());
         softly.assertAll();
+    }
+
+    @Test
+    @DisplayName("Deep equals(Object, EqualityFlags): equal members are equal; differing members, null and foreign types are not")
+    void deepEquals() {
+        final var intType = new SimpleType(Integer.class, "integer");
+        final var strType = new SimpleType(String.class, "string");
+        final var union = new UnionType(new UnionType.Member("i", intType, "Integer", 1), new UnionType.Member("s", strType, "String", 2));
+        final var same = new UnionType(new UnionType.Member("i", intType, "Integer", 1), new UnionType.Member("s", strType, "String", 2));
+        final var different = new UnionType(new UnionType.Member("i", intType, "Integer", 1));
+
+        assertThat(union.equals(union, EqualityFlags.EMPTY).isEqual()).isTrue();
+        assertThat(union.equals(same, EqualityFlags.EMPTY).isEqual()).isTrue();
+        assertThat(union.equals(different, EqualityFlags.EMPTY).isNotEqual()).isTrue();
+        assertThat(union.equals(null, EqualityFlags.EMPTY).isNotEqual()).isTrue();
+        assertThat(union.equals("not-a-union", EqualityFlags.EMPTY).isNotEqual()).isTrue();
     }
 }

--- a/ksml-data/src/test/java/io/axual/ksml/data/type/UnresolvedTypeTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/type/UnresolvedTypeTest.java
@@ -1,0 +1,56 @@
+package io.axual.ksml.data.type;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Data Library
+ * %%
+ * Copyright (C) 2021 - 2026 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import io.axual.ksml.data.compare.EqualityFlags;
+import io.axual.ksml.data.object.DataInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UnresolvedTypeTest {
+
+    private final UnresolvedType type = UnresolvedType.INSTANCE;
+
+    @Test
+    @DisplayName("Exposes its marker name, spec and container class")
+    void metadata() {
+        assertThat(type.name()).isEqualTo("Unresolved");
+        assertThat(type.spec()).isEqualTo("unresolved");
+        assertThat(type.containerClass()).isEqualTo(Object.class);
+        assertThat(type.toString()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("An unresolved type is assignable from nothing")
+    void notAssignable() {
+        assertThat(type.isAssignableFrom(DataInteger.DATATYPE).isNotAssignable()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Deep equals: equal only to itself, not to other types or null")
+    void deepEquals() {
+        assertThat(type.equals(UnresolvedType.INSTANCE, EqualityFlags.EMPTY).isEqual()).isTrue();
+        assertThat(type.equals(DataInteger.DATATYPE, EqualityFlags.EMPTY).isNotEqual()).isTrue();
+        assertThat(type.equals(null, EqualityFlags.EMPTY).isNotEqual()).isTrue();
+    }
+}

--- a/ksml-data/src/test/java/io/axual/ksml/data/type/UnresolvedTypeTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/type/UnresolvedTypeTest.java
@@ -37,7 +37,7 @@ class UnresolvedTypeTest {
         assertThat(type.name()).isEqualTo("Unresolved");
         assertThat(type.spec()).isEqualTo("unresolved");
         assertThat(type.containerClass()).isEqualTo(Object.class);
-        assertThat(type.toString()).isNotBlank();
+        assertThat(type).hasToString("unresolved");
     }
 
     @Test

--- a/ksml-data/src/test/java/io/axual/ksml/data/util/AssignableUtilTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/util/AssignableUtilTest.java
@@ -1,0 +1,61 @@
+package io.axual.ksml.data.util;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Data Library
+ * %%
+ * Copyright (C) 2021 - 2026 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import io.axual.ksml.data.compare.Assignable;
+import io.axual.ksml.data.object.DataInteger;
+import io.axual.ksml.data.object.DataString;
+import io.axual.ksml.data.schema.DataSchema;
+import io.axual.ksml.data.type.UnionType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AssignableUtilTest {
+
+    private static final UnionType UNION = new UnionType(new UnionType.Member(DataInteger.DATATYPE));
+
+    @Test
+    @DisplayName("Every factory produces a not-assignable Assignable")
+    void factoriesProduceNotAssignable() {
+        assertThat(AssignableUtil.fieldNotAssignable("f", "t1", 1, "t2", 2).isNotAssignable()).isTrue();
+        assertThat(AssignableUtil.schemaMismatch(DataSchema.INTEGER_SCHEMA, DataSchema.STRING_SCHEMA).isNotAssignable()).isTrue();
+        assertThat(AssignableUtil.typeMismatch(DataInteger.DATATYPE, DataString.DATATYPE).isNotAssignable()).isTrue();
+        assertThat(AssignableUtil.unionNotAssignableFromMember(UNION, new UnionType.Member(DataString.DATATYPE)).isNotAssignable()).isTrue();
+        assertThat(AssignableUtil.unionNotAssignableFromType(UNION, DataString.DATATYPE).isNotAssignable()).isTrue();
+        assertThat(AssignableUtil.unionNotAssignableFromValue(UNION, "some-value").isNotAssignable()).isTrue();
+    }
+
+    @Test
+    @DisplayName("The cause-carrying fieldNotAssignable variant keeps its cause")
+    void fieldNotAssignableWithCause() {
+        final var cause = Assignable.notAssignable("inner");
+
+        assertThat(AssignableUtil.fieldNotAssignable("f", "t1", 1, "t2", 2, cause).cause()).isSameAs(cause);
+    }
+
+    @Test
+    @DisplayName("Messages mention the relevant field name")
+    void messagesAreInformative() {
+        assertThat(AssignableUtil.fieldNotAssignable("myField", "t1", 1, "t2", 2).message()).contains("myField");
+    }
+}

--- a/ksml-data/src/test/java/io/axual/ksml/data/util/ConvertUtilTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/util/ConvertUtilTest.java
@@ -24,13 +24,11 @@ import io.axual.ksml.data.exception.DataException;
 import io.axual.ksml.data.mapper.DataTypeDataSchemaMapper;
 import io.axual.ksml.data.mapper.NativeDataObjectMapper;
 import io.axual.ksml.data.notation.Notation;
-import io.axual.ksml.data.type.DataType;
-import org.apache.kafka.common.serialization.Serde;
+import io.axual.ksml.data.object.DataBoolean;
 import io.axual.ksml.data.object.DataByte;
 import io.axual.ksml.data.object.DataDouble;
 import io.axual.ksml.data.object.DataFloat;
 import io.axual.ksml.data.object.DataInteger;
-import io.axual.ksml.data.object.DataBoolean;
 import io.axual.ksml.data.object.DataList;
 import io.axual.ksml.data.object.DataLong;
 import io.axual.ksml.data.object.DataMap;
@@ -42,18 +40,21 @@ import io.axual.ksml.data.object.DataStruct;
 import io.axual.ksml.data.object.DataTuple;
 import io.axual.ksml.data.schema.DataSchema;
 import io.axual.ksml.data.schema.StructSchema;
+import io.axual.ksml.data.type.DataType;
 import io.axual.ksml.data.type.ListType;
 import io.axual.ksml.data.type.MapType;
 import io.axual.ksml.data.type.StructType;
 import io.axual.ksml.data.type.TupleType;
 import io.axual.ksml.data.type.UnionType;
-
-import java.util.List;
+import org.apache.kafka.common.serialization.Serde;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ConvertUtilTest {
     private final ConvertUtil converter = new ConvertUtil(new NativeDataObjectMapper(), new DataTypeDataSchemaMapper());
@@ -280,7 +281,7 @@ class ConvertUtilTest {
 
         final var result = (DataList) converter.convert(new ListType(DataLong.DATATYPE), source);
 
-        assertThat(result.size()).isEqualTo(2);
+        assertThat(result).hasSize(2);
         assertThat(result.get(0)).isEqualTo(new DataLong(1L));
         assertThat(result.get(1)).isEqualTo(new DataLong(2L));
     }
@@ -303,8 +304,7 @@ class ConvertUtilTest {
 
         final var result = (DataTuple) converter.convert(new TupleType(DataLong.DATATYPE, DataString.DATATYPE), source);
 
-        assertThat(result.elements().get(0)).isEqualTo(new DataLong(1L));
-        assertThat(result.elements().get(1)).isEqualTo(new DataString("2"));
+        assertThat(result.elements()).containsExactly(new DataLong(1L), new DataString("2"));
     }
 
     @Test
@@ -354,8 +354,8 @@ class ConvertUtilTest {
     @Test
     @DisplayName("convert: a DataNull maps to the target scalar type's null representation without throwing")
     void convertNullToScalarType() {
-        assertThat(converter.convert(DataString.DATATYPE, DataNull.INSTANCE)).isNotNull();
-        assertThat(converter.convert(DataLong.DATATYPE, DataNull.INSTANCE)).isNotNull();
+        assertThat(converter.convert(DataString.DATATYPE, DataNull.INSTANCE)).isEqualTo(new DataString());
+        assertThat(converter.convert(DataLong.DATATYPE, DataNull.INSTANCE)).isEqualTo(new DataLong());
     }
 
     private static StructSchema personSchema() {
@@ -399,18 +399,15 @@ class ConvertUtilTest {
     }
 
     @Test
-    @DisplayName("convert: a value is converted to a compatible member of a union type")
+    @DisplayName("convert: a value is converted to the first compatible member of a union type")
     void convertToUnionMember() {
         final var union = new UnionType(new UnionType.Member(DataLong.DATATYPE), new UnionType.Member(DataString.DATATYPE));
 
         final var result = converter.convert(union, new DataInteger(5));
 
-        // The result must be a value that fits one of the union's member types.
-        assertThat(result).isNotNull();
-        assertThat(union.isAssignableFrom(result).isAssignable()).isTrue();
+        assertThat(result).isEqualTo(new DataLong(5L));
     }
 
-    /** A Notation whose converter always returns the given fixed value (all other members are unused). */
     private static Notation notationConvertingTo(DataObject fixed) {
         return new Notation() {
             @Override
@@ -476,7 +473,7 @@ class ConvertUtilTest {
     @DisplayName("convertStringToDataObject: a JSON string is parsed into a list/map/struct/tuple of the target type")
     void convertStringToComplexTypes() {
         final var list = (DataList) converter.convertStringToDataObject(new ListType(DataInteger.DATATYPE), "[1, 2, 3]", false);
-        assertThat(list.size()).isEqualTo(3);
+        assertThat(list).hasSize(3);
 
         final var map = (DataMap) converter.convertStringToDataObject(new MapType(DataInteger.DATATYPE), "{\"a\": 1}", false);
         assertThat(map.get("a")).isEqualTo(new DataInteger(1));
@@ -485,22 +482,25 @@ class ConvertUtilTest {
         assertThat(struct.get("id")).isEqualTo(new DataInteger(1));
 
         final var tuple = (DataTuple) converter.convertStringToDataObject(new TupleType(DataInteger.DATATYPE, DataString.DATATYPE), "[1, \"x\"]", false);
-        assertThat(tuple.elements().get(0)).isEqualTo(new DataInteger(1));
+        assertThat(tuple.elements()).containsExactly(new DataInteger(1), new DataString("x"));
 
-        // A tuple may also be written with round brackets
         final var tuple2 = (DataTuple) converter.convertStringToDataObject(new TupleType(DataInteger.DATATYPE, DataString.DATATYPE), "(1, \"x\")", false);
-        assertThat(tuple2.elements()).hasSize(2);
+        assertThat(tuple2.elements()).containsExactly(new DataInteger(1), new DataString("x"));
     }
 
     @Test
     @DisplayName("convertStringToDataObject: malformed JSON returns null with allowFail and throws otherwise; wrong tuple arity always throws")
     void convertStringToComplexTypesErrors() {
-        assertThat(converter.convertStringToDataObject(new ListType(DataInteger.DATATYPE), "not-json", true)).isNull();
-        assertThatCode(() -> converter.convertStringToDataObject(new MapType(DataInteger.DATATYPE), "not-json", false))
+        final var listType = new ListType(DataInteger.DATATYPE);
+        final var mapType = new MapType(DataInteger.DATATYPE);
+        final var structType = new StructType(personSchema());
+        final var tupleType = new TupleType(DataInteger.DATATYPE, DataString.DATATYPE);
+        assertThat(converter.convertStringToDataObject(listType, "not-json", true)).isNull();
+        assertThatThrownBy(() -> converter.convertStringToDataObject(mapType, "not-json", false))
                 .isInstanceOf(DataException.class);
-        assertThatCode(() -> converter.convertStringToDataObject(new StructType(personSchema()), "not-json", false))
+        assertThatThrownBy(() -> converter.convertStringToDataObject(structType, "not-json", false))
                 .isInstanceOf(DataException.class);
-        assertThatCode(() -> converter.convertStringToDataObject(new TupleType(DataInteger.DATATYPE, DataString.DATATYPE), "[1]", false))
+        assertThatThrownBy(() -> converter.convertStringToDataObject(tupleType, "[1]", false))
                 .isInstanceOf(DataException.class);
     }
 

--- a/ksml-data/src/test/java/io/axual/ksml/data/util/ConvertUtilTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/util/ConvertUtilTest.java
@@ -28,8 +28,16 @@ import io.axual.ksml.data.object.DataDouble;
 import io.axual.ksml.data.object.DataFloat;
 import io.axual.ksml.data.object.DataInteger;
 import io.axual.ksml.data.object.DataBoolean;
+import io.axual.ksml.data.object.DataList;
 import io.axual.ksml.data.object.DataLong;
+import io.axual.ksml.data.object.DataMap;
+import io.axual.ksml.data.object.DataNull;
 import io.axual.ksml.data.object.DataShort;
+import io.axual.ksml.data.object.DataString;
+import io.axual.ksml.data.object.DataTuple;
+import io.axual.ksml.data.type.ListType;
+import io.axual.ksml.data.type.MapType;
+import io.axual.ksml.data.type.TupleType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -248,5 +256,51 @@ class ConvertUtilTest {
                 .isInstanceOf(DataException.class)
                 .hasMessageContaining("BOOLEAN");
         assertThat(converter.convertStringToDataObject(DataBoolean.DATATYPE, "yes", true)).isNull();
+    }
+
+    // ---- complex (recursive) conversions ----
+
+    @Test
+    @DisplayName("convert: a list is converted element-by-element to the target value type")
+    void convertListElements() {
+        final var source = new DataList(DataInteger.DATATYPE);
+        source.add(new DataInteger(1));
+        source.add(new DataInteger(2));
+
+        final var result = (DataList) converter.convert(new ListType(DataLong.DATATYPE), source);
+
+        assertThat(result.size()).isEqualTo(2);
+        assertThat(result.get(0)).isEqualTo(new DataLong(1L));
+        assertThat(result.get(1)).isEqualTo(new DataLong(2L));
+    }
+
+    @Test
+    @DisplayName("convert: a map's values are converted to the target value type")
+    void convertMapValues() {
+        final var source = new DataMap(DataInteger.DATATYPE);
+        source.put("a", new DataInteger(1));
+
+        final var result = (DataMap) converter.convert(new MapType(DataLong.DATATYPE), source);
+
+        assertThat(result.get("a")).isEqualTo(new DataLong(1L));
+    }
+
+    @Test
+    @DisplayName("convert: a tuple's elements are converted position-by-position to the target types")
+    void convertTupleElements() {
+        final var source = new DataTuple(new DataInteger(1), new DataInteger(2));
+
+        final var result = (DataTuple) converter.convert(new TupleType(DataLong.DATATYPE, DataString.DATATYPE), source);
+
+        assertThat(result.elements().get(0)).isEqualTo(new DataLong(1L));
+        assertThat(result.elements().get(1)).isEqualTo(new DataString("2"));
+    }
+
+    @Test
+    @DisplayName("convert: a DataNull becomes a (null) instance of the requested complex type")
+    void convertNullToComplexType() {
+        final var result = converter.convert(new ListType(DataLong.DATATYPE), DataNull.INSTANCE);
+
+        assertThat(result).isInstanceOf(DataList.class);
     }
 }

--- a/ksml-data/src/test/java/io/axual/ksml/data/util/ConvertUtilTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/util/ConvertUtilTest.java
@@ -23,6 +23,9 @@ package io.axual.ksml.data.util;
 import io.axual.ksml.data.exception.DataException;
 import io.axual.ksml.data.mapper.DataTypeDataSchemaMapper;
 import io.axual.ksml.data.mapper.NativeDataObjectMapper;
+import io.axual.ksml.data.notation.Notation;
+import io.axual.ksml.data.type.DataType;
+import org.apache.kafka.common.serialization.Serde;
 import io.axual.ksml.data.object.DataByte;
 import io.axual.ksml.data.object.DataDouble;
 import io.axual.ksml.data.object.DataFloat;
@@ -32,12 +35,20 @@ import io.axual.ksml.data.object.DataList;
 import io.axual.ksml.data.object.DataLong;
 import io.axual.ksml.data.object.DataMap;
 import io.axual.ksml.data.object.DataNull;
+import io.axual.ksml.data.object.DataObject;
 import io.axual.ksml.data.object.DataShort;
 import io.axual.ksml.data.object.DataString;
+import io.axual.ksml.data.object.DataStruct;
 import io.axual.ksml.data.object.DataTuple;
+import io.axual.ksml.data.schema.DataSchema;
+import io.axual.ksml.data.schema.StructSchema;
 import io.axual.ksml.data.type.ListType;
 import io.axual.ksml.data.type.MapType;
+import io.axual.ksml.data.type.StructType;
 import io.axual.ksml.data.type.TupleType;
+import io.axual.ksml.data.type.UnionType;
+
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -302,5 +313,208 @@ class ConvertUtilTest {
         final var result = converter.convert(new ListType(DataLong.DATATYPE), DataNull.INSTANCE);
 
         assertThat(result).isInstanceOf(DataList.class);
+    }
+
+    @Test
+    @DisplayName("convert: numeric values widen across the byte/short/int/long/double/float ladder")
+    void convertNumericWidening() {
+        assertThat(converter.convert(DataShort.DATATYPE, new DataByte((byte) 5))).isEqualTo(new DataShort((short) 5));
+        assertThat(converter.convert(DataInteger.DATATYPE, new DataByte((byte) 5))).isEqualTo(new DataInteger(5));
+        assertThat(converter.convert(DataLong.DATATYPE, new DataByte((byte) 5))).isEqualTo(new DataLong(5L));
+        assertThat(converter.convert(DataDouble.DATATYPE, new DataByte((byte) 5))).isEqualTo(new DataDouble(5.0));
+        assertThat(converter.convert(DataFloat.DATATYPE, new DataByte((byte) 5))).isEqualTo(new DataFloat(5.0f));
+
+        assertThat(converter.convert(DataInteger.DATATYPE, new DataShort((short) 6))).isEqualTo(new DataInteger(6));
+        assertThat(converter.convert(DataLong.DATATYPE, new DataShort((short) 6))).isEqualTo(new DataLong(6L));
+        assertThat(converter.convert(DataDouble.DATATYPE, new DataShort((short) 6))).isEqualTo(new DataDouble(6.0));
+        assertThat(converter.convert(DataFloat.DATATYPE, new DataShort((short) 6))).isEqualTo(new DataFloat(6.0f));
+
+        assertThat(converter.convert(DataDouble.DATATYPE, new DataInteger(7))).isEqualTo(new DataDouble(7.0));
+        assertThat(converter.convert(DataFloat.DATATYPE, new DataInteger(7))).isEqualTo(new DataFloat(7.0f));
+
+        assertThat(converter.convert(DataDouble.DATATYPE, new DataLong(8L))).isEqualTo(new DataDouble(8.0));
+        assertThat(converter.convert(DataFloat.DATATYPE, new DataLong(8L))).isEqualTo(new DataFloat(8.0f));
+
+        assertThat(converter.convert(DataFloat.DATATYPE, new DataDouble(9.0))).isEqualTo(new DataFloat(9.0f));
+        assertThat(converter.convert(DataDouble.DATATYPE, new DataFloat(9.0f))).isEqualTo(new DataDouble(9.0));
+    }
+
+    @Test
+    @DisplayName("convertStringToDataObject: byte/short/float/double numeric strings parse to their types")
+    void convertStringToNumericTypes() {
+        assertThat(converter.convertStringToDataObject(DataByte.DATATYPE, "5", false)).isEqualTo(new DataByte((byte) 5));
+        assertThat(converter.convertStringToDataObject(DataShort.DATATYPE, "6", false)).isEqualTo(new DataShort((short) 6));
+        assertThat(converter.convertStringToDataObject(DataFloat.DATATYPE, "1.5", false)).isEqualTo(new DataFloat(1.5f));
+        assertThat(converter.convertStringToDataObject(DataDouble.DATATYPE, "2.5", false)).isEqualTo(new DataDouble(2.5));
+        // A null expected type wraps the raw string; a null value yields DataNull.
+        assertThat(converter.convertStringToDataObject(null, "x", false)).isEqualTo(new DataString("x"));
+        assertThat(converter.convertStringToDataObject(DataInteger.DATATYPE, null, false)).isEqualTo(DataNull.INSTANCE);
+    }
+
+    @Test
+    @DisplayName("convert: a DataNull maps to the target scalar type's null representation without throwing")
+    void convertNullToScalarType() {
+        assertThat(converter.convert(DataString.DATATYPE, DataNull.INSTANCE)).isNotNull();
+        assertThat(converter.convert(DataLong.DATATYPE, DataNull.INSTANCE)).isNotNull();
+    }
+
+    private static StructSchema personSchema() {
+        return new StructSchema("ns", "Person", null, List.of(new StructSchema.Field("id", DataSchema.INTEGER_SCHEMA, null, 0)));
+    }
+
+    @Test
+    @DisplayName("convert: a map is converted into a struct of the target StructType")
+    void convertMapToStruct() {
+        final var map = new DataMap(DataInteger.DATATYPE);
+        map.put("id", new DataInteger(1));
+
+        final var result = converter.convert(new StructType(personSchema()), map);
+
+        assertThat(result).isInstanceOf(DataStruct.class);
+        assertThat(((DataStruct) result).get("id")).isEqualTo(new DataInteger(1));
+    }
+
+    @Test
+    @DisplayName("convert: a struct is converted into a map of the target MapType")
+    void convertStructToMap() {
+        final var struct = new DataStruct(personSchema());
+        struct.put("id", new DataInteger(1));
+
+        final var result = converter.convert(new MapType(DataInteger.DATATYPE), struct);
+
+        assertThat(result).isInstanceOf(DataMap.class);
+        assertThat(((DataMap) result).get("id")).isEqualTo(new DataInteger(1));
+    }
+
+    @Test
+    @DisplayName("convert: a schemaless struct is converted into a struct with the target schema")
+    void convertStructToStruct() {
+        final var struct = new DataStruct();
+        struct.put("id", new DataInteger(1));
+
+        final var result = converter.convert(new StructType(personSchema()), struct);
+
+        assertThat(result).isInstanceOf(DataStruct.class);
+        assertThat(((DataStruct) result).get("id")).isEqualTo(new DataInteger(1));
+    }
+
+    @Test
+    @DisplayName("convert: a value is converted to a compatible member of a union type")
+    void convertToUnionMember() {
+        final var union = new UnionType(new UnionType.Member(DataLong.DATATYPE), new UnionType.Member(DataString.DATATYPE));
+
+        final var result = converter.convert(union, new DataInteger(5));
+
+        // The result must be a value that fits one of the union's member types.
+        assertThat(result).isNotNull();
+        assertThat(union.isAssignableFrom(result).isAssignable()).isTrue();
+    }
+
+    /** A Notation whose converter always returns the given fixed value (all other members are unused). */
+    private static Notation notationConvertingTo(DataObject fixed) {
+        return new Notation() {
+            @Override
+            public Notation.SchemaUsage schemaUsage() {
+                return null;
+            }
+
+            @Override
+            public DataType defaultType() {
+                return null;
+            }
+
+            @Override
+            public String name() {
+                return "stub";
+            }
+
+            @Override
+            public String filenameExtension() {
+                return null;
+            }
+
+            @Override
+            public Serde<Object> serde(DataType type, boolean isKey) {
+                return null;
+            }
+
+            @Override
+            public Notation.Converter converter() {
+                return (value, targetType) -> fixed;
+            }
+
+            @Override
+            public Notation.SchemaParser schemaParser() {
+                return null;
+            }
+        };
+    }
+
+    @Test
+    @DisplayName("convert: the target notation's converter is used when it produces an assignable value")
+    void convertUsesTargetNotationConverter() {
+        final var converted = new DataString("converted");
+        final var targetNotation = notationConvertingTo(converted);
+
+        final var result = converter.convert(null, targetNotation, DataString.DATATYPE, new DataInteger(1), false);
+
+        assertThat(result).isEqualTo(converted);
+    }
+
+    @Test
+    @DisplayName("convert: the source notation's converter is used when the target notation cannot convert")
+    void convertFallsBackToSourceNotationConverter() {
+        final var converted = new DataString("from-source");
+        final var sourceNotation = notationConvertingTo(converted);
+
+        final var result = converter.convert(sourceNotation, null, DataString.DATATYPE, new DataInteger(1), false);
+
+        assertThat(result).isEqualTo(converted);
+    }
+
+    @Test
+    @DisplayName("convertStringToDataObject: a JSON string is parsed into a list/map/struct/tuple of the target type")
+    void convertStringToComplexTypes() {
+        final var list = (DataList) converter.convertStringToDataObject(new ListType(DataInteger.DATATYPE), "[1, 2, 3]", false);
+        assertThat(list.size()).isEqualTo(3);
+
+        final var map = (DataMap) converter.convertStringToDataObject(new MapType(DataInteger.DATATYPE), "{\"a\": 1}", false);
+        assertThat(map.get("a")).isEqualTo(new DataInteger(1));
+
+        final var struct = (DataStruct) converter.convertStringToDataObject(new StructType(personSchema()), "{\"id\": 1}", false);
+        assertThat(struct.get("id")).isEqualTo(new DataInteger(1));
+
+        final var tuple = (DataTuple) converter.convertStringToDataObject(new TupleType(DataInteger.DATATYPE, DataString.DATATYPE), "[1, \"x\"]", false);
+        assertThat(tuple.elements().get(0)).isEqualTo(new DataInteger(1));
+
+        // A tuple may also be written with round brackets
+        final var tuple2 = (DataTuple) converter.convertStringToDataObject(new TupleType(DataInteger.DATATYPE, DataString.DATATYPE), "(1, \"x\")", false);
+        assertThat(tuple2.elements()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("convertStringToDataObject: malformed JSON returns null with allowFail and throws otherwise; wrong tuple arity always throws")
+    void convertStringToComplexTypesErrors() {
+        assertThat(converter.convertStringToDataObject(new ListType(DataInteger.DATATYPE), "not-json", true)).isNull();
+        assertThatCode(() -> converter.convertStringToDataObject(new MapType(DataInteger.DATATYPE), "not-json", false))
+                .isInstanceOf(DataException.class);
+        assertThatCode(() -> converter.convertStringToDataObject(new StructType(personSchema()), "not-json", false))
+                .isInstanceOf(DataException.class);
+        assertThatCode(() -> converter.convertStringToDataObject(new TupleType(DataInteger.DATATYPE, DataString.DATATYPE), "[1]", false))
+                .isInstanceOf(DataException.class);
+    }
+
+    @Test
+    @DisplayName("convert: float and double values narrow to the integral types")
+    void convertFloatingToIntegral() {
+        assertThat(converter.convert(DataByte.DATATYPE, new DataFloat(5.0f))).isEqualTo(new DataByte((byte) 5));
+        assertThat(converter.convert(DataShort.DATATYPE, new DataFloat(5.0f))).isEqualTo(new DataShort((short) 5));
+        assertThat(converter.convert(DataInteger.DATATYPE, new DataFloat(5.0f))).isEqualTo(new DataInteger(5));
+        assertThat(converter.convert(DataLong.DATATYPE, new DataFloat(5.0f))).isEqualTo(new DataLong(5L));
+
+        assertThat(converter.convert(DataByte.DATATYPE, new DataDouble(6.0))).isEqualTo(new DataByte((byte) 6));
+        assertThat(converter.convert(DataShort.DATATYPE, new DataDouble(6.0))).isEqualTo(new DataShort((short) 6));
+        assertThat(converter.convert(DataInteger.DATATYPE, new DataDouble(6.0))).isEqualTo(new DataInteger(6));
+        assertThat(converter.convert(DataLong.DATATYPE, new DataDouble(6.0))).isEqualTo(new DataLong(6L));
     }
 }

--- a/ksml-data/src/test/java/io/axual/ksml/data/util/ConvertUtilTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/util/ConvertUtilTest.java
@@ -24,6 +24,7 @@ import io.axual.ksml.data.exception.DataException;
 import io.axual.ksml.data.mapper.DataTypeDataSchemaMapper;
 import io.axual.ksml.data.mapper.NativeDataObjectMapper;
 import io.axual.ksml.data.notation.Notation;
+import io.axual.ksml.data.notation.NotationStub;
 import io.axual.ksml.data.object.DataBoolean;
 import io.axual.ksml.data.object.DataByte;
 import io.axual.ksml.data.object.DataDouble;
@@ -40,13 +41,11 @@ import io.axual.ksml.data.object.DataStruct;
 import io.axual.ksml.data.object.DataTuple;
 import io.axual.ksml.data.schema.DataSchema;
 import io.axual.ksml.data.schema.StructSchema;
-import io.axual.ksml.data.type.DataType;
 import io.axual.ksml.data.type.ListType;
 import io.axual.ksml.data.type.MapType;
 import io.axual.ksml.data.type.StructType;
 import io.axual.ksml.data.type.TupleType;
 import io.axual.ksml.data.type.UnionType;
-import org.apache.kafka.common.serialization.Serde;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -409,42 +408,7 @@ class ConvertUtilTest {
     }
 
     private static Notation notationConvertingTo(DataObject fixed) {
-        return new Notation() {
-            @Override
-            public Notation.SchemaUsage schemaUsage() {
-                return null;
-            }
-
-            @Override
-            public DataType defaultType() {
-                return null;
-            }
-
-            @Override
-            public String name() {
-                return "stub";
-            }
-
-            @Override
-            public String filenameExtension() {
-                return null;
-            }
-
-            @Override
-            public Serde<Object> serde(DataType type, boolean isKey) {
-                return null;
-            }
-
-            @Override
-            public Notation.Converter converter() {
-                return (value, targetType) -> fixed;
-            }
-
-            @Override
-            public Notation.SchemaParser schemaParser() {
-                return null;
-            }
-        };
+        return new NotationStub("stub", null, (value, targetType) -> fixed);
     }
 
     @Test

--- a/ksml-data/src/test/java/io/axual/ksml/data/util/EqualUtilTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/util/EqualUtilTest.java
@@ -1,0 +1,58 @@
+package io.axual.ksml.data.util;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Data Library
+ * %%
+ * Copyright (C) 2021 - 2026 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import io.axual.ksml.data.compare.Equality;
+import io.axual.ksml.data.object.DataInteger;
+import io.axual.ksml.data.object.DataLong;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EqualUtilTest {
+
+    @Test
+    @DisplayName("Every factory produces a not-equal Equality with an explanatory message")
+    void factoriesProduceNotEqual() {
+        assertThat(EqualUtil.otherIsNull(new DataInteger(1)).isNotEqual()).isTrue();
+        assertThat(EqualUtil.containerClassNotEqual(String.class, Integer.class).isNotEqual()).isTrue();
+        assertThat(EqualUtil.objectNotEqual(new DataInteger(1), new DataInteger(2)).isNotEqual()).isTrue();
+        assertThat(EqualUtil.typeNotEqual(DataInteger.DATATYPE, DataLong.DATATYPE, Equality.notEqual("cause")).isNotEqual()).isTrue();
+        assertThat(EqualUtil.fieldNotEqual("field", new DataInteger(1), 1, new DataInteger(2), 2).isNotEqual()).isTrue();
+    }
+
+    @Test
+    @DisplayName("The cause-carrying variants keep their underlying cause")
+    void variantsCarryCause() {
+        final var cause = Equality.notEqual("inner");
+
+        assertThat(EqualUtil.objectNotEqual(new DataInteger(1), new DataInteger(2), cause).cause()).isSameAs(cause);
+        assertThat(EqualUtil.fieldNotEqual("field", new DataInteger(1), 1, new DataInteger(2), 2, cause).cause()).isSameAs(cause);
+    }
+
+    @Test
+    @DisplayName("Messages mention the relevant detail (class names / field name)")
+    void messagesAreInformative() {
+        assertThat(EqualUtil.containerClassNotEqual(String.class, Integer.class).message()).contains("String", "Integer");
+        assertThat(EqualUtil.fieldNotEqual("myField", new DataInteger(1), 1, new DataInteger(2), 2).message()).contains("myField");
+    }
+}

--- a/ksml-data/src/test/java/io/axual/ksml/data/util/JsonNodeUtilTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/util/JsonNodeUtilTest.java
@@ -85,7 +85,7 @@ class JsonNodeUtilTest {
         source.put("nested", Map.of("inner", 9));
 
         final var node = JsonNodeUtil.convertNativeToJsonNode(source);
-        final Object roundTripped = JsonNodeUtil.convertJsonNodeToNative(node);
+        final var roundTripped = JsonNodeUtil.convertJsonNodeToNative(node);
 
         assertThat(roundTripped).isInstanceOf(Map.class);
         @SuppressWarnings("unchecked")

--- a/ksml-data/src/test/java/io/axual/ksml/data/util/JsonNodeUtilTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/util/JsonNodeUtilTest.java
@@ -20,10 +20,14 @@ package io.axual.ksml.data.util;
  * =========================LICENSE_END==================================
  */
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.axual.ksml.data.exception.DataException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -53,9 +57,7 @@ class JsonNodeUtilTest {
     @Test
     @DisplayName("convertStringToJsonNode yields a null node for null, a tree for valid JSON, and null for invalid")
     void convertStringToJsonNode() {
-        final var nullNode = JsonNodeUtil.convertStringToJsonNode(null);
-        assertThat(nullNode).isNotNull();
-        assertThat(nullNode.isNull()).isTrue();
+        assertThat(JsonNodeUtil.convertStringToJsonNode(null)).isNotNull().isInstanceOf(NullNode.class);
         assertThat(JsonNodeUtil.convertStringToJsonNode("[1,2]")).isNotNull();
         assertThat(JsonNodeUtil.convertStringToJsonNode("invalid{")).isNull();
     }
@@ -63,9 +65,9 @@ class JsonNodeUtilTest {
     @Test
     @DisplayName("convertNativeToJsonNode handles null, lists and maps, and rejects unsupported types")
     void convertNativeToJsonNode() {
-        assertThat(JsonNodeUtil.convertNativeToJsonNode(null).isNull()).isTrue();
-        assertThat(JsonNodeUtil.convertNativeToJsonNode(List.of(1, "x", true)).isArray()).isTrue();
-        assertThat(JsonNodeUtil.convertNativeToJsonNode(Map.of("k", "v")).isObject()).isTrue();
+        assertThat(JsonNodeUtil.convertNativeToJsonNode(null)).isInstanceOf(NullNode.class);
+        assertThat(JsonNodeUtil.convertNativeToJsonNode(List.of(1, "x", true))).isInstanceOf(ArrayNode.class);
+        assertThat(JsonNodeUtil.convertNativeToJsonNode(Map.of("k", "v"))).isInstanceOf(ObjectNode.class);
         assertThatThrownBy(() -> JsonNodeUtil.convertNativeToJsonNode("a string"))
                 .isInstanceOf(DataException.class);
     }
@@ -73,7 +75,7 @@ class JsonNodeUtilTest {
     @Test
     @DisplayName("A native map with mixed value types round-trips through JsonNode")
     void mixedMapRoundTrips() {
-        final var source = new java.util.LinkedHashMap<String, Object>();
+        final var source = new LinkedHashMap<String, Object>();
         source.put("bool", true);
         source.put("int", 1);
         source.put("long", 2L);
@@ -91,8 +93,8 @@ class JsonNodeUtilTest {
         assertThat(result)
                 .containsEntry("bool", true)
                 .containsEntry("int", 1)
-                .containsEntry("string", "text");
-        assertThat(result.get("list")).isEqualTo(List.of(10, 20));
+                .containsEntry("string", "text")
+                .containsEntry("list", List.of(10, 20));
     }
 
     @Test

--- a/ksml-data/src/test/java/io/axual/ksml/data/util/JsonNodeUtilTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/util/JsonNodeUtilTest.java
@@ -1,0 +1,106 @@
+package io.axual.ksml.data.util;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Data Library
+ * %%
+ * Copyright (C) 2021 - 2026 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import io.axual.ksml.data.exception.DataException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JsonNodeUtilTest {
+
+    @Test
+    @DisplayName("convertStringToList parses a JSON array, and returns null for non-arrays/invalid/null")
+    void convertStringToList() {
+        assertThat(JsonNodeUtil.convertStringToList("[1, 2, 3]")).containsExactly(1, 2, 3);
+        assertThat(JsonNodeUtil.convertStringToList("{}")).isNull();      // not an array
+        assertThat(JsonNodeUtil.convertStringToList("not-json")).isNull();// parse failure
+        assertThat(JsonNodeUtil.convertStringToList(null)).isNull();      // null input
+    }
+
+    @Test
+    @DisplayName("convertStringToMap parses a JSON object, and returns null for null input")
+    void convertStringToMap() {
+        assertThat(JsonNodeUtil.convertStringToMap("{\"a\": 1, \"b\": \"x\"}"))
+                .containsEntry("a", 1)
+                .containsEntry("b", "x");
+        assertThat(JsonNodeUtil.convertStringToMap(null)).isNull();
+    }
+
+    @Test
+    @DisplayName("convertStringToJsonNode yields a null node for null, a tree for valid JSON, and null for invalid")
+    void convertStringToJsonNode() {
+        final var nullNode = JsonNodeUtil.convertStringToJsonNode(null);
+        assertThat(nullNode).isNotNull();
+        assertThat(nullNode.isNull()).isTrue();
+        assertThat(JsonNodeUtil.convertStringToJsonNode("[1,2]")).isNotNull();
+        assertThat(JsonNodeUtil.convertStringToJsonNode("invalid{")).isNull();
+    }
+
+    @Test
+    @DisplayName("convertNativeToJsonNode handles null, lists and maps, and rejects unsupported types")
+    void convertNativeToJsonNode() {
+        assertThat(JsonNodeUtil.convertNativeToJsonNode(null).isNull()).isTrue();
+        assertThat(JsonNodeUtil.convertNativeToJsonNode(List.of(1, "x", true)).isArray()).isTrue();
+        assertThat(JsonNodeUtil.convertNativeToJsonNode(Map.of("k", "v")).isObject()).isTrue();
+        assertThatThrownBy(() -> JsonNodeUtil.convertNativeToJsonNode("a string"))
+                .isInstanceOf(DataException.class);
+    }
+
+    @Test
+    @DisplayName("A native map with mixed value types round-trips through JsonNode")
+    void mixedMapRoundTrips() {
+        final var source = new java.util.LinkedHashMap<String, Object>();
+        source.put("bool", true);
+        source.put("int", 1);
+        source.put("long", 2L);
+        source.put("double", 3.5);
+        source.put("string", "text");
+        source.put("list", List.of(10, 20));
+        source.put("nested", Map.of("inner", 9));
+
+        final var node = JsonNodeUtil.convertNativeToJsonNode(source);
+        final Object roundTripped = JsonNodeUtil.convertJsonNodeToNative(node);
+
+        assertThat(roundTripped).isInstanceOf(Map.class);
+        @SuppressWarnings("unchecked")
+        final var result = (Map<String, Object>) roundTripped;
+        assertThat(result)
+                .containsEntry("bool", true)
+                .containsEntry("int", 1)
+                .containsEntry("string", "text");
+        assertThat(result.get("list")).isEqualTo(List.of(10, 20));
+    }
+
+    @Test
+    @DisplayName("convertJsonNodeToNative rejects a scalar node that is neither array nor object")
+    void convertJsonNodeToNativeRejectsScalar() {
+        final var scalar = JsonNodeUtil.convertStringToJsonNode("42");
+
+        assertThatThrownBy(() -> JsonNodeUtil.convertJsonNodeToNative(scalar))
+                .isInstanceOf(DataException.class);
+    }
+}

--- a/ksml-data/src/test/java/io/axual/ksml/data/value/TupleTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/value/TupleTest.java
@@ -38,15 +38,16 @@ class TupleTest {
     @Test
     @DisplayName("toString renders the elements comma-separated in parentheses")
     void rendersToString() {
-        assertThat(new Tuple<>("a", "b").toString()).isEqualTo("(a, b)");
+        assertThat(new Tuple<>("a", "b")).hasToString("(a, b)");
     }
 
     @Test
     @DisplayName("Tuples with equal elements are equal and share a hash code")
     void valueEquality() {
-        assertThat(new Tuple<>("a", "b"))
+        final var tuple = new Tuple<>("a", "b");
+        assertThat(tuple)
                 .isEqualTo(new Tuple<>("a", "b"))
-                .hasSameHashCodeAs(new Tuple<>("a", "b"));
-        assertThat(new Tuple<>("a", "b")).isNotEqualTo(new Tuple<>("a", "c"));
+                .hasSameHashCodeAs(new Tuple<>("a", "b"))
+                .isNotEqualTo(new Tuple<>("a", "c"));
     }
 }

--- a/ksml-data/src/test/java/io/axual/ksml/data/value/TupleTest.java
+++ b/ksml-data/src/test/java/io/axual/ksml/data/value/TupleTest.java
@@ -1,0 +1,52 @@
+package io.axual.ksml.data.value;
+
+/*-
+ * ========================LICENSE_START=================================
+ * KSML Data Library
+ * %%
+ * Copyright (C) 2021 - 2026 Axual B.V.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TupleTest {
+
+    @Test
+    @DisplayName("A tuple exposes its ordered elements")
+    void exposesElements() {
+        final var tuple = new Tuple<>("a", "b", "c");
+
+        assertThat(tuple.elements()).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    @DisplayName("toString renders the elements comma-separated in parentheses")
+    void rendersToString() {
+        assertThat(new Tuple<>("a", "b").toString()).isEqualTo("(a, b)");
+    }
+
+    @Test
+    @DisplayName("Tuples with equal elements are equal and share a hash code")
+    void valueEquality() {
+        assertThat(new Tuple<>("a", "b"))
+                .isEqualTo(new Tuple<>("a", "b"))
+                .hasSameHashCodeAs(new Tuple<>("a", "b"));
+        assertThat(new Tuple<>("a", "b")).isNotEqualTo(new Tuple<>("a", "c"));
+    }
+}


### PR DESCRIPTION
# Add unit tests to `ksml-data` module

## What this PR does

Adds unit tests for the `ksml-data` module, which had no tests before. It also includes some runner code refactoring that was done to make the runner logic easier to test in a future PR.

---

## Changes

### New tests in `ksml-data` (13 new files)

| Area | New test classes |
|---|---|
| Comparison | `EqualityFlagsTest`, `EqualityTest` |
| Exception | `DataExceptionTest` |
| Notation | `NotationTest`, `NotationStub` |
| Schema types | `DataSchemaConstantsTest`, `UnionSchemaMemberTest` |
| Data types | `UnionTypeMemberTest`, `UnresolvedTypeTest` |
| Utilities | `AssignableUtilTest`, `EqualUtilTest`, `JsonNodeUtilTest` |
| Value | `TupleTest` |

### Expanded tests in `ksml-data` (12 existing files extended)

`NotationProviderTest`, `EnumSchemaTest`, `FixedSchemaTest`, `ListSchemaTest`, `MapSchemaTest`, `StructFieldTest`, `StructSchemaTest`, `UnionSchemaTest`, `EnumTypeTest`, `StructTypeTest`, `UnionTypeTest`, `ConvertUtilTest`