### PR TITLE
Group Dependabot version updates per ecosystem

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,18 +2,28 @@
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+#
+# Keep a "groups" block on every ecosystem. Without one, every package gets its
+# own pull request.
+#
+# Do not add "update-types" to split majors into their own group. Groups match
+# on "patterns" only, so the second group stays empty and majors can be dropped
+# with no warning. See dependabot-core #13665 and #14202. Majors are batched
+# with the rest; use "ignore" for one we do not want.
+#
+# Security updates ignore "schedule" and are still raised right away.
 
 version: 2
 updates:
   - package-ecosystem: "maven" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
     groups:
       dev-deps:
         dependency-type: "development"
       prod-deps:
-        dependency-type: "production"      
+        dependency-type: "production"
     ignore:
     - dependency-name: "com.google.protobuf:protobuf-java"
       versions: [ ">=4.0.0" ]   # 4.x has breaking lite-runtime semantics; KSML on 3.25.9
@@ -24,20 +34,24 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
+      interval: "weekly"
     allow:
       # Allow both direct and indirect updates for all packages
       - dependency-type: "all"
+    groups:
+      python-deps:
+        patterns: [ "*" ]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      actions-deps:
+        patterns: [ "*" ]
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     groups:
-      actions-deps:
-        patterns:
-          - "*"
+      docker-images:
+        patterns: [ "*" ]

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ CLAUDE.md
 .vscode/
 diff-coverage.html
 
+__pycache__/
+*.pyc
+
 workspace/*
 /packaging/helm-charts/**/*.tgz
 /packaging/helm-charts/workspace/*


### PR DESCRIPTION
## What this PR does

The `pip` and `github-actions` blocks had no `groups` key. Updates that match no group get
their own pull request, so every Python package arrived separately. Of the 95 dependency
bumps merged in the last 6 months, 58 were single Python packages.

- Add a group to `pip` and `github-actions`, so every ecosystem now has one.
- Move all four ecosystems from `daily` to `weekly`. With grouping, a daily run just
  force-pushes the same group PR again, which restarts CI and discards any review.
- Drop `open-pull-requests-limit: 10` from `pip`. It only made up for the missing group.
- Rename the `docker` group `actions-deps` to `docker-images`, the ecosystem it covers.

Maven groups, the `ignore` list and the pip `allow` block are unchanged.

## Note for reviewers

No group uses `update-types`. Splitting majors into their own group does not work: a
dependency joins the first group whose `patterns` match, and `update-types` takes no part
in that choice, so the second group stays empty and majors can be dropped with no warning
(dependabot-core #13665, #14202). Majors are batched with the rest; use `ignore` for one we
do not want.

## Effect

Against the 12 Dependabot PRs open on 2026-08-09 this produces 3. Security updates are
unaffected, because they follow advisories and not `schedule`.

After merging, check Insights > Dependency graph > Dependabot for a config error, since a
rejected config silently stops version updates. Dependabot should close the superseded
single PRs itself, but that is unreliable, so close any leftovers by hand.